### PR TITLE
[CP-600] Get CRC32 from the last build

### DIFF
--- a/packages/app/src/backend/device-file-system-service/device-file-system-service.test.ts
+++ b/packages/app/src/backend/device-file-system-service/device-file-system-service.test.ts
@@ -38,7 +38,6 @@ test("downloading file handle properly chunks data", async () => {
               rxID: "1",
               fileSize: 2,
               chunkSize: 1,
-              fileCrc32: "30898fa4",
             },
           }
         } else if (
@@ -57,6 +56,7 @@ test("downloading file handle properly chunks data", async () => {
             status: DeviceResponseStatus.Ok,
             data: {
               data: secondsPartEncodeLog,
+              fileCrc32: "30898fa4",
             },
           }
         } else {
@@ -92,7 +92,6 @@ test("downloading file handle properly chunks data if fileSize is less than chun
               rxID: "1",
               fileSize: 0.5,
               chunkSize: 1,
-              fileCrc32: "91c634cd",
             },
           }
         } else if (
@@ -102,6 +101,7 @@ test("downloading file handle properly chunks data if fileSize is less than chun
             status: DeviceResponseStatus.Ok,
             data: {
               data: firstsPartEncodeLog,
+              fileCrc32: "91c634cd",
             },
           }
         } else {

--- a/packages/app/src/backend/device-service.ts
+++ b/packages/app/src/backend/device-service.ts
@@ -142,7 +142,6 @@ class DeviceService {
   public request(config: GetFileSystemRequestConfig): Promise<
     DeviceResponse<{
       rxID: string
-      fileCrc32: string
       fileSize: number
       chunkSize: number
     }>
@@ -152,6 +151,7 @@ class DeviceService {
       rxID: string
       chunkNo: number
       data: string
+      fileCrc32?: string
     }>
   >
   public request(config: SendFileSystemRequestConfig): Promise<

--- a/packages/app/src/backend/requests/get-device-log-files/get-device-log-files.request.test.ts
+++ b/packages/app/src/backend/requests/get-device-log-files/get-device-log-files.request.test.ts
@@ -41,7 +41,6 @@ test("GetDeviceLogs request works properly", (done) => {
               rxID: "1",
               fileSize: 1,
               chunkSize: 1,
-              fileCrc32: "265B86C6",
             },
           }
         } else if (
@@ -51,6 +50,7 @@ test("GetDeviceLogs request works properly", (done) => {
             status: DeviceResponseStatus.Ok,
             data: {
               data: "SGVsbG8sIFdvcmxk",
+              fileCrc32: "265B86C6",
             },
           }
         } else {

--- a/packages/app/src/renderer/models/settings/settings.ts
+++ b/packages/app/src/renderer/models/settings/settings.ts
@@ -162,7 +162,7 @@ const settings = createModel<RootModel>({
       },
       async sendDiagnosticData(_, state): Promise<void> {
         const { appCollectingData, diagnosticSentTimestamp } = state.settings
-        const { serialNumber } = state.device.data
+        const { serialNumber } = state.device?.data
 
         if (serialNumber === undefined) {
           logger.error(

--- a/packages/app/src/renderer/requests/download-device-file.request.ts
+++ b/packages/app/src/renderer/requests/download-device-file.request.ts
@@ -5,12 +5,12 @@
 
 import { ipcRenderer } from "electron-better-ipc"
 import DeviceResponse from "Backend/adapters/device-response.interface"
-import { DeviceFile } from "Backend/device-file-system-service/device-file-system-service"
+import { DeviceFileDeprecated } from "Backend/device-file-system-service/device-file-system-service"
 import { IpcRequest } from "Common/requests/ipc-request.enum"
 
 const downloadDeviceFile = async (
   filePath: string
-): Promise<DeviceResponse<DeviceFile>> => {
+): Promise<DeviceResponse<DeviceFileDeprecated>> => {
   return await ipcRenderer.callMain(IpcRequest.DownloadDeviceFile, filePath)
 }
 


### PR DESCRIPTION
Jira: [CP-600]

**Description**
Changing downloading files flow. Instead of await till the device calculate `crc32` we starting the upload process and take the  CRC in the last chunk. The CRC32 is calculated concurrently with sending process.

<details>
<summary><b>Screenshots</b></summary>
// put images here
</details>

**Self check**

- [x] Self CR'd
- [x] Tests included
- [ ] Description and screenshots attached

**PR Status**

- [ ] Code Review
- [ ] Quality Assurance

**Blockers**

**Deploy Notes**


[CP-600]: https://appnroll.atlassian.net/browse/CP-600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ