### PR TITLE
[CP-1576] Remove contact panel buttons when selection manager is open

### DIFF
--- a/packages/app/src/contacts/components/contact-panel/contact-panel.component.tsx
+++ b/packages/app/src/contacts/components/contact-panel/contact-panel.component.tsx
@@ -165,31 +165,33 @@ const ContactPanel: FunctionComponent<ContactPanelProps> = ({
             data-testid={ContactPanelTestIdsEnum.SelectionManager}
           />
         ) : (
-          <ContactInputSearch
-            onContactSelect={onContactSelect}
-            onSearchEnterClick={onSearchEnterClick}
-            searchValue={searchValue}
-            onSearchValueChange={onSearchValueChange}
-            showSearchResults
-            results={results}
-          />
+          <>
+            <ContactInputSearch
+              onContactSelect={onContactSelect}
+              onSearchEnterClick={onSearchEnterClick}
+              searchValue={searchValue}
+              onSearchValueChange={onSearchValueChange}
+              showSearchResults
+              results={results}
+            />
+            <Buttons>
+              <ButtonComponent
+                displayStyle={DisplayStyle.Secondary}
+                labelMessage={{ id: "module.contacts.importButton" }}
+                onClick={onManageButtonClick}
+                data-testid={ContactPanelTestIdsEnum.ImportButton}
+              />
+              <ButtonComponent
+                labelMessage={{
+                  id: "module.contacts.panelNewContactButton",
+                }}
+                onClick={onNewButtonClick}
+                disabled={editMode}
+                data-testid={ContactPanelTestIdsEnum.NewButton}
+              />
+            </Buttons>
+          </>
         )}
-        <Buttons>
-          <ButtonComponent
-            displayStyle={DisplayStyle.Secondary}
-            labelMessage={{ id: "module.contacts.importButton" }}
-            onClick={onManageButtonClick}
-            data-testid={ContactPanelTestIdsEnum.ImportButton}
-          />
-          <ButtonComponent
-            labelMessage={{
-              id: "module.contacts.panelNewContactButton",
-            }}
-            onClick={onNewButtonClick}
-            disabled={editMode}
-            data-testid={ContactPanelTestIdsEnum.NewButton}
-          />
-        </Buttons>
       </Panel>
       {showSearchResults && (
         <SearchTitle

--- a/packages/app/src/contacts/components/contact-panel/contact-panel.styled.tsx
+++ b/packages/app/src/contacts/components/contact-panel/contact-panel.styled.tsx
@@ -21,12 +21,6 @@ export const Panel = styled.div<{
   align-items: end;
   padding: 2.4rem 3.2rem 0 3.2rem;
   background-color: ${backgroundColor("main")};
-  ${({ selectionMode }) =>
-    selectionMode &&
-    css`
-      grid-template-columns: 62.4rem auto;
-      padding-left: 0.6rem;
-    `};
   label {
     width: auto;
   }

--- a/packages/app/src/contacts/components/contact-panel/contact-panel.styled.tsx
+++ b/packages/app/src/contacts/components/contact-panel/contact-panel.styled.tsx
@@ -3,7 +3,7 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import styled, { css } from "styled-components"
+import styled from "styled-components"
 import {
   backgroundColor,
   transitionTime,

--- a/packages/app/src/contacts/components/contact-panel/contact-panel.test.tsx
+++ b/packages/app/src/contacts/components/contact-panel/contact-panel.test.tsx
@@ -94,4 +94,15 @@ describe("`ContactPanel` component", () => {
       "[value] module.contacts.searchResultsTitle"
     )
   })
+  test("import and new contact buttons are hidden when there is at least one contact selected", () => {
+    const { queryByTestId } = render({
+      selectedContacts: [contacts[0].id],
+    })
+    expect(
+      queryByTestId(ContactPanelTestIdsEnum.ImportButton)
+    ).not.toBeInTheDocument()
+    expect(
+      queryByTestId(ContactPanelTestIdsEnum.NewButton)
+    ).not.toBeInTheDocument()
+  })
 })

--- a/packages/app/src/contacts/components/contacts/contacts.component.tsx
+++ b/packages/app/src/contacts/components/contacts/contacts.component.tsx
@@ -154,7 +154,6 @@ const Contacts: FunctionComponent<ContactsProps> = ({
     setNewContact(defaultContact)
     setShowSearchResults(false)
     setSearchValue("")
-    resetAllItems()
   }
 
   const cancelOrCloseContactHandler = () => {
@@ -418,7 +417,6 @@ const Contacts: FunctionComponent<ContactsProps> = ({
         inputElement.removeEventListener("change", onFileSelect)
       }
     }
-    resetAllItems()
     inputElement.click()
     inputElement.addEventListener("change", onFileSelect)
   }
@@ -428,7 +426,6 @@ const Contacts: FunctionComponent<ContactsProps> = ({
   const authorizeAtOutLook = () => authorizeAtProvider(Provider.Outlook)
 
   const authorizeAtProvider = async (provider: ExternalProvider) => {
-    resetAllItems()
     try {
       await authorize(provider)
       await getContacts({ type: provider })


### PR DESCRIPTION
Jira: [CP-1576]

**Description**
Changed design. Now there are no import and new contact buttons when selection manager is visible. 
<details>
<summary><b>Screenshots</b></summary>
<img width="980" alt="Screen Shot 2022-09-08 at 19 25 41" src="https://user-images.githubusercontent.com/15948014/189187861-e78496b4-881e-42bb-aa4e-16a7f108521c.png">




</details>


[CP-1576]: https://appnroll.atlassian.net/browse/CP-1576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ