### PR TITLE
[CP-708] Fixes after the design review 

### DIFF
--- a/packages/app/src/contacts/components/contact-list/contact-list.component.tsx
+++ b/packages/app/src/contacts/components/contact-list/contact-list.component.tsx
@@ -117,6 +117,16 @@ const SelectableContacts = styled(Table)<{ mouseLock?: boolean }>`
   }
 `
 
+const activeRowStyles = css`
+  ${InitialsAvatar} {
+    ${lightAvatarStyles};
+  }
+`
+
+const ContactListRow = styled(Row)`
+  ${({ active }) => active && activeRowStyles};
+`
+
 type SelectHook = Pick<
   UseTableSelect<Contact>,
   "getRowStatus" | "toggleRow" | "noneRowsSelected"
@@ -229,7 +239,7 @@ const ContactList: FunctionComponent<Props> = ({
                   (nextContact || contacts[index]).id === activeRow?.id
 
                 const interactiveRow = (ref: Ref<HTMLDivElement>) => (
-                  <Row selected={selected} active={rowActive} ref={ref}>
+                  <ContactListRow selected={selected} active={rowActive} ref={ref}>
                     <Col>
                       <Checkbox
                         checked={selected}
@@ -327,12 +337,12 @@ const ContactList: FunctionComponent<Props> = ({
                       key={contact.id}
                       active={scrollActive}
                     />
-                  </Row>
+                  </ContactListRow>
                 )
 
                 const placeholderRow = (ref: Ref<HTMLDivElement>) => {
                   return (
-                    <Row ref={ref}>
+                    <ContactListRow ref={ref}>
                       <Col />
                       <Col>
                         <AvatarPlaceholder />
@@ -347,7 +357,7 @@ const ContactList: FunctionComponent<Props> = ({
                         key={contact.id}
                         active={scrollActive}
                       />
-                    </Row>
+                    </ContactListRow>
                   )
                 }
 


### PR DESCRIPTION
Jira: [CP-708]

**Description**

InitialsAvatar styled fixed in active row state for contacts

<details>
<summary><b>Screenshots</b></summary>

**Before:**
after saving the edited contact, the problem of the avatar color of the active contact returns (It has the wrong color)

<img width="1392" alt="Zrzut ekranu 2021-11-22 o 08 24 55" src="https://user-images.githubusercontent.com/17147149/142820260-21502622-e4c5-40c5-a545-eeb35333062c.png">

</details>


[CP-708]: https://appnroll.atlassian.net/browse/CP-708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ