### PR TITLE
[CP-940] Mudita Center shut down after a certain time of inactivity

### DIFF
--- a/packages/app/src/main/utils/logger.ts
+++ b/packages/app/src/main/utils/logger.ts
@@ -49,8 +49,8 @@ const createDailyRotateFileTransport = (
     filename: "mc-%DATE%",
     extension: ".log",
     datePattern: "YYYY-MM-DD",
-    maxFiles: 3,
-    maxSize: "1m",
+    maxFiles: 10,
+    maxSize: "1d",
     level: "info",
     format,
   })


### PR DESCRIPTION
Jira: [CP-940]

**Description**
Logs were limited to 3 files and 1MB per file and this limit was reached after less than hour, then it crashed. I increase files and size limit. 
<details>
<summary><b>Screenshots</b></summary>
// put images here
</details>


[CP-940]: https://appnroll.atlassian.net/browse/CP-940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ