### PR TITLE
[CP-774] Improved loading state in init fetch data

### DIFF
--- a/packages/app/src/messages/actions/load-threads-total-count.action.test.ts
+++ b/packages/app/src/messages/actions/load-threads-total-count.action.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) Mudita sp. z o.o. All rights reserved.
+ * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
+ */
+
+import createMockStore from "redux-mock-store"
+import thunk from "redux-thunk"
+import { AnyAction } from "@reduxjs/toolkit"
+import { MessagesEvent } from "App/messages/constants"
+import { testError } from "Renderer/store/constants"
+import DeviceResponse, {
+  DeviceResponseStatus,
+} from "Backend/adapters/device-response.interface"
+import getThreads from "Renderer/requests/get-threads.request"
+import { loadThreadsTotalCount } from "App/messages/actions/load-threads-total-count.action"
+import { GetThreadsResponse } from "Backend/adapters/pure-phone-messages/pure-phone-messages.class"
+import { LoadThreadsError } from "App/messages/errors"
+import { Thread } from "App/messages/reducers"
+
+jest.mock("Renderer/requests/get-threads.request")
+
+const threads: Thread[] = [
+  {
+    id: "1",
+    phoneNumber: "+48 755 853 216",
+    lastUpdatedAt: new Date("2020-06-01T13:53:27.087Z"),
+    messageSnippet:
+      "Exercitationem vel quasi doloremque. Enim qui quis quidem eveniet est corrupti itaque recusandae.",
+    unread: true,
+  },
+]
+
+const successDeviceResponse: DeviceResponse<GetThreadsResponse> = {
+  status: DeviceResponseStatus.Ok,
+  data: {
+    data: threads,
+    totalCount: threads.length
+  },
+}
+
+const errorDeviceResponse: DeviceResponse = {
+  status: DeviceResponseStatus.Error,
+}
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe("async `loadThreadsTotalCount` ", () => {
+  describe("when `getThreads` request return success", () => {
+    test("fire async `loadThreadsTotalCount` call `SetThreadsTotalCount`", async () => {
+      ;(getThreads as jest.Mock).mockReturnValue(successDeviceResponse)
+      const mockStore = createMockStore([thunk])()
+      const {
+        meta: { requestId },
+      } = await mockStore.dispatch(
+        loadThreadsTotalCount() as unknown as AnyAction
+      )
+
+      expect(mockStore.getActions()).toEqual([
+        loadThreadsTotalCount.pending(requestId, undefined),
+        {
+          type: MessagesEvent.SetThreadsTotalCount,
+          payload: threads.length,
+        },
+        loadThreadsTotalCount.fulfilled(undefined, requestId, undefined),
+      ])
+
+      expect(getThreads).toHaveBeenCalled()
+    })
+  })
+
+  describe("when `getThreads` request return error", () => {
+    test("fire async `loadThreadsTotalCount` returns `rejected` action", async () => {
+      ;(getThreads as jest.Mock).mockReturnValue(errorDeviceResponse)
+      const errorMock = new LoadThreadsError("Get Threads request failed")
+      const mockStore = createMockStore([thunk])()
+      const {
+        meta: { requestId },
+      } = await mockStore.dispatch(
+        loadThreadsTotalCount() as unknown as AnyAction
+      )
+
+      expect(mockStore.getActions()).toEqual([
+        loadThreadsTotalCount.pending(requestId, undefined),
+        loadThreadsTotalCount.rejected(testError, requestId, undefined, errorMock),
+      ])
+
+      expect(getThreads).toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/app/src/messages/actions/load-threads-total-count.action.ts
+++ b/packages/app/src/messages/actions/load-threads-total-count.action.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Mudita sp. z o.o. All rights reserved.
+ * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
+ */
+
+import { createAsyncThunk } from "@reduxjs/toolkit"
+import { MessagesEvent } from "App/messages/constants"
+import getThreads from "Renderer/requests/get-threads.request"
+import { LoadThreadsError } from "App/messages/errors"
+import { setThreadsTotalCount } from "App/messages/actions/base.action"
+
+export const loadThreadsTotalCount = createAsyncThunk<undefined, undefined>(
+  MessagesEvent.LoadThreadsTotalCount,
+  async (_, { dispatch, rejectWithValue }) => {
+    const { data, error } = await getThreads({ limit: 1, offset: 0 })
+
+    if (error || data === undefined) {
+      return rejectWithValue(new LoadThreadsError("Get Threads request failed"))
+    }
+
+    dispatch(setThreadsTotalCount(data.totalCount))
+
+    return
+  }
+)

--- a/packages/app/src/messages/components/messages/messages.component.tsx
+++ b/packages/app/src/messages/components/messages/messages.component.tsx
@@ -73,6 +73,8 @@ interface Props extends MessagesComponentProps, Pick<AppSettings, "language"> {
   loadThreads: (
     pagination: PaginationBody
   ) => Promise<PayloadAction<PaginationBody | undefined>>
+  loadThreadsTotalCount: () => Promise<void>
+  loadContacts: () => Promise<void>
   getMessagesByThreadId: (threadId: string) => Message[]
   getContact: (contactId: string) => Contact | undefined
   getReceiver: (phoneNumber: string) => Receiver
@@ -87,6 +89,8 @@ interface Props extends MessagesComponentProps, Pick<AppSettings, "language"> {
 
 const Messages: FunctionComponent<Props> = ({
   loadThreads,
+  loadThreadsTotalCount,
+  loadContacts,
   threadsTotalCount,
   threadsState,
   receivers,
@@ -130,8 +134,14 @@ const Messages: FunctionComponent<Props> = ({
     setThreadsPaginationOffset(response.payload?.offset)
   }
 
+  const fetchData = async () => {
+    await loadThreadsTotalCount()
+    await loadContacts()
+    await loadThreadsRequest()
+  }
+
   useEffect(() => {
-    void loadThreadsRequest()
+    void fetchData()
   }, [])
 
   const [messagesState, setMessagesState] = useState(MessagesState.List)

--- a/packages/app/src/messages/components/messages/messages.stories.tsx
+++ b/packages/app/src/messages/components/messages/messages.stories.tsx
@@ -6,12 +6,22 @@
 import React from "react"
 import { storiesOf } from "@storybook/react"
 import Messages from "App/messages/components/messages/messages.component"
-import { rowMessages, rowThreads } from "Renderer/components/core/table/table.fake-data"
+import {
+  rowMessages,
+  rowThreads,
+} from "Renderer/components/core/table/table.fake-data"
 import AttachContactModal from "App/messages/components/attach-contact-modal.component"
-import { ModalBackdrop, ModalWrapper } from "Renderer/components/core/modal/modal.styled.elements"
+import {
+  ModalBackdrop,
+  ModalWrapper,
+} from "Renderer/components/core/modal/modal.styled.elements"
 import { ContactCategory } from "App/contacts/store/contacts.interface"
 import { Contact } from "App/contacts/store/contacts.type"
-import { Receiver, ReceiverIdentification, ResultState } from "App/messages/reducers/messages.interface"
+import {
+  Receiver,
+  ReceiverIdentification,
+  ResultState,
+} from "App/messages/reducers/messages.interface"
 import { action } from "@storybook/addon-actions"
 import history from "Renderer/routes/history"
 import { Router } from "react-router"
@@ -147,6 +157,8 @@ storiesOf("Views|Messages", module).add("Messages", () => (
         loadThreads={loadData}
         threadsState={ResultState.Loaded}
         threadsTotalCount={rowThreads.length}
+        loadContacts={jest.fn()}
+        loadThreadsTotalCount={jest.fn()}
       />
     </div>
   </Router>

--- a/packages/app/src/messages/components/messages/messages.test.tsx
+++ b/packages/app/src/messages/components/messages/messages.test.tsx
@@ -38,7 +38,6 @@ jest.mock("react-virtualized", () => {
   }
 })
 
-
 const contact: Contact = {
   id: "1",
   firstName: "John",
@@ -94,6 +93,8 @@ const defaultProps: Props = {
   language: "en",
   loadThreads: jest.fn().mockReturnValue({ payload: undefined }),
   getReceiver: jest.fn().mockReturnValue(receiver),
+  loadContacts: jest.fn(),
+  loadThreadsTotalCount: jest.fn(),
   getContactByPhoneNumber: jest.fn(),
   addNewMessage: jest.fn(),
   getContact: jest.fn(),
@@ -240,7 +241,11 @@ describe("Messages component", () => {
     const renderProps: RenderProps = { callbacks: [setNewMessageState] }
 
     test("length of thread list is increased by 1 (tmp thread)", async () => {
-      const { queryByTestId } = renderer({ ...renderProps, threads: [], threadsTotalCount: 0 })
+      const { queryByTestId } = renderer({
+        ...renderProps,
+        threads: [],
+        threadsTotalCount: 0,
+      })
       expect(queryByTestId(ThreadListTestIds.Row)).toBeInTheDocument()
     })
 
@@ -386,7 +391,7 @@ describe("Messages component", () => {
       const { queryByTestId, queryAllByTestId } = renderer({
         ...renderProps,
         threads: [firstThread, secondThread],
-        threadsTotalCount: 2
+        threadsTotalCount: 2,
       })
       const tableRow = queryAllByTestId(ThreadListTestIds.Row)[1]
       fireEvent.click(tableRow)

--- a/packages/app/src/messages/constants/event.enum.ts
+++ b/packages/app/src/messages/constants/event.enum.ts
@@ -5,6 +5,7 @@
 
 export enum MessagesEvent {
   LoadThreads = "LOAD_THREADS",
+  LoadThreadsTotalCount = "LOAD_THREADS_TOTAL_COUNT",
   LoadMessagesById = "LOAD_MESSAGES_BY_ID",
   ToggleThreadReadStatus = "TOGGLE_THREAD_READ_STATUS",
   MarkThreadAsRead = "MARK_THREAD_AS_READ",

--- a/packages/app/src/messages/messages.container.tsx
+++ b/packages/app/src/messages/messages.container.tsx
@@ -34,6 +34,7 @@ import {
 import { PaginationBody } from "@mudita/pure"
 import { PayloadAction } from "@reduxjs/toolkit"
 import { GetMessagesBody } from "Backend/adapters/pure-phone-messages/pure-phone-messages.class"
+import { loadThreadsTotalCount } from "App/messages/actions/load-threads-total-count.action"
 
 const selector = select(({ contacts }) => ({
   getContact: contacts.getContact,
@@ -58,6 +59,8 @@ const mapStateToProps = (state: RootState & ReduxRootState) => ({
 })
 
 const mapDispatchToProps = (dispatch: TmpDispatch) => ({
+  loadThreadsTotalCount: (): Promise<void> =>
+    dispatch(loadThreadsTotalCount()),
   loadThreads: (
     pagination: PaginationBody
   ): Promise<PayloadAction<PaginationBody>> =>
@@ -74,6 +77,7 @@ const mapDispatchToProps = (dispatch: TmpDispatch) => ({
     dispatch(loadMessagesById(body)),
   addNewMessage: async (newMessage: NewMessage): Promise<Message | undefined> =>
     dispatch(addNewMessage(newMessage)),
+  loadContacts: () => dispatch.contacts.loadData(),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(Messages)

--- a/packages/app/src/renderer/wrappers/base-app.component.tsx
+++ b/packages/app/src/renderer/wrappers/base-app.component.tsx
@@ -70,7 +70,7 @@ const BaseApp: FunctionComponent<Props> = ({
     [URL_MAIN.contacts]: [() => loadContacts()],
     [URL_MAIN.phone]: [() => loadContacts()],
     [URL_OVERVIEW.root]: [() => getConnectedDevice()],
-    [URL_MAIN.messages]: [() => loadContacts()],
+    [URL_MAIN.messages]: [],
   })
   useEffect(() => {
     setAppUpdateStepModalVisible(


### PR DESCRIPTION
Jira: [CP-774]

**Description**

Moved loading contacts to messages view, after request to API for totalCount Threads

<details>
<summary><b>Screenshots</b></summary>

Before
https://user-images.githubusercontent.com/17147149/139386898-49f52eb7-5119-4a8f-8b6b-91a0bd3ff474.mov

After
https://user-images.githubusercontent.com/17147149/139388569-15f873e1-0a34-435f-8ed9-35c8cef535af.mov



</details>


[CP-774]: https://appnroll.atlassian.net/browse/CP-774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ