### PR TITLE
[CP-827] The no result state isn't display when user doesn't have messages {2}

### DIFF
--- a/packages/app/src/messages/actions/base.action.test.ts
+++ b/packages/app/src/messages/actions/base.action.test.ts
@@ -9,7 +9,7 @@ import {
   changeSearchValue,
   changeVisibilityFilter,
   deleteThreads,
-  devClearAllThreads,
+  clearAllThreads,
   markThreadsAsRead,
   setMessages,
   setThreads,
@@ -108,12 +108,12 @@ describe("Action: setMessages", () => {
   })
 })
 
-describe("Action: devClearAllThreads", () => {
+describe("Action: clearAllThreads", () => {
   test("fire action without payload and `DevClearAllThreads` type", () => {
-    mockStore.dispatch(devClearAllThreads())
+    mockStore.dispatch(clearAllThreads())
     expect(mockStore.getActions()).toEqual([
       {
-        type: MessagesEvent.DevClearAllThreads,
+        type: MessagesEvent.ClearAllThreads,
         payload: undefined,
       },
     ])

--- a/packages/app/src/messages/actions/base.action.ts
+++ b/packages/app/src/messages/actions/base.action.ts
@@ -32,4 +32,4 @@ export const setThreadsTotalCount = createAction<number>(
 
 export const setMessages = createAction<Message[]>(MessagesEvent.SetMessages)
 
-export const devClearAllThreads = createAction(MessagesEvent.DevClearAllThreads)
+export const clearAllThreads = createAction(MessagesEvent.ClearAllThreads)

--- a/packages/app/src/messages/actions/load-threads.action.test.ts
+++ b/packages/app/src/messages/actions/load-threads.action.test.ts
@@ -39,6 +39,14 @@ const successDeviceResponse: DeviceResponse<GetThreadsResponse> = {
   },
 }
 
+const emptyDataSuccessDeviceResponse: DeviceResponse<GetThreadsResponse> = {
+  status: DeviceResponseStatus.Ok,
+  data: {
+    data: [],
+    totalCount: 0
+  },
+}
+
 const errorDeviceResponse: DeviceResponse = {
   status: DeviceResponseStatus.Error,
 }
@@ -66,12 +74,39 @@ describe("async `loadThreads` ", () => {
       expect(mockStore.getActions()).toEqual([
         loadThreads.pending(requestId, pagination),
         {
+          type: MessagesEvent.SetThreadsTotalCount,
+          payload: threads.length,
+        },
+        {
           type: MessagesEvent.SetThreads,
           payload: threads,
         },
+        loadThreads.fulfilled(undefined, requestId, pagination),
+      ])
+
+      expect(getThreads).toHaveBeenCalled()
+    })
+  })
+
+  describe("when `getThreads` request return success with empty data", () => {
+    test("fire async `loadThreads` call `clearAllThreads`", async () => {
+      ;(getThreads as jest.Mock).mockReturnValue(emptyDataSuccessDeviceResponse)
+      const mockStore = createMockStore([thunk])()
+      const {
+        meta: { requestId },
+      } = await mockStore.dispatch(
+        loadThreads(pagination) as unknown as AnyAction
+      )
+
+      expect(mockStore.getActions()).toEqual([
+        loadThreads.pending(requestId, pagination),
         {
           type: MessagesEvent.SetThreadsTotalCount,
-          payload: threads.length,
+          payload: 0,
+        },
+        {
+          type: MessagesEvent.ClearAllThreads,
+          payload: undefined,
         },
         loadThreads.fulfilled(undefined, requestId, pagination),
       ])

--- a/packages/app/src/messages/actions/load-threads.action.ts
+++ b/packages/app/src/messages/actions/load-threads.action.ts
@@ -8,6 +8,7 @@ import { MessagesEvent } from "App/messages/constants"
 import getThreads from "Renderer/requests/get-threads.request"
 import { LoadThreadsError } from "App/messages/errors"
 import {
+  clearAllThreads,
   setThreads,
   setThreadsTotalCount,
 } from "App/messages/actions/base.action"
@@ -25,8 +26,13 @@ export const loadThreads = createAsyncThunk<
       return rejectWithValue(new LoadThreadsError("Get Threads request failed"))
     }
 
-    dispatch(setThreads(data.data))
     dispatch(setThreadsTotalCount(data.totalCount))
+
+    if (data.totalCount === 0) {
+      dispatch(clearAllThreads())
+    } else {
+      dispatch(setThreads(data.data))
+    }
 
     return data.nextPage
   }

--- a/packages/app/src/messages/constants/event.enum.ts
+++ b/packages/app/src/messages/constants/event.enum.ts
@@ -14,7 +14,7 @@ export enum MessagesEvent {
   SetThreadsTotalCount = "SET_THREADS_TOTAL_COUNT",
   SetMessages = "SET_MESSAGES",
   AddNewMessage = "ADD_NEW_MESSAGE",
-  DevClearAllThreads = "DEV_CLEAR_ALL_THREADS",
+  ClearAllThreads = "CLEAR_ALL_THREADS",
 
   // TODO: move to UI? :think:
   ChangeVisibilityFilter = "CHANGE_VISIBILITY_FILTER",

--- a/packages/app/src/messages/reducers/messages.reducer.test.ts
+++ b/packages/app/src/messages/reducers/messages.reducer.test.ts
@@ -580,7 +580,7 @@ describe("Dev Clear All Threads data functionality", () => {
             [message.threadId]: [message.id],
           },
         },
-        { type: MessagesEvent.DevClearAllThreads }
+        { type: MessagesEvent.ClearAllThreads }
       )
     ).toEqual({
       ...initialState,

--- a/packages/app/src/messages/reducers/messages.reducer.ts
+++ b/packages/app/src/messages/reducers/messages.reducer.ts
@@ -261,7 +261,7 @@ export const messagesReducer = createReducer<MessagesState>(
         }
       )
 
-      .addCase(MessagesEvent.DevClearAllThreads, (state) => {
+      .addCase(MessagesEvent.ClearAllThreads, (state) => {
         return {
           ...state,
           threadMap: {},

--- a/packages/app/src/renderer/register-app-context-menu.ts
+++ b/packages/app/src/renderer/register-app-context-menu.ts
@@ -16,7 +16,7 @@ import { remote } from "electron"
 import { name } from "../../package.json"
 import importDeviceCrashDumpFiles from "Renderer/requests/import-device-crash-dumps-files.request"
 import { loadThreads } from "App/messages/actions"
-import { devClearAllThreads } from "App/messages/actions/base.action"
+import { clearAllThreads } from "App/messages/actions/base.action"
 
 const filePath = `${remote.app.getPath("appData")}/${name}/pure-logs`
 
@@ -57,7 +57,7 @@ const registerAppContextMenu = (menu: ContextMenu) => {
     },
     {
       label: "Clear all threads",
-      click: () => store.dispatch(devClearAllThreads()),
+      click: () => store.dispatch(clearAllThreads()),
     },
   ])
 


### PR DESCRIPTION
Jira: [CP-827]

**Description**

`LoadThreads` action extended by `clearAllThreads` action to handle empty state in UI.

[CP-827]: https://appnroll.atlassian.net/browse/CP-827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ