### PR TITLE
Hotfix: Reverted 'inspect element' option to right-click menu

### DIFF
--- a/src/context-menu/context-menu.ts
+++ b/src/context-menu/context-menu.ts
@@ -100,7 +100,7 @@ class ContextMenu {
     }
   }
 
-  private rebuildMenu() {
+  private rebuildMenu({ clientX, clientY }: MouseEvent) {
     this.contextMenu = new electron.remote.Menu()
 
     if (this.isDevModeEnabled && this.devModeToggler) {
@@ -121,19 +121,34 @@ class ContextMenu {
 
     this.contextMenu.append(
       new electron.remote.MenuItem({
+        label: "Inspect element",
+        click: () => {
+          electron.remote
+            .getCurrentWindow()
+            .webContents.inspectElement(clientX, clientY)
+        },
+      })
+    )
+
+    this.contextMenu.append(
+      new electron.remote.MenuItem({
         label: "Toggle Developer Tools",
         role: "toggleDevTools",
       })
     )
   }
 
-  private showMenu() {
-    this.rebuildMenu()
+  private showMenu(event: MouseEvent) {
+    this.rebuildMenu(event)
     this.contextMenu.popup()
   }
 
   public init() {
-    window.addEventListener("contextmenu", () => this.showMenu(), false)
+    window.addEventListener(
+      "contextmenu",
+      (event) => this.showMenu(event),
+      false
+    )
   }
 
   public registerItem(mainLabel: string, menuItem: MenuItem) {


### PR DESCRIPTION
**Description**
Reverted 'inspect element' option to the right-click menu

<details>
<summary><b>Screenshots</b></summary>

![image](https://user-images.githubusercontent.com/15341913/103520776-fb5a3580-4e77-11eb-8166-9131e0b11a92.png)

</details>

**Self check**

- [x] Self CR'd
- [ ] Tests included
- [x] Description and screenshots attached

**PR Status**

- [ ] Code Review
- [ ] Quality Assurance

**Blockers**

**Deploy Notes**
