### PR TITLE
[CP-40] Adds temporary modal on connecting page

### DIFF
--- a/packages/app/src/renderer/modules/onboarding/connecting.component.tsx
+++ b/packages/app/src/renderer/modules/onboarding/connecting.component.tsx
@@ -3,7 +3,7 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import React, { useEffect } from "react"
+import React, { useEffect, useState } from "react"
 import { useHistory } from "react-router"
 import { URL_MAIN, URL_ONBOARDING } from "Renderer/constants/urls"
 import OnboardingConnecting from "Renderer/components/rest/onboarding/onboarding-connecting.component"
@@ -11,23 +11,35 @@ import { updateAppSettings } from "Renderer/requests/app-settings.request"
 import { FunctionComponent } from "Renderer/types/function-component.interface"
 import { RootState, select } from "Renderer/store"
 import { connect } from "react-redux"
+import ModalDialog from "Renderer/components/core/modal-dialog/modal-dialog.component"
+import { ModalSize } from "Renderer/components/core/modal/modal.interface"
+import Text, {
+  TextDisplayStyle,
+} from "Renderer/components/core/text/text.component"
 
 export const registerFirstPhoneConnection = async () => {
   updateAppSettings({ key: "pureNeverConnected", value: false })
 }
 
-const Connecting: FunctionComponent<{ pureFeaturesVisible: boolean }> = ({
-  pureFeaturesVisible,
-}) => {
+const Connecting: FunctionComponent<{
+  deviceUnlocked: boolean | undefined
+}> = ({ deviceUnlocked }) => {
+  const [dialogOpen, setDialogOpen] = useState(false)
+
   useEffect(() => {
     const timeout = setTimeout(() => {
-      if (pureFeaturesVisible) {
+      if (deviceUnlocked) {
+        registerFirstPhoneConnection()
         history.push(URL_MAIN.overview)
       }
     }, 500)
 
+    if (deviceUnlocked === false) {
+      setDialogOpen(true)
+    }
+
     return () => clearTimeout(timeout)
-  }, [pureFeaturesVisible])
+  }, [deviceUnlocked])
 
   const history = useHistory()
 
@@ -38,16 +50,37 @@ const Connecting: FunctionComponent<{ pureFeaturesVisible: boolean }> = ({
     // TODO: on success call registerFirstPhoneConnection function
     history.push(URL_ONBOARDING.troubleshooting)
   }
-  return <OnboardingConnecting onCancel={onCancel} />
+
+  const onActionButtonClick = () => {
+    setDialogOpen(false)
+  }
+
+  return (
+    <>
+      <ModalDialog
+        open={dialogOpen}
+        closeButton={false}
+        onActionButtonClick={onActionButtonClick}
+        actionButtonLabel={"ok"}
+        title={"Pure is locked"}
+        size={ModalSize.VerySmall}
+      >
+        <Text displayStyle={TextDisplayStyle.LargeText}>
+          Unlock your Pure to successfully connection
+        </Text>
+      </ModalDialog>
+      <OnboardingConnecting onCancel={onCancel} />
+    </>
+  )
 }
 
 const selection = select((models: any) => ({
-  pureFeaturesVisible: models.basicInfo.pureFeaturesVisible,
+  deviceUnlocked: models.basicInfo.deviceUnlocked,
 }))
 
 const mapStateToProps = (state: RootState) => {
   return {
-    ...(selection(state, null) as { connected: boolean }),
+    ...(selection(state, null) as { deviceUnlocked: boolean | undefined }),
   }
 }
 


### PR DESCRIPTION
Jira: [CP-40]

**Description**

Adds a modal to display user information that the user phone is locked. This solution is temporary until passcode modal isn't be implement 👉   [CP-17](https://appnroll.atlassian.net/browse/CP-17)

<details>
<summary><b>Screenshots</b></summary>
<img width="1392" alt="Zrzut ekranu 2021-05-13 o 08 40 57" src="https://user-images.githubusercontent.com/17147149/118088297-26750880-b3c7-11eb-89f6-a8ed56928de6.png">
</details>

**Self check**

- [x] Self CR'd
- [ ] Tests included
- [x] Description and screenshots attached

**PR Status**

- [ ] Code Review
- [ ] Quality Assurance

**Blockers**

**Deploy Notes**


[CP-40]: https://appnroll.atlassian.net/browse/CP-40