### PR TITLE
[CP-40] Added the `initialDataLoad` prop state

### DIFF
--- a/packages/app/src/contacts/components/contact-list/contact-list.component.tsx
+++ b/packages/app/src/contacts/components/contact-list/contact-list.component.tsx
@@ -40,7 +40,7 @@ import { ContactListTestIdsEnum } from "App/contacts/components/contact-list/con
 import ScrollAnchorContainer from "Renderer/components/rest/scroll-anchor-container/scroll-anchor-container.component"
 import { HighlightContactList } from "App/contacts/components/highlight-contact-list/highlight-contact-list.component"
 import { Contacts } from "App/contacts/store/contacts.interface"
-import { ResultsState } from "Renderer/models/basic-info/basic-info.typings"
+import { ResultsState } from "App/contacts/store/contacts.enum"
 import { productionEnvironment } from "Renderer/constants/menu-elements"
 import { HiddenButton } from "App/contacts/components/contact-list/contact-list.styled"
 
@@ -292,8 +292,7 @@ const ContactList: FunctionComponent<ContactListProps> = ({
                           >
                             <HiddenButton
                               labelMessage={{
-                                id:
-                                  "module.contacts.exportAsVcard",
+                                id: "module.contacts.exportAsVcard",
                               }}
                               Icon={Type.Upload}
                               onClick={handleExport}
@@ -302,8 +301,7 @@ const ContactList: FunctionComponent<ContactListProps> = ({
                             />
                             <HiddenButton
                               labelMessage={{
-                                id:
-                                  "module.contacts.forwardNamecard",
+                                id: "module.contacts.forwardNamecard",
                               }}
                               Icon={Type.Forward}
                               onClick={handleForward}
@@ -384,8 +382,7 @@ const ContactList: FunctionComponent<ContactListProps> = ({
             <EmptyState
               title={{ id: "module.contacts.emptyListTitle" }}
               description={{
-                id:
-                  "module.contacts.emptySearchDescription",
+                id: "module.contacts.emptySearchDescription",
               }}
             />
           ))}
@@ -394,8 +391,7 @@ const ContactList: FunctionComponent<ContactListProps> = ({
             <EmptyState
               title={{ id: "module.contacts.emptyListTitle" }}
               description={{
-                id:
-                  "module.contacts.emptyPhonebook",
+                id: "module.contacts.emptyPhonebook",
               }}
             />
           ))}

--- a/packages/app/src/renderer/models/basic-info/basic-info.typings.ts
+++ b/packages/app/src/renderer/models/basic-info/basic-info.typings.ts
@@ -18,7 +18,7 @@ export interface MemorySpace {
   readonly full: number
 }
 
-export enum ResultsState {
+export enum DataState {
   Loading,
   Loaded,
   Empty,
@@ -35,7 +35,8 @@ export interface StoreValues {
   readonly memorySpace: MemorySpace
   readonly lastBackup?: BackupItemInfo
   readonly simCards: SimCard[]
-  readonly resultsState: ResultsState
+  readonly basicInfoDataState: DataState
+  readonly initialDataLoaded: boolean
 }
 
 export interface StoreEffects {

--- a/packages/app/src/renderer/modules/overview/overview-ui.component.tsx
+++ b/packages/app/src/renderer/modules/overview/overview-ui.component.tsx
@@ -61,7 +61,11 @@ interface OverviewUIProps {
 const OverviewUI: FunctionComponent<
   Omit<
     BasicInfoInitialState,
-    "loadData" | "resultsState" | "deviceUpdating" | "deviceConnected"
+    | "loadData"
+    | "basicInfoDataState"
+    | "deviceUpdating"
+    | "deviceConnected"
+    | "initialDataLoaded"
   > &
     PhoneUpdate &
     OverviewUIProps &

--- a/packages/app/src/renderer/modules/overview/overview.container.tsx
+++ b/packages/app/src/renderer/modules/overview/overview.container.tsx
@@ -34,7 +34,6 @@ const mapDispatchToProps = (dispatch: any) => ({
   updateBasicInfo: (updateInfo: Partial<BasicInfoValues>) =>
     dispatch.basicInfo.update(updateInfo),
   toggleDeviceUpdating: dispatch.basicInfo.toggleDeviceUpdating,
-  loadData: () => dispatch.basicInfo.loadData(),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(Overview)

--- a/packages/app/src/renderer/modules/overview/overview.test.tsx
+++ b/packages/app/src/renderer/modules/overview/overview.test.tsx
@@ -9,7 +9,7 @@ import Overview, {
   UpdateBasicInfo,
 } from "Renderer/modules/overview/overview.component"
 import {
-  ResultsState,
+  DataState,
   Store as BasicInfoInitialState,
 } from "Renderer/models/basic-info/basic-info.typings"
 import { PhoneUpdateStore } from "Renderer/models/phone-update/phone-update.interface"
@@ -70,7 +70,8 @@ const renderer = (extraProps?: {}) => {
     pureNeverConnected: false,
     pureOsBackupLocation: "path/location/backup",
     pureOsDownloadLocation: "path/location/download",
-    resultsState: ResultsState.Empty,
+    basicInfoDataState: DataState.Empty,
+    initialDataLoaded: false,
     setCollectingData: jest.fn(),
     simCards: [
       {

--- a/packages/app/src/renderer/wrappers/base-app.component.tsx
+++ b/packages/app/src/renderer/wrappers/base-app.component.tsx
@@ -75,7 +75,7 @@ const BaseApp: FunctionComponent<Props> = ({
   useRouterListener(history, {
     [URL_MAIN.contacts]: [store.dispatch.contacts.loadData],
     [URL_MAIN.phone]: [store.dispatch.contacts.loadData],
-    [URL_MAIN.overview]: [store.dispatch.basicInfo.loadData],
+    [URL_MAIN.overview]: [store.dispatch.basicInfo.loadBasicInfoData],
     [URL_MAIN.messages]: [store.dispatch.messages.loadData],
   })
 


### PR DESCRIPTION
Jira: [CP-40]

**Description**

- Added the `initialDataLoad` prop state to handle correctly the pureFeaturesVisible selector
- Reduced fetching initial data to only data for `basicInfo`

**Self check**

- [x] Self CR'd
- [x] Tests included
- [x] Description and screenshots attached

**PR Status**

- [ ] Code Review
- [ ] Quality Assurance

**Blockers**

**Deploy Notes**


[CP-40]: https://appnroll.atlassian.net/browse/CP-40