### PR TITLE
[CP-801][CP-821] Rendering Screen Component fixed by move outside from the Overview

### DIFF
--- a/packages/app/src/device/actions/disconnect-device.action.test.ts
+++ b/packages/app/src/device/actions/disconnect-device.action.test.ts
@@ -12,6 +12,7 @@ import { disconnectDevice } from "App/device/actions/disconnect-device.action"
 import { DeviceDisconnectionError } from "App/device/errors"
 import disconnectDeviceRequest from "Renderer/requests/disconnect-device.request"
 import { testError } from "App/renderer/store/constants"
+import { RestoreDeviceDataState } from "App/restore-device/reducers"
 
 const mockStore = createMockStore([thunk])({
   device: {
@@ -30,6 +31,20 @@ describe("Device with updatingState different than `null`", () => {
     const store = createMockStore([thunk])({
       device: {
         updatingState: UpdatingState.Updating,
+      },
+    })
+
+    await store.dispatch(disconnectDevice() as unknown as AnyAction)
+
+    expect(disconnectDeviceRequest).not.toHaveBeenCalled()
+  })
+})
+
+describe("`restoreDevice` is set to running", () => {
+  test("do not call `disconnectDevice`", async () => {
+    const store = createMockStore([thunk])({
+      restoreDevice: {
+        state: RestoreDeviceDataState.Running,
       },
     })
 

--- a/packages/app/src/device/actions/disconnect-device.action.ts
+++ b/packages/app/src/device/actions/disconnect-device.action.ts
@@ -10,6 +10,7 @@ import disconnectDeviceRequest from "Renderer/requests/disconnect-device.request
 import { setConnectionStatus } from "App/device/actions/base.action"
 import { DeviceResponseStatus } from "Backend/adapters/device-response.interface"
 import { DeviceDisconnectionError } from "App/device/errors"
+import { RestoreDeviceDataState } from "App/restore-device/reducers"
 
 export const disconnectDevice = createAsyncThunk(
   DeviceEvent.Disconnected,
@@ -17,6 +18,10 @@ export const disconnectDevice = createAsyncThunk(
     const state = getState() as ReduxRootState
 
     if (state.device.updatingState === UpdatingState.Updating) {
+      return
+    }
+
+    if (state.restoreDevice.state === RestoreDeviceDataState.Running) {
       return
     }
 

--- a/packages/app/src/overview/components/backup-device-flow/backup-device-flow.component.tsx
+++ b/packages/app/src/overview/components/backup-device-flow/backup-device-flow.component.tsx
@@ -3,7 +3,7 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import React, { ComponentProps, useState } from "react"
+import React, { ComponentProps, useEffect, useState } from "react"
 import { FunctionComponent } from "Renderer/types/function-component.interface"
 import {
   BackupFailureModal,
@@ -45,6 +45,10 @@ const BackupDeviceFlow: FunctionComponent<Props> = ({
   const startBackupDeviceButtonClick = (secretKey = ""): void => {
     onStartBackupDeviceButtonClick(secretKey)
   }
+
+  useEffect(() => {
+    setState(openState)
+  }, [openState])
 
   return (
     <>

--- a/packages/app/src/overview/components/overview/overview.component.tsx
+++ b/packages/app/src/overview/components/overview/overview.component.tsx
@@ -3,9 +3,9 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { FunctionComponent } from "Renderer/types/function-component.interface"
-import { DeviceType } from "@mudita/pure"
 import React, { ComponentProps } from "react"
+import { DeviceType } from "@mudita/pure"
+import { FunctionComponent } from "Renderer/types/function-component.interface"
 import {
   PureOverview,
   HarmonyOverview,
@@ -15,19 +15,19 @@ type PureOverviewProps = ComponentProps<typeof PureOverview>
 type HarmonyOverviewProps = ComponentProps<typeof HarmonyOverview>
 type Props = PureOverviewProps & HarmonyOverviewProps
 
-const Overview: FunctionComponent<Props> = (props) => {
-  const Screen = () => {
-    switch (props.deviceType) {
-      case DeviceType.MuditaPure:
-        return <PureOverview {...props} />
-      case DeviceType.MuditaHarmony:
-        return <HarmonyOverview {...props} />
-      default:
-        return <></>
-    }
-  }
 
-  return <Screen />
+const Screen: FunctionComponent<Props> = (props) => {
+  switch (props.deviceType) {
+    case DeviceType.MuditaPure:
+      return <PureOverview {...props} />
+    case DeviceType.MuditaHarmony:
+      return <HarmonyOverview {...props} />
+    default:
+      return <></>
+  }
+}
+const Overview: FunctionComponent<Props> = (props) => {
+  return <Screen {...props} />
 }
 
 export default Overview

--- a/packages/app/src/overview/components/restore-device-flow/restore-device-flow.component.tsx
+++ b/packages/app/src/overview/components/restore-device-flow/restore-device-flow.component.tsx
@@ -3,7 +3,7 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import React, { ComponentProps, useState } from "react"
+import React, { ComponentProps, useEffect, useState } from "react"
 import { FunctionComponent } from "Renderer/types/function-component.interface"
 import {
   RestoreFailureModal,
@@ -56,6 +56,10 @@ const RestoreDeviceFlow: FunctionComponent<Props> = ({
       onStartRestoreDeviceButtonClick({ backup: activeBackup, secretKey })
     }
   }
+
+  useEffect(() => {
+    setState(openState)
+  }, [openState])
 
   return (
     <>


### PR DESCRIPTION
Jira: [CP-801]

**Description**

Rendering Screen Component fixed by moving outside from the Overview Component. This PR handles two bugs:
 - [CP-801 - "Go to support" after failed OS update doesn't work](https://appnroll.atlassian.net/browse/CP-801)
 - [CP-821 - Restore confirmation window disappears automatically](https://appnroll.atlassian.net/browse/CP-821)



[CP-801]: https://appnroll.atlassian.net/browse/CP-801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-801]: https://appnroll.atlassian.net/browse/CP-801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-821]: https://appnroll.atlassian.net/browse/CP-821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ