### PR TITLE
Fix height of empty state of contacts

### DIFF
--- a/src/renderer/components/core/table/table.component.tsx
+++ b/src/renderer/components/core/table/table.component.tsx
@@ -244,6 +244,7 @@ export const SidebarHeaderIcon = styled(ButtonComponent).attrs(() => ({
 
 /* Empty state */
 const EmptyStateWrapper = styled.div`
+  height: 100%;
   flex: 1;
   display: flex;
   flex-direction: column;

--- a/src/renderer/components/rest/phone/highlight-contact-list.component.tsx
+++ b/src/renderer/components/rest/phone/highlight-contact-list.component.tsx
@@ -2,6 +2,7 @@ import { Contact, ContactCategory } from "Renderer/models/phone/phone.typings"
 import { FunctionComponent } from "Renderer/types/function-component.interface"
 import { noop } from "Renderer/utils/noop"
 import React, { useEffect, useRef } from "react"
+import { HighLightContactListWrapper } from "Renderer/components/rest/phone/highlight-contact-list.styled"
 
 interface Props {
   contactList: ContactCategory[]
@@ -48,8 +49,8 @@ export const HighlightContactList: FunctionComponent<Props> = ({
   }, [selectedContact])
 
   return (
-    <div ref={listRef} {...props}>
+    <HighLightContactListWrapper ref={listRef} {...props}>
       {children}
-    </div>
+    </HighLightContactListWrapper>
   )
 }

--- a/src/renderer/components/rest/phone/highlight-contact-list.styled.tsx
+++ b/src/renderer/components/rest/phone/highlight-contact-list.styled.tsx
@@ -1,0 +1,5 @@
+import styled from "styled-components"
+
+export const HighLightContactListWrapper = styled.div`
+  height: 100%;
+`


### PR DESCRIPTION
Jira: [PDA-XXX]

**Description**

Before:
![Zrzut ekranu 2021-01-4 o 10 11 04](https://user-images.githubusercontent.com/22203423/103523271-eaabbe80-4e7b-11eb-9406-803c38f516f7.png)


After, highlighting contact through search also works as it was before: 
![Zrzut ekranu 2021-01-4 o 10 59 14](https://user-images.githubusercontent.com/22203423/103523238-e384b080-4e7b-11eb-88ca-05e0d55e393a.png)


<details>
<summary><b>Screenshots</b></summary>
// put images here
</details>

**Self check**

- [x] Self CR'd
- [ ] Tests included
- [x] Description and screenshots attached

**PR Status**

- [ ] Code Review
- [ ] Quality Assurance

**Blockers**

**Deploy Notes**
