### PR TITLE
[CP-827] The no result state isn't display when user doesn't have messages

### DIFF
--- a/packages/app/src/messages/components/messages/messages-test-ids.enum.ts
+++ b/packages/app/src/messages/components/messages/messages-test-ids.enum.ts
@@ -4,6 +4,8 @@
  */
 
 export enum MessagesTestIds {
+  EmptyThreadListState = "messages-empty-thread-list-state",
+  ThreadList = "messages-thread-list",
   ThreadDetails = "messages-thread-details",
   NewMessageForm = "messages-new-message-form",
 }

--- a/packages/app/src/messages/components/messages/messages.component.tsx
+++ b/packages/app/src/messages/components/messages/messages.component.tsx
@@ -5,7 +5,10 @@
 
 import React, { useEffect, useState } from "react"
 import { defineMessages } from "react-intl"
-import { TableWithSidebarWrapper } from "Renderer/components/core/table/table.component"
+import {
+  EmptyState,
+  TableWithSidebarWrapper,
+} from "Renderer/components/core/table/table.component"
 import ThreadList from "App/messages/components/thread-list.component"
 import { ComponentProps as MessagesComponentProps } from "App/messages/components/messages/messages.interface"
 import { FunctionComponent } from "Renderer/types/function-component.interface"
@@ -43,10 +46,16 @@ import { PayloadAction } from "@reduxjs/toolkit"
 import { GetMessagesBody } from "Backend/adapters/pure-phone-messages/pure-phone-messages.class"
 import { IndexRange } from "react-virtualized"
 
-const deleteModalMessages = defineMessages({
-  title: { id: "module.messages.deleteModalTitle" },
-  body: {
+const messages = defineMessages({
+  deleteModalTitle: { id: "module.messages.deleteModalTitle" },
+  deleteModalBody: {
     id: "module.messages.deleteModalBody",
+  },
+  emptyListTitle: {
+    id: "module.messages.emptyListTitle",
+  },
+  emptyListDescription: {
+    id: "module.messages.emptyListDescription",
   },
 })
 
@@ -185,7 +194,7 @@ const Messages: FunctionComponent<Props> = ({
     const thread = threads.find(findById) as Thread
 
     return {
-      ...deleteModalMessages.body,
+      ...messages.deleteModalBody,
       values: {
         caller: getPrettyCaller(
           getContactByPhoneNumber(thread.phoneNumber),
@@ -198,7 +207,7 @@ const Messages: FunctionComponent<Props> = ({
   }
 
   const remove = (ids: string[]) => {
-    const title = intl.formatMessage(deleteModalMessages.title)
+    const title = intl.formatMessage(messages.deleteModalTitle)
     const message = getDeletingMessage(ids)
     const onDelete = () => {
       deleteThreads(ids)
@@ -423,19 +432,30 @@ const Messages: FunctionComponent<Props> = ({
         onNewMessageClick={handleNewMessageClick}
       />
       <TableWithSidebarWrapper>
-        <ThreadList
-          threadsTotalCount={getThreadsTotalCount()}
-          language={language}
-          activeThread={activeThread}
-          threads={getThreads()}
-          onThreadClick={handleThreadClick}
-          getContactByPhoneNumber={getContactByPhoneNumber}
-          onDeleteClick={removeSingleConversation}
-          onToggleReadStatus={toggleReadStatus}
-          onContactClick={contactClick}
-          loadMoreRows={loadMoreRows}
-          {...rest}
-        />
+        {threads.length === 0 &&
+        messagesState !== MessagesState.NewMessage &&
+        messagesState !== MessagesState.ThreadDetails ? (
+          <EmptyState
+            data-testid={MessagesTestIds.EmptyThreadListState}
+            title={messages.emptyListTitle}
+            description={messages.emptyListDescription}
+          />
+        ) : (
+          <ThreadList
+            data-testid={MessagesTestIds.ThreadList}
+            threadsTotalCount={getThreadsTotalCount()}
+            language={language}
+            activeThread={activeThread}
+            threads={getThreads()}
+            onThreadClick={handleThreadClick}
+            getContactByPhoneNumber={getContactByPhoneNumber}
+            onDeleteClick={removeSingleConversation}
+            onToggleReadStatus={toggleReadStatus}
+            onContactClick={contactClick}
+            loadMoreRows={loadMoreRows}
+            {...rest}
+          />
+        )}
         {messagesState === MessagesState.ThreadDetails && activeThread && (
           <ThreadDetails
             data-testid={MessagesTestIds.ThreadDetails}

--- a/packages/app/src/messages/components/thread-list.component.tsx
+++ b/packages/app/src/messages/components/thread-list.component.tsx
@@ -82,6 +82,7 @@ const ThreadList: FunctionComponent<Props> = ({
   getContactByPhoneNumber,
   onContactClick,
   loadMoreRows,
+  ...props
 }) => {
   const sidebarOpened = Boolean(activeThread)
 
@@ -124,6 +125,7 @@ const ThreadList: FunctionComponent<Props> = ({
       noneRowsSelected={noneRowsSelected}
       hideableColumnsIndexes={[2, 3, 4]}
       hideColumns={sidebarOpened}
+      {...props}
     >
       <InfiniteLoader
         isRowLoaded={isRowLoaded}

--- a/packages/app/src/renderer/locales/default/en-US.json
+++ b/packages/app/src/renderer/locales/default/en-US.json
@@ -350,6 +350,8 @@
   "module.messages.dropdownContactDetails": "Contact Details",
   "module.messages.dropdownDelete": "Delete Conversation",
   "module.messages.dropdownMarkAsRead": "Mark as read",
+  "module.messages.emptyListTitle": "You don't have any messages yet",
+  "module.messages.emptyListDescription": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
   "module.messages.loadingThreadModalErrorBody": "Something went wrong",
   "module.messages.markAsRead": "Mark as read",
   "module.messages.markAsUnread": "Mark as unread",


### PR DESCRIPTION
Jira: [CP-827]

**Description**

EmptyState component added to Messages Page when threads length size is equal 0


[CP-827]: https://appnroll.atlassian.net/browse/CP-827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ