### PR TITLE
Hotfix for downloading fonts

### DIFF
--- a/packages/app/scripts/downloadFonts.js
+++ b/packages/app/scripts/downloadFonts.js
@@ -39,6 +39,7 @@ require("dotenv").config({
       if (!fileExists) {
         const url = `${process.env.FONTS_DIRECTORY_URL}/${fileName}`
         const { data } = await axios.get(url, {
+          responseType: "arraybuffer",
           headers: {
             Authorization: `token ${process.env.GITHUB_ACCESS_TOKEN}`,
           },


### PR DESCRIPTION
**Description**

I found out that downloading fonts using current way breaks them. This is fixed now.

<details>
<summary><b>Screenshots</b></summary>

![image](https://user-images.githubusercontent.com/15341913/108818999-83c49f00-75ba-11eb-8adf-7194c80c15f8.png)

</details>

**Self check**

- [x] Self CR'd
- [ ] ~Tests included~
- [x] Description and screenshots attached

**PR Status**

- [ ] Code Review
- [ ] Quality Assurance

**Blockers**

**Deploy Notes**
