### PR TITLE
[CP-899] Crash Dump Modal is displaying even when crash dumps were sent

### DIFF
--- a/packages/app/src/crash-dump/actions/send-crash-dump-data.action.ts
+++ b/packages/app/src/crash-dump/actions/send-crash-dump-data.action.ts
@@ -28,7 +28,7 @@ export const sendCrashDumpData = createAsyncThunk(
       )
     }
 
-    for await (const path of state.crashDump.data.downloadedFiles) {
+    for await (const [index, path] of state.crashDump.data.downloadedFiles.entries()) {
       const fileName = path.split("/").pop()
       const buffer = await readFile(path)
 
@@ -43,10 +43,8 @@ export const sendCrashDumpData = createAsyncThunk(
           serialNumber: state.device.data.serialNumber,
         })
 
-        await dispatch(removeFile(state.crashDump.data.files[0]))
-        await dispatch(resetCrashDump())
+        await dispatch(removeFile(state.crashDump.data.files[index]))
 
-        return
       } catch (error) {
         return rejectWithValue(
           new SendingCrashDumpError(
@@ -56,6 +54,8 @@ export const sendCrashDumpData = createAsyncThunk(
         )
       }
     }
+
+    await dispatch(resetCrashDump())
 
     return
   }


### PR DESCRIPTION
Jira: [CP-899]

**Description**

- `removeFile` dispatching modified to handle passed property dynamically https://github.com/mudita/mudita-center/commit/9a18ab492eb6acf9fc47fec8bb3c3fe56aa228d5






[CP-899]: https://appnroll.atlassian.net/browse/CP-899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ