### PR TITLE
[CP-1312] Incorrect string for marked Conversations counter in Selection Manager

### DIFF
--- a/packages/app/src/messages/components/messages-panel.component.tsx
+++ b/packages/app/src/messages/components/messages-panel.component.tsx
@@ -64,7 +64,7 @@ const MessagesPanel: FunctionComponent<Props> = ({
         <ContactSelectionManager
           selectedItemsNumber={selectedItemsCount}
           allItemsSelected={Boolean(allItemsSelected)}
-          message={{ id: "module.contacts.selectionsNumber" }}
+          message={{ id: "module.messages.selectionNumber" }}
           checkboxSize={Size.Medium}
           onToggle={toggleAll}
           data-testid={MessagePanelTestIds.SelectionManager}

--- a/packages/app/src/renderer/locales/default/en-US.json
+++ b/packages/app/src/renderer/locales/default/en-US.json
@@ -406,6 +406,7 @@
   "module.messages.newMessageBadge": "1 new message",
   "module.messages.newMessagesBadge": "{number} new messages",
   "module.messages.search": "Search",
+  "module.messages.selectionNumber": "{num, plural, =-1 {All Conversations} one {# Conversation} other {# Conversations}} selected",
   "module.messages.sendButtonTooltipDescription": "Send message",
   "module.messages.textAreaPlaceholder": "Type your message",
   "module.messages.unreadOnly": "Unread only",


### PR DESCRIPTION
Jira: [CP-1312]

**Description**
Fix after tests form CP-1122.
Fix text in conversations Selection Manager
<details>
<summary><b>Screenshots</b></summary>

![Screen Shot 2022-05-24 at 00 19 08](https://user-images.githubusercontent.com/15948014/169914115-ef06a3b5-1d0b-44ab-8fe6-d0596b075ab5.png)

![Screen Shot 2022-05-24 at 00 19 20](https://user-images.githubusercontent.com/15948014/169914172-ddee8cd1-76f9-4d85-9354-fa9c4f565cb9.png)

![Screen Shot 2022-05-24 at 00 19 26](https://user-images.githubusercontent.com/15948014/169914183-2411f3ce-fd0b-4d3d-8285-e30661760f0e.png)


</details>


[CP-1312]: https://appnroll.atlassian.net/browse/CP-1312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ