### PR TITLE
[CP-1141] Fix deleting notification from the main menu after read message vol.2

### DIFF
--- a/packages/app/src/messages/actions/base.action.test.ts
+++ b/packages/app/src/messages/actions/base.action.test.ts
@@ -9,7 +9,6 @@ import {
   changeSearchValue,
   changeVisibilityFilter,
   clearAllThreads,
-  markThreadsAsRead,
 } from "App/messages/actions/base.action"
 import { MessagesEvent } from "App/messages/constants"
 import { VisibilityFilter } from "App/messages/reducers"
@@ -18,18 +17,6 @@ const mockStore = createMockStore([thunk])()
 
 afterEach(() => {
   mockStore.clearActions()
-})
-
-describe("Action: markThreadsAsRead", () => {
-  test("fire action with empty array and `MarkThreadAsRead` type", () => {
-    mockStore.dispatch(markThreadsAsRead([]))
-    expect(mockStore.getActions()).toEqual([
-      {
-        type: MessagesEvent.MarkThreadAsRead,
-        payload: [],
-      },
-    ])
-  })
 })
 
 describe("Action: changeVisibilityFilter", () => {

--- a/packages/app/src/messages/actions/base.action.ts
+++ b/packages/app/src/messages/actions/base.action.ts
@@ -7,10 +7,6 @@ import { createAction } from "@reduxjs/toolkit"
 import { MessagesEvent } from "App/messages/constants"
 import { MessagesState } from "App/messages/reducers"
 
-export const markThreadsAsRead = createAction<string[]>(
-  MessagesEvent.MarkThreadAsRead
-)
-
 export const changeVisibilityFilter = createAction<
   MessagesState["visibilityFilter"]
 >(MessagesEvent.ChangeVisibilityFilter)

--- a/packages/app/src/messages/actions/toggle-threads-read-status.action.ts
+++ b/packages/app/src/messages/actions/toggle-threads-read-status.action.ts
@@ -13,7 +13,7 @@ export const toggleThreadsReadStatus = createAsyncThunk<
   Error | Thread[],
   Thread[]
 >(
-  MessagesEvent.ToggleThreadReadStatus,
+  MessagesEvent.ToggleThreadsReadStatus,
   async (threads, { rejectWithValue }) => {
     const { error } = await toggleThreadsReadStatusRequest(threads)
     if (error && error.data === undefined) {

--- a/packages/app/src/messages/components/messages/messages.component.tsx
+++ b/packages/app/src/messages/components/messages/messages.component.tsx
@@ -429,7 +429,6 @@ const Messages: FunctionComponent<Props> = ({
             onContactClick={contactClick}
             loadMoreRows={loadMoreRows}
             newConversation={mockThread.phoneNumber}
-            messageLayoutNotifications={messageLayoutNotifications}
             {...rest}
           />
         )}

--- a/packages/app/src/messages/components/thread-details-messages.component.tsx
+++ b/packages/app/src/messages/components/thread-details-messages.component.tsx
@@ -62,7 +62,20 @@ const ThreadDetailsMessages: FunctionComponent<Properties> = ({
     }
   }, [messages])
 
+  const isMessageIncomingDuringBeBottom = (): boolean => {
+    return (
+      onBottom &&
+      prevMessages.messages.length < messages.length &&
+      messages[messages.length - 1].messageType === MessageType.INBOX
+    )
+  }
+
   const closeNewMessageBadge = useCallback(() => {
+    if (isMessageIncomingDuringBeBottom()) {
+      // when the application will stop supporting `messages.observer` than this condition is to remove
+      onMessageRead()
+    }
+
     const notificationOnThread = messageLayoutNotifications?.find(
       (item) =>
         (item.content as Message)?.threadId === messages[0].threadId &&
@@ -87,19 +100,17 @@ const ThreadDetailsMessages: FunctionComponent<Properties> = ({
 
   const callback = (entries: IntersectionObserverEntry[]) => {
     // notification when user during scroll
-    setOnBottom(entries[0].isIntersecting)
-    if (entries[0] && entries[0].isIntersecting) {
+    const isIntersecting = entries[0].isIntersecting
+    setOnBottom(isIntersecting)
+
+    if (isIntersecting) {
       closeNewMessageBadge()
     }
   }
 
   useEffect(() => {
     // notification when user in bottom
-    if (
-      onBottom &&
-      prevMessages.messages.length < messages.length &&
-      messages[messages.length - 1].messageType === MessageType.INBOX
-    ) {
+    if (isMessageIncomingDuringBeBottom()) {
       closeNewMessageBadge()
     }
     return () => {
@@ -173,7 +184,7 @@ const ThreadDetailsMessages: FunctionComponent<Properties> = ({
           return <MessageDayBubble key={id} {...messageDayBubble} />
         }}
       </ViewportList>
-      <div ref={wrapperBottomRef}></div>
+      <div ref={wrapperBottomRef} />
     </MessageBubblesWrapper>
   )
 }

--- a/packages/app/src/messages/components/thread-details-messages.component.tsx
+++ b/packages/app/src/messages/components/thread-details-messages.component.tsx
@@ -62,7 +62,7 @@ const ThreadDetailsMessages: FunctionComponent<Properties> = ({
     }
   }, [messages])
 
-  const isMessageIncomingDuringBeBottom = (): boolean => {
+  const isMessageIncomingWhileScrollOnBottom = (): boolean => {
     return (
       onBottom &&
       prevMessages.messages.length < messages.length &&
@@ -71,7 +71,7 @@ const ThreadDetailsMessages: FunctionComponent<Properties> = ({
   }
 
   const closeNewMessageBadge = useCallback(() => {
-    if (isMessageIncomingDuringBeBottom()) {
+    if (isMessageIncomingWhileScrollOnBottom()) {
       // when the application will stop supporting `messages.observer` than this condition is to remove
       onMessageRead()
     }
@@ -110,7 +110,7 @@ const ThreadDetailsMessages: FunctionComponent<Properties> = ({
 
   useEffect(() => {
     // notification when user in bottom
-    if (isMessageIncomingDuringBeBottom()) {
+    if (isMessageIncomingWhileScrollOnBottom()) {
       closeNewMessageBadge()
     }
     return () => {

--- a/packages/app/src/messages/components/thread-list.component.tsx
+++ b/packages/app/src/messages/components/thread-list.component.tsx
@@ -15,7 +15,6 @@ import { Contact } from "App/contacts/reducers/contacts.interface"
 import { AutoSizer, IndexRange, List, ListRowProps } from "react-virtualized"
 import ThreadRow from "App/messages/components/thread-row.component"
 import ThreadPlaceholderRow from "App/messages/components/thread-placeholder-row.component"
-import { Notification } from "App/notification/types"
 
 const Threads = styled(Table)<{
   noneRowsSelected?: boolean
@@ -43,7 +42,6 @@ interface Props extends SelectHook, Pick<AppSettings, "language"> {
   onContactClick: (phoneNumber: string) => void
   loadMoreRows: (props: IndexRange) => Promise<void>
   newConversation: string
-  messageLayoutNotifications?: Notification[]
 }
 
 const ThreadList: FunctionComponent<Props> = ({
@@ -60,7 +58,6 @@ const ThreadList: FunctionComponent<Props> = ({
   onContactClick,
   loadMoreRows,
   newConversation,
-  messageLayoutNotifications,
   ...props
 }) => {
   const sidebarOpened = Boolean(activeThread)
@@ -93,7 +90,6 @@ const ThreadList: FunctionComponent<Props> = ({
           thread={thread}
           style={style}
           newConversation={newConversation}
-          messageLayoutNotifications={messageLayoutNotifications}
         />
       )
     }

--- a/packages/app/src/messages/components/thread-row.component.tsx
+++ b/packages/app/src/messages/components/thread-row.component.tsx
@@ -3,7 +3,7 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import React, { useEffect, useState } from "react"
+import React from "react"
 import { FunctionComponent } from "Renderer/types/function-component.interface"
 import { Size } from "Renderer/components/core/input-checkbox/input-checkbox.component"
 import Avatar, {
@@ -49,11 +49,6 @@ import { IconButtonWithSecondaryTooltip } from "Renderer/components/core/icon-bu
 import { defineMessages } from "react-intl"
 import { ElementWithTooltipPlace } from "Renderer/components/core/tooltip/element-with-tooltip.component"
 import { IconType } from "Renderer/components/core/icon/icon-type"
-import {
-  Message as MessageContent,
-  MessageType,
-} from "App/messages/reducers/messages.interface"
-import { Notification } from "App/notification/types"
 
 const messages = defineMessages({
   dropdownTogllerTooltipDescription: {
@@ -149,7 +144,6 @@ interface Props
   onToggleReadClick: (threads: Thread[]) => void
   onContactClick: (phoneNumber: Thread["phoneNumber"]) => void
   newConversation: string
-  messageLayoutNotifications?: Notification[]
 }
 
 const ThreadRow: FunctionComponent<Props> = ({
@@ -167,26 +161,16 @@ const ThreadRow: FunctionComponent<Props> = ({
   onToggleReadClick,
   onContactClick,
   newConversation,
-  messageLayoutNotifications,
   ...props
 }) => {
   const contactCreated = contact !== undefined
   const { unread, id, phoneNumber } = thread
-  const [hasNotification, setHasNotification] = useState<boolean>()
+
   const handleCheckboxChange = () => onCheckboxChange(thread)
   const handleRowClick = () => onRowClick(thread)
   const handleDeleteClick = () => onDeleteClick(id)
   const handleToggleClick = () => onToggleReadClick([thread])
   const handleContactClick = () => onContactClick(phoneNumber)
-
-  useEffect(() => {
-    const notificationOnThread = messageLayoutNotifications?.find(
-      (item) =>
-        (item.content as MessageContent)?.threadId === id &&
-        (item.content as MessageContent)?.messageType === MessageType.INBOX
-    )
-    setHasNotification(notificationOnThread ? true : false)
-  }, [messageLayoutNotifications])
 
   return (
     <ThreadRowContainer key={id} selected={selected} active={active} {...props}>
@@ -237,9 +221,7 @@ const ThreadRow: FunctionComponent<Props> = ({
                     .format("ll")}
             </Time>
             <LastMessageText
-              unread={
-                hasNotification || !(active && !hasNotification) || unread
-              }
+              unread={unread}
               color="secondary"
               displayStyle={
                 unread

--- a/packages/app/src/messages/constants/errors.enum.ts
+++ b/packages/app/src/messages/constants/errors.enum.ts
@@ -7,4 +7,6 @@ export enum MessagesError {
   LoadThreads = "LOAD_THREADS_DATA_ERROR",
   LoadMessagesById = "LOAD_MESSAGES_DATA_BY_ID_ERROR",
   AddNewMessage = "ADD_NEW_MESSAGE_ERROR",
+  ToggleThreadsReadStatus = "TOGGLE_THREADS_READ_STATUS_ERROR",
+  MarkThreadsReadStatus = "MARK_THREADS_READ_STATUS_ERROR",
 }

--- a/packages/app/src/messages/constants/event.enum.ts
+++ b/packages/app/src/messages/constants/event.enum.ts
@@ -4,9 +4,7 @@
  */
 
 export enum MessagesEvent {
-  ToggleThreadReadStatus = "TOGGLE_THREAD_READ_STATUS",
-  MarkThreadAsRead = "MARK_THREAD_AS_READ",
-
+  ToggleThreadsReadStatus = "TOGGLE_THREADS_READ_STATUS",
   MarkThreadsReadStatus = "MARK_THREADS_READ_STATUS",
 
   DeleteThreads = "DELETE_THREADS",

--- a/packages/app/src/messages/controllers/thread.controller.ts
+++ b/packages/app/src/messages/controllers/thread.controller.ts
@@ -24,9 +24,9 @@ export class ThreadController {
   }
 
   @IpcEvent(IpcThreadEvent.ToggleThreadsReadStatus)
-  public toggleThreadReadStatus(
+  public toggleThreadsReadStatus(
     threads: Thread[]
   ): Promise<RequestResponse<Thread[]>> {
-    return this.threadService.toggleThreadReadStatus(threads)
+    return this.threadService.toggleThreadsReadStatus(threads)
   }
 }

--- a/packages/app/src/messages/errors/mark-threads-read-status.error.ts
+++ b/packages/app/src/messages/errors/mark-threads-read-status.error.ts
@@ -3,10 +3,10 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { MessagesEvent } from "App/messages/constants"
+import { MessagesError } from "App/messages/constants"
 
 export class MarkThreadsReadStatusError extends Error {
-  public type = MessagesEvent.ToggleThreadsReadStatus
+  public type = MessagesError.MarkThreadsReadStatus
 
   constructor(public message: string, public payload?: any) {
     super()

--- a/packages/app/src/messages/errors/mark-threads-read-status.error.ts
+++ b/packages/app/src/messages/errors/mark-threads-read-status.error.ts
@@ -6,7 +6,7 @@
 import { MessagesEvent } from "App/messages/constants"
 
 export class MarkThreadsReadStatusError extends Error {
-  public type = MessagesEvent.ToggleThreadReadStatus
+  public type = MessagesEvent.ToggleThreadsReadStatus
 
   constructor(public message: string, public payload?: any) {
     super()

--- a/packages/app/src/messages/errors/toggle-threads-read-status.error.ts
+++ b/packages/app/src/messages/errors/toggle-threads-read-status.error.ts
@@ -6,7 +6,7 @@
 import { MessagesEvent } from "App/messages/constants"
 
 export class ToggleThreadsReadStatusError extends Error {
-  public type = MessagesEvent.ToggleThreadReadStatus
+  public type = MessagesEvent.ToggleThreadsReadStatus
 
   constructor(public message: string, public payload?: any) {
     super()

--- a/packages/app/src/messages/errors/toggle-threads-read-status.error.ts
+++ b/packages/app/src/messages/errors/toggle-threads-read-status.error.ts
@@ -3,10 +3,10 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { MessagesEvent } from "App/messages/constants"
+import { MessagesError } from "App/messages/constants"
 
 export class ToggleThreadsReadStatusError extends Error {
-  public type = MessagesEvent.ToggleThreadsReadStatus
+  public type = MessagesError.ToggleThreadsReadStatus
 
   constructor(public message: string, public payload?: any) {
     super()

--- a/packages/app/src/messages/messages.container.tsx
+++ b/packages/app/src/messages/messages.container.tsx
@@ -16,7 +16,6 @@ import {
   changeSearchValue,
   changeVisibilityFilter,
   hideDeleteModal,
-  markThreadsAsRead,
 } from "App/messages/actions/base.action"
 import { addNewMessage } from "App/messages/actions"
 import {
@@ -70,7 +69,6 @@ const mapDispatchToProps = (dispatch: TmpDispatch) => ({
     dispatch(changeVisibilityFilter(filter)),
   deleteThreads: async (threadIds: string[]): Promise<string[] | undefined> =>
     dispatch(deleteThreads(threadIds)),
-  markAsRead: (threadIds: string[]) => dispatch(markThreadsAsRead(threadIds)),
   toggleReadStatus: (threads: Thread[]) =>
     dispatch(toggleThreadsReadStatus(threads)),
   markThreadsReadStatus: (threads: Thread[]) =>

--- a/packages/app/src/messages/reducers/messages-reducer.helpers.test.ts
+++ b/packages/app/src/messages/reducers/messages-reducer.helpers.test.ts
@@ -16,23 +16,23 @@ const thread: Thread = {
 }
 
 describe("Messages Reducer - helpers", () => {
-  test("when as arguments has empty `threadMap` and empty `threads` array than returns empty object", () => {
+  test("when both `threadMap` and `threads` are empty, the empty object is returned", () => {
     const result = markThreadsReadStatus([], {})
     expect(result).toEqual({})
   })
 
-  test("when as arguments has empty `threadMap` object event with `threads` array than returns empty object", () => {
+  test("when is empty `threadMap` and `threads` array is filled with some threads, the empty object is returned", () => {
     const result = markThreadsReadStatus([thread], {})
     expect(result).toEqual({})
   })
 
-  test("when as arguments has `threadMap` and empty `threads` array than returns object without modified", () => {
+  test("when `threadMap` is filed with the thread and `threads` array is empty, the return result is equal to `threadMap`", () => {
     const threadMap = { ["1"]: thread }
     const result = markThreadsReadStatus([], threadMap)
     expect(result).toEqual(threadMap)
   })
 
-  test("when as arguments has `threadMap` and `threads` array than returns object with modified", () => {
+  test("when `threadMap` both `threads` are filled with the same thread, the modified threadMap is returned", () => {
     const result = markThreadsReadStatus([thread], { ["1"]: thread })
     expect(result).toEqual({ ["1"]: { ...thread, unread: false } })
   })

--- a/packages/app/src/messages/reducers/messages-reducer.helpers.test.ts
+++ b/packages/app/src/messages/reducers/messages-reducer.helpers.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Mudita sp. z o.o. All rights reserved.
+ * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
+ */
+
+import { markThreadsReadStatus } from "App/messages/reducers/messages-reducer.helpers"
+import { Thread } from "App/messages/reducers/messages.interface"
+
+const thread: Thread = {
+  id: "1",
+  phoneNumber: "+48 755 853 216",
+  lastUpdatedAt: new Date("2020-06-01T13:53:27.087Z"),
+  messageSnippet:
+    "Exercitationem vel quasi doloremque. Enim qui quis quidem eveniet est corrupti itaque recusandae.",
+  unread: true,
+}
+
+describe("Messages Reducer - helpers", () => {
+  test("when as arguments has empty `threadMap` and empty `threads` array than returns empty object", () => {
+    const result = markThreadsReadStatus([], {})
+    expect(result).toEqual({})
+  })
+
+  test("when as arguments has empty `threadMap` object event with `threads` array than returns empty object", () => {
+    const result = markThreadsReadStatus([thread], {})
+    expect(result).toEqual({})
+  })
+
+  test("when as arguments has `threadMap` and empty `threads` array than returns object without modified", () => {
+    const threadMap = { ["1"]: thread }
+    const result = markThreadsReadStatus([], threadMap)
+    expect(result).toEqual(threadMap)
+  })
+
+  test("when as arguments has `threadMap` and `threads` array than returns object with modified", () => {
+    const result = markThreadsReadStatus([thread], { ["1"]: thread })
+    expect(result).toEqual({ ["1"]: { ...thread, unread: false } })
+  })
+})

--- a/packages/app/src/messages/reducers/messages-reducer.helpers.ts
+++ b/packages/app/src/messages/reducers/messages-reducer.helpers.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Mudita sp. z o.o. All rights reserved.
+ * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
+ */
+
+import { Thread, ThreadMap } from "App/messages/reducers/messages.interface"
+
+export const markThreadsReadStatus = (
+  threads: Thread[],
+  threadMap: ThreadMap
+): ThreadMap => {
+  const ids = threads.map((thread) => thread.id)
+  return Object.keys(threadMap).reduce(
+    (prevThreadMap, id) => {
+      if (ids.includes(id)) {
+        const thread = prevThreadMap[id]
+        prevThreadMap[id] = {
+          ...thread,
+          unread: false,
+        }
+        return prevThreadMap
+      } else {
+        return prevThreadMap
+      }
+    },
+    { ...threadMap }
+  )
+}

--- a/packages/app/src/messages/reducers/messages.interface.ts
+++ b/packages/app/src/messages/reducers/messages.interface.ts
@@ -87,23 +87,26 @@ export type AddNewMessageAction = PayloadAction<
   MessagesEvent.AddNewMessage
 >
 
-export type ToggleThreadReadStatusPendingAction = PayloadAction<
+export type ToggleThreadsReadStatusPendingAction = PayloadAction<
   undefined,
-  MessagesEvent.ToggleThreadReadStatus,
+  MessagesEvent.ToggleThreadsReadStatus,
   {
     arg: Thread[]
   }
 >
 export type MarkThreadsReadStatusPendingAction = PayloadAction<
   undefined,
-  MessagesEvent.ToggleThreadReadStatus,
+  MessagesEvent.ToggleThreadsReadStatus,
   {
     arg: Thread[]
   }
 >
-export type MarkThreadAsReadAction = PayloadAction<
-  string,
-  MessagesEvent.MarkThreadAsRead
+export type MarkThreadsReadStatusAction = PayloadAction<
+  Thread[],
+  MessagesEvent.ToggleThreadsReadStatus,
+  {
+    arg: Thread[]
+  }
 >
 
 export type DeleteThreadsAction = PayloadAction<

--- a/packages/app/src/messages/reducers/messages.reducer.test.ts
+++ b/packages/app/src/messages/reducers/messages.reducer.test.ts
@@ -40,7 +40,7 @@ describe("Toggle Thread Read Status data functionality", () => {
         arg: Thread[]
       }
     > = {
-      type: pendingAction(MessagesEvent.ToggleThreadReadStatus),
+      type: pendingAction(MessagesEvent.ToggleThreadsReadStatus),
       payload: undefined,
       meta: { arg: [thread] },
     }
@@ -74,7 +74,7 @@ describe("Mark Thread Read Status data functionality", () => {
     unread: true,
   }
 
-  test("Event: MarkThreadsReadStatus update properly threadMap field", () => {
+  test("Event: MarkThreadsReadStatus/pending update properly threadMap field", () => {
     const markThreadsReadStatusAction: PayloadAction<
       undefined,
       string,
@@ -104,22 +104,18 @@ describe("Mark Thread Read Status data functionality", () => {
       },
     })
   })
-})
 
-describe("Mark Thread As Read data functionality", () => {
-  const thread: Thread = {
-    id: "1",
-    phoneNumber: "+48 755 853 216",
-    lastUpdatedAt: new Date("2020-06-01T13:53:27.087Z"),
-    messageSnippet:
-      "Exercitationem vel quasi doloremque. Enim qui quis quidem eveniet est corrupti itaque recusandae.",
-    unread: true,
-  }
-
-  test("Event: MarkThreadAsRead update properly threadMap field", () => {
-    const markThreadAsRead: PayloadAction<string[]> = {
-      type: MessagesEvent.MarkThreadAsRead,
-      payload: [thread.id],
+  test("Event: MarkThreadsReadStatus/fulfilled update properly threadMap field", () => {
+    const markThreadsReadStatusAction: PayloadAction<
+      undefined,
+      string,
+      {
+        arg: Thread[]
+      }
+    > = {
+      type: fulfilledAction(MessagesEvent.MarkThreadsReadStatus),
+      payload: undefined,
+      meta: { arg: [thread] },
     }
 
     expect(
@@ -127,10 +123,10 @@ describe("Mark Thread As Read data functionality", () => {
         {
           ...initialState,
           threadMap: {
-            [thread.id]: { ...thread, unread: true },
+            [thread.id]: thread,
           },
         },
-        markThreadAsRead
+        markThreadsReadStatusAction
       )
     ).toEqual({
       ...initialState,

--- a/packages/app/src/messages/reducers/messages.reducer.test.ts
+++ b/packages/app/src/messages/reducers/messages.reducer.test.ts
@@ -32,8 +32,8 @@ describe("Toggle Thread Read Status data functionality", () => {
     unread: true,
   }
 
-  test("Event: ToggleThreadReadStatus update properly threadMap field", () => {
-    const toggleThreadReadStatusAction: PayloadAction<
+  test("Event: ToggleThreadsReadStatus update properly threadMap field", () => {
+    const toggleThreadsReadStatusAction: PayloadAction<
       undefined,
       string,
       {
@@ -53,7 +53,7 @@ describe("Toggle Thread Read Status data functionality", () => {
             [thread.id]: thread,
           },
         },
-        toggleThreadReadStatusAction
+        toggleThreadsReadStatusAction
       )
     ).toEqual({
       ...initialState,

--- a/packages/app/src/messages/services/thread.service.test.ts
+++ b/packages/app/src/messages/services/thread.service.test.ts
@@ -128,20 +128,20 @@ describe("`ThreadService`", () => {
     })
   })
 
-  describe("`toggleThreadReadStatus` method", () => {
+  describe("`toggleThreadsReadStatus` method", () => {
     test("map data and returns success when `deviceService.request` returns success", async () => {
       deviceService.request = jest.fn().mockReturnValue({
         status: RequestResponseStatus.Ok,
         thread: [thread],
       })
-      const response = await subject.toggleThreadReadStatus([thread])
+      const response = await subject.toggleThreadsReadStatus([thread])
       expect(deviceService.request).toHaveBeenCalled()
       expect(response.status).toEqual(RequestResponseStatus.Ok)
     })
 
     test("returns error when `deviceService.request` returns error", async () => {
       deviceService.request = jest.fn().mockReturnValue(errorResponse)
-      const response = await subject.toggleThreadReadStatus([thread])
+      const response = await subject.toggleThreadsReadStatus([thread])
       expect(deviceService.request).toHaveBeenCalled()
       expect(response.status).toEqual(RequestResponseStatus.Error)
     })

--- a/packages/app/src/messages/services/thread.service.ts
+++ b/packages/app/src/messages/services/thread.service.ts
@@ -163,7 +163,7 @@ export class ThreadService {
     }
   }
 
-  public async toggleThreadReadStatus(
+  public async toggleThreadsReadStatus(
     threads: Thread[]
   ): Promise<RequestResponse<Thread[]>> {
     const results = threads.map(async (thread) => {


### PR DESCRIPTION
Jira: [CP-1141]

**Description**

This PR is a part of the improvements to  👉  https://github.com/mudita/mudita-center/pull/743

- [Revert "CP-1141 set unread status on thread"](https://github.com/mudita/mudita-center/pull/753/commits/99ca6cd2d4871bc90cb8bb9a32a69420e499458b)
- handle the events emitted by `messages.observer`
- workaround to handle a "redux lag" by duplicate redux logic in both states in pending and fulfilled

[CP-1141]: https://appnroll.atlassian.net/browse/CP-1141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ