### PR TITLE
[CP-341] Redux Toolkit implementation preparing

### DIFF
--- a/packages/app/package-lock.json
+++ b/packages/app/package-lock.json
@@ -7307,6 +7307,24 @@
         "react-lifecycles-compat": "^3.0.4"
       }
     },
+    "@reduxjs/toolkit": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.6.1.tgz",
+      "integrity": "sha512-pa3nqclCJaZPAyBhruQtiRwtTjottRrVJqziVZcWzI73i6L3miLTtUyWfauwv08HWtiXLx1xGyGt+yLFfW/d0A==",
+      "requires": {
+        "immer": "^9.0.1",
+        "redux": "^4.1.0",
+        "redux-thunk": "^2.3.0",
+        "reselect": "^4.0.0"
+      },
+      "dependencies": {
+        "immer": {
+          "version": "9.0.6",
+          "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
+          "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ=="
+        }
+      }
+    },
     "@rematch/core": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@rematch/core/-/core-1.4.0.tgz",
@@ -32478,9 +32496,9 @@
       }
     },
     "react-redux": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.4.tgz",
-      "integrity": "sha512-hOQ5eOSkEJEXdpIKbnRyl04LhaWabkDPV+Ix97wqQX3T3d2NQ8DUblNXXtNMavc7DpswyQM6xfaN4HQDKNY2JA==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.5.tgz",
+      "integrity": "sha512-Dt29bNyBsbQaysp6s/dN0gUodcq+dVKKER8Qv82UrpeygwYeX1raTtil7O/fftw/rFqzaf6gJhDZRkkZnn6bjg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.1",
@@ -32492,9 +32510,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.14.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
-          "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
+          "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
           "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
@@ -32507,9 +32525,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.13.7",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "version": "0.13.9",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
           "dev": true
         }
       }
@@ -32918,16 +32936,14 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.1.tgz",
       "integrity": "sha512-hZQZdDEM25UY2P493kPYuKqviVwZ58lEmGQNeQ+gXa+U0gYPUBf7NKYazbe3m+bs/DzM/ahN12DbF+NG8i0CWw==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.9.2"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.15.3",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
-          "integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
-          "dev": true,
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
+          "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -32935,8 +32951,7 @@
         "regenerator-runtime": {
           "version": "0.13.9",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-          "dev": true
+          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
         }
       }
     },
@@ -32994,8 +33009,7 @@
     "redux-thunk": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
-      "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==",
-      "dev": true
+      "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
     },
     "refractor": {
       "version": "3.4.0",
@@ -33590,8 +33604,7 @@
     "reselect": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
-      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==",
-      "dev": true
+      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
     },
     "resolve": {
       "version": "1.15.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -245,7 +245,7 @@
     "react-intl": "5.0.2",
     "react-intl-translations-manager": "^5.0.3",
     "react-modal": "^3.14.3",
-    "react-redux": "^7.2.4",
+    "react-redux": "^7.2.5",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "react-svg-loader": "^3.0.3",
@@ -291,6 +291,7 @@
     "winston-transport-rollbar-3": "^3.2.0"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "^1.6.1",
     "serialport": "^9.2.0",
     "usb": "^1.6.5"
   },

--- a/packages/app/src/messages/components/messages/messages.test.tsx
+++ b/packages/app/src/messages/components/messages/messages.test.tsx
@@ -146,13 +146,13 @@ const setNewMessageState = ({ queryByTestId }: RenderResult): void => {
 describe("Messages component", () => {
   describe("when component is render with defaults props", () => {
     test("length of thread list should be correct", () => {
-      const { queryAllByTestId } = renderer()
-      expect(queryAllByTestId(ThreadListTestIds.Row)).toHaveLength(1)
+      const { queryByTestId } = renderer()
+      expect(queryByTestId(ThreadListTestIds.Row)).toBeInTheDocument()
     })
 
     test("length of passed empty thread list should be equal 0", () => {
-      const { queryAllByTestId } = renderer({ threads: [] })
-      expect(queryAllByTestId(ThreadListTestIds.Row)).toHaveLength(0)
+      const { queryByTestId } = renderer({ threads: [] })
+      expect(queryByTestId(ThreadListTestIds.Row)).not.toBeInTheDocument()
     })
 
     test("any sidebar isn't open", () => {
@@ -227,8 +227,8 @@ describe("Messages component", () => {
     const renderProps: RenderProps = { callbacks: [setNewMessageState] }
 
     test("length of thread list is increased by 1 (tmp thread)", async () => {
-      const { queryAllByTestId } = renderer({ ...renderProps, threads: [] })
-      expect(queryAllByTestId(ThreadListTestIds.Row)).toHaveLength(1)
+      const { queryByTestId } = renderer({ ...renderProps, threads: [] })
+      expect(queryByTestId(ThreadListTestIds.Row)).toBeInTheDocument()
     })
 
     test("value of new message text area is empty", () => {
@@ -477,8 +477,8 @@ describe("Messages component", () => {
   })
 
   test("displays correct amount of dropdown call buttons", () => {
-    const { getAllByTestId } = renderer()
-    expect(getAllByTestId("dropdown-call")).toHaveLength(1)
+    const { getByTestId } = renderer()
+    expect(getByTestId("dropdown-call")).toBeInTheDocument()
   })
 
   test("dropdown contact details button has correct content", () => {
@@ -493,8 +493,8 @@ describe("Messages component", () => {
 
   test("displays correct amount of dropdown contact details buttons for contacts", () => {
     const isContactCreated = jest.fn().mockReturnValue(true)
-    const { getAllByTestId } = renderer({ isContactCreated })
-    expect(getAllByTestId("dropdown-contact-details")).toHaveLength(1)
+    const { getByTestId } = renderer({ isContactCreated })
+    expect(getByTestId("dropdown-contact-details")).toBeInTheDocument()
   })
 
   test("displays correct amount of dropdown add to contacts buttons for person that is unknown", () => {
@@ -520,8 +520,8 @@ describe("Messages component", () => {
   })
 
   test("displays correct amount of dropdown mark as read buttons", () => {
-    const { getAllByTestId } = renderer()
-    expect(getAllByTestId("dropdown-mark-as-read")).toHaveLength(1)
+    const { getByTestId } = renderer()
+    expect(getByTestId("dropdown-mark-as-read")).toBeInTheDocument()
   })
 
   test("dropdown delete button has correct content", () => {
@@ -534,7 +534,7 @@ describe("Messages component", () => {
   })
 
   test("displays correct amount of dropdown delete buttons", () => {
-    const { getAllByTestId } = renderer()
-    expect(getAllByTestId("dropdown-delete")).toHaveLength(1)
+    const { getByTestId } = renderer()
+    expect(getByTestId("dropdown-delete")).toBeInTheDocument()
   })
 })

--- a/packages/app/src/renderer/app.tsx
+++ b/packages/app/src/renderer/app.tsx
@@ -5,6 +5,7 @@
 
 import * as React from "react"
 import * as ReactDOM from "react-dom"
+import { Provider } from "react-redux"
 import { AppContainer } from "react-hot-loader"
 import modalService from "Renderer/components/core/modal/modal.service"
 import { defaultLanguage } from "App/translations.config.json"
@@ -28,9 +29,11 @@ document.body.appendChild(mainElement)
 Modal.setAppElement("#app")
 
 ReactDOM.render(
-  <AppContainer>
-    <RootWrapper store={store} history={history} />
-  </AppContainer>,
+  <Provider store={store}>
+    <AppContainer>
+      <RootWrapper history={history} />
+    </AppContainer>
+  </Provider>,
   mainElement
 )
 

--- a/packages/app/src/renderer/store/index.ts
+++ b/packages/app/src/renderer/store/index.ts
@@ -8,21 +8,37 @@ import {
   RematchDispatch,
   RematchRootState,
   InitConfig,
+  Middleware,
 } from "@rematch/core"
 import selectPlugin from "@rematch/select"
+import logger from "redux-logger"
+import thunk from "redux-thunk"
 import { models, RootModel } from "Renderer/models/models"
 import { filesManagerSeed } from "App/seeds/filesManager"
 import { templatesSeed } from "App/seeds/templates"
 import { helpSeed } from "App/seeds/help"
 import { notesSeed } from "App/seeds/notes"
 
+import { reducers, combinedReducers } from "./reducers"
+
+const middlewares: Middleware[] = [thunk]
+
+if (process.env.NODE_ENV === "development") {
+  middlewares.push(logger)
+}
+
 const config: InitConfig<RootModel> = {
   models,
   plugins: [selectPlugin()],
+  redux: {
+    reducers: reducers,
+    middlewares,
+  },
 }
 
 if (process.env.NODE_ENV !== "test") {
   config.redux = {
+    ...config.redux,
     initialState: {
       filesManager: filesManagerSeed,
       templates: templatesSeed,
@@ -38,5 +54,7 @@ export const { select } = store
 export type RootState = RematchRootState<typeof models>
 export type Store = typeof store
 export type Dispatch = RematchDispatch<RootModel>
+
+export type ReduxRootState = ReturnType<typeof combinedReducers>
 
 export default store

--- a/packages/app/src/renderer/store/reducers.ts
+++ b/packages/app/src/renderer/store/reducers.ts
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Mudita sp. z o.o. All rights reserved.
+ * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
+ */
+
+import { combineReducers } from "redux"
+
+export const reducers = {}
+export const combinedReducers = combineReducers({})

--- a/packages/app/src/renderer/wrappers/base-app.component.tsx
+++ b/packages/app/src/renderer/wrappers/base-app.component.tsx
@@ -5,21 +5,19 @@
 
 import React, { useEffect } from "react"
 import { FunctionComponent } from "Renderer/types/function-component.interface"
-import { connect, Provider } from "react-redux"
+import { connect } from "react-redux"
 import NetworkStatusChecker from "Renderer/components/core/network-status-checker/network-status-checker.container"
 import { Router } from "react-router"
 import BaseRoutes from "Renderer/routes/base-routes"
-import { select, Store } from "Renderer/store"
+import store, { select, RootState, ReduxRootState } from "Renderer/store"
 import { History } from "history"
 import { URL_ONBOARDING } from "Renderer/constants/urls"
 import { URL_MAIN } from "Renderer/constants/urls"
-import { RootState } from "Renderer/store"
 import useRouterListener from "Renderer/utils/hooks/use-router-listener/use-router-listener"
 import CollectingDataModal from "Renderer/wrappers/collecting-data-modal/collecting-data-modal.component"
 import AppUpdateStepModal from "Renderer/wrappers/app-update-step-modal/app-update-step-modal.component"
 
 interface Props {
-  store: Store
   history: History
   pureFeaturesVisible?: boolean
   deviceConnecting?: boolean
@@ -38,7 +36,6 @@ interface Props {
 }
 
 const BaseApp: FunctionComponent<Props> = ({
-  store,
   history,
   pureFeaturesVisible,
   deviceConnecting,
@@ -100,7 +97,7 @@ const BaseApp: FunctionComponent<Props> = ({
   }
 
   return (
-    <Provider store={store}>
+    <>
       <NetworkStatusChecker />
       <CollectingDataModal
         open={collectingDataModalVisible}
@@ -124,7 +121,7 @@ const BaseApp: FunctionComponent<Props> = ({
       <Router history={history}>
         <BaseRoutes />
       </Router>
-    </Provider>
+    </>
   )
 }
 
@@ -134,7 +131,7 @@ const selection = select((models: any) => ({
   deviceParred: models.basicInfo.deviceParred,
 }))
 
-const mapStateToProps = (state: RootState) => {
+const mapStateToProps = (state: RootState & ReduxRootState) => {
   return {
     ...(selection(state, null) as {
       pureFeaturesVisible: boolean


### PR DESCRIPTION
Jira: [CP-341]

**Description**
Preparing to migration to [`redux-toolkit`](https://redux-toolkit.js.org/)

The migration will be implementing step-by-step starting from `basicInfo` model. The `rematch` allows us to directly pass an extra reducer inside the redux config, so we are able to replace legacy functionality with the new one and using two standards in the scope of one store.

In the scope of this PR was implemented:
- Action logging on the development environment
- ReduxToolkit state typing for margin the new state with a legacy
- Moving the `Provider` component to the right place
- RootWarapper tests fixing

<details>
<summary><b>Screenshots</b></summary>
// put images here
</details>

**Self check**

- [x] Self CR'd
- [ ] Tests included
- [ ] Description and screenshots attached

**PR Status**

- [ ] Code Review
- [ ] Quality Assurance

**Blockers**

**Deploy Notes**


[CP-341]: https://appnroll.atlassian.net/browse/CP-341