### PR TITLE
[CP-1605] Adding `NoSpaceError` to files manager

### DIFF
--- a/packages/app/src/__deprecated__/backend/device-service.ts
+++ b/packages/app/src/__deprecated__/backend/device-service.ts
@@ -516,6 +516,11 @@ export class DeviceService {
         error,
         status: RequestResponseStatus.NotAcceptable,
       }
+    } else if (status === ResponseStatus.InsufficientStorage) {
+      return {
+        error,
+        status: RequestResponseStatus.InsufficientStorage,
+      }
     } else {
       return {
         error,

--- a/packages/app/src/__deprecated__/renderer/locales/default/en-US.json
+++ b/packages/app/src/__deprecated__/renderer/locales/default/en-US.json
@@ -394,6 +394,8 @@
   "module.filesManager.uploadingModalBody": "Please wait, this might take a few minutes",
   "module.filesManager.uploadingModalErrorSubtitle": "Uploading failed",
   "module.filesManager.uploadingModalErrorTitle": "Uploading Files",
+  "module.filesManager.uploadingModalNoSpaceErrorSubtitle": "Not enough space on your device",
+  "module.filesManager.uploadingModalNoSpaceErrorTitle": "Uploading Files",
   "module.filesManager.uploadingModalInfo": "{num, plural, =-1 {All files} one {# File} other {# Files}} uploaded.",
   "module.filesManager.uploadingModalSubtitle": "Files uploading...",
   "module.filesManager.uploadingModalTitle": "Upload files",

--- a/packages/app/src/core/types/request-response.interface.ts
+++ b/packages/app/src/core/types/request-response.interface.ts
@@ -11,6 +11,7 @@ export enum RequestResponseStatus {
   Duplicated = "phone-number-duplicated",
   UnprocessableEntity = "unprocessable-entity",
   NotAcceptable = "agreement-is-not-accepted",
+  InsufficientStorage = "not-enough-space-on-device",
 }
 
 // AUTO DISABLED - fix me if you like :)

--- a/packages/app/src/device-file-system/commands/file-upload.command.ts
+++ b/packages/app/src/device-file-system/commands/file-upload.command.ts
@@ -56,6 +56,15 @@ export class FileUploadCommand extends BaseCommand {
       response.status !== RequestResponseStatus.Ok ||
       response.data === undefined
     ) {
+      if (response.status === RequestResponseStatus.InsufficientStorage) {
+        return Result.failed(
+          new AppError(
+            DeviceFileSystemError.NoSpaceLeft,
+            "Not enough space on device"
+          )
+        )
+      }
+
       return Result.failed(
         new AppError(
           DeviceFileSystemError.FileUploadRequest,

--- a/packages/app/src/device-file-system/constants/error.enum.ts
+++ b/packages/app/src/device-file-system/constants/error.enum.ts
@@ -10,4 +10,5 @@ export enum DeviceFileSystemError {
   FileUploadUnreadable = "DEVICE_FILE_UPLOADING_UNREADABLE_ERROR",
   FilesRetrieve = "DEVICE_FILES_RETRIEVE_ERROR",
   FileDeleteCommand = "DEVICE_FILE_DELETE_ERROR",
+  NoSpaceLeft = "NO_SPACE_LEFT_ON_DEVICE_ERROR",
 }

--- a/packages/app/src/files-manager/components/files-manager/files-manager.component.tsx
+++ b/packages/app/src/files-manager/components/files-manager/files-manager.component.tsx
@@ -49,6 +49,7 @@ const FilesManager: FunctionComponent<FilesManagerProps> = ({
   resetUploadingState,
   uploadingFileLength,
   uploadBlocked,
+  error,
 }) => {
   const { noFoundFiles, searchValue, filteredFiles, handleSearchValueChange } =
     useFilesFilter({ files })
@@ -217,6 +218,7 @@ const FilesManager: FunctionComponent<FilesManagerProps> = ({
   return (
     <FilesManagerContainer data-testid={FilesManagerTestIds.Container}>
       <UploadFilesModals
+        error={error}
         filesLength={uploadingFileLength}
         uploading={states.uploading}
         uploadingInfo={states.uploadingInfo}

--- a/packages/app/src/files-manager/components/files-manager/files-manager.interface.tsx
+++ b/packages/app/src/files-manager/components/files-manager/files-manager.interface.tsx
@@ -5,6 +5,7 @@
 
 import { DeviceType } from "@mudita/pure"
 import { State } from "App/core/constants"
+import { AppError } from "App/core/errors"
 import { DiskSpaceCategoryType } from "App/files-manager/constants"
 import { IconType } from "App/__deprecated__/renderer/components/core/icon/icon-type"
 import { File } from "App/files-manager/dto"
@@ -29,6 +30,7 @@ export interface FilesManagerProps {
   resetUploadingState: () => void
   uploadFile: () => void
   uploadBlocked: boolean
+  error: AppError | null
 }
 
 export interface DiskSpaceCategory {

--- a/packages/app/src/files-manager/components/files-manager/files-manager.test.tsx
+++ b/packages/app/src/files-manager/components/files-manager/files-manager.test.tsx
@@ -17,6 +17,7 @@ import { UploadFilesModalsTestIds } from "App/files-manager/components/upload-fi
 
 type Props = ComponentProps<typeof FilesManager>
 const defaultProps: Props = {
+  error: null,
   uploadingFileLength: 0,
   memorySpace: {
     reservedSpace: 62914560,

--- a/packages/app/src/files-manager/components/upload-files-modals/upload-files-modals.component.tsx
+++ b/packages/app/src/files-manager/components/upload-files-modals/upload-files-modals.component.tsx
@@ -7,6 +7,7 @@ import React from "react"
 import { defineMessages } from "react-intl"
 import { UploadFilesModalsTestIds } from "App/files-manager/components/upload-files-modals/upload-files-modals-test-ids.enum"
 import { UploadFilesModalProps } from "App/files-manager/components/upload-files-modals/upload-files-modals.interface"
+import { FilesManagerError } from "App/files-manager/constants"
 import ErrorModal from "App/ui/components/error-modal/error-modal.component"
 import InfoPopup from "App/ui/components/info-popup/info-popup.component"
 import LoaderModal from "App/ui/components/loader-modal/loader-modal.component"
@@ -14,12 +15,18 @@ import { FunctionComponent } from "App/__deprecated__/renderer/types/function-co
 import { intl, textFormatters } from "App/__deprecated__/renderer/utils/intl"
 
 const messages = defineMessages({
-    uploadingModalInfo: { id: "module.filesManager.uploadingModalInfo" },
+  uploadingModalInfo: { id: "module.filesManager.uploadingModalInfo" },
   uploadingModalErrorTitle: {
     id: "module.filesManager.uploadingModalErrorTitle",
   },
   uploadingModalErrorSubtitle: {
     id: "module.filesManager.uploadingModalErrorSubtitle",
+  },
+  uploadingModalNoSpaceErrorTitle: {
+    id: "module.filesManager.uploadingModalNoSpaceErrorTitle",
+  },
+  uploadingModalErrorNoSpaceSubtitle: {
+    id: "module.filesManager.uploadingModalNoSpaceErrorSubtitle",
   },
   uploadingModalTitle: { id: "module.filesManager.uploadingModalTitle" },
   uploadingModalSubtitle: { id: "module.filesManager.uploadingModalSubtitle" },
@@ -27,12 +34,22 @@ const messages = defineMessages({
 })
 
 export const UploadFilesModals: FunctionComponent<UploadFilesModalProps> = ({
+  error,
   filesLength,
   uploading,
   uploadingInfo,
   uploadingFailed,
   onCloseUploadingErrorModal,
 }) => {
+  const errorTitle =
+    error?.type === FilesManagerError.NotEnoughSpace
+      ? messages.uploadingModalNoSpaceErrorTitle
+      : messages.uploadingModalErrorTitle
+  const errorSubtitle =
+    error?.type === FilesManagerError.NotEnoughSpace
+      ? messages.uploadingModalErrorNoSpaceSubtitle
+      : messages.uploadingModalErrorSubtitle
+
   return (
     <>
       {uploading && (
@@ -57,8 +74,8 @@ export const UploadFilesModals: FunctionComponent<UploadFilesModalProps> = ({
         <ErrorModal
           testId={UploadFilesModalsTestIds.ErrorModal}
           open={uploadingFailed}
-          title={intl.formatMessage(messages.uploadingModalErrorTitle)}
-          subtitle={intl.formatMessage(messages.uploadingModalErrorSubtitle)}
+          title={intl.formatMessage(errorTitle)}
+          subtitle={intl.formatMessage(errorSubtitle)}
           closeModal={onCloseUploadingErrorModal}
         />
       )}

--- a/packages/app/src/files-manager/components/upload-files-modals/upload-files-modals.interface.ts
+++ b/packages/app/src/files-manager/components/upload-files-modals/upload-files-modals.interface.ts
@@ -3,7 +3,10 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
+import { AppError } from "App/core/errors"
+
 export interface UploadFilesModalProps {
+  error: AppError | null
   filesLength: number
   uploading: boolean
   uploadingInfo: boolean

--- a/packages/app/src/files-manager/components/upload-files-modals/upload-files-modals.test.tsx
+++ b/packages/app/src/files-manager/components/upload-files-modals/upload-files-modals.test.tsx
@@ -5,6 +5,8 @@
 
 import React from "react"
 import { fireEvent } from "@testing-library/dom"
+import { AppError } from "App/core/errors"
+import { FilesManagerError } from "App/files-manager/constants"
 import { renderWithThemeAndIntl } from "App/__deprecated__/renderer/utils/render-with-theme-and-intl"
 import { ModalTestIds } from "App/__deprecated__/renderer/components/core/modal/modal-test-ids.enum"
 import { UploadFilesModals } from "App/files-manager/components/upload-files-modals/upload-files-modals.component"
@@ -16,6 +18,7 @@ const defaultProps: UploadFilesModalProps = {
   uploading: false,
   uploadingInfo: false,
   uploadingFailed: false,
+  error: null,
   onCloseUploadingErrorModal: jest.fn(),
 }
 
@@ -52,7 +55,9 @@ describe("Component: `UploadFilesModals`", () => {
     const popUp = queryByTestId(UploadFilesModalsTestIds.UploadedPopUp)
 
     expect(popUp).toBeInTheDocument()
-    expect(popUp).toHaveTextContent("[value] module.filesManager.uploadingModalInfo")
+    expect(popUp).toHaveTextContent(
+      "[value] module.filesManager.uploadingModalInfo"
+    )
 
     expect(
       queryByTestId(UploadFilesModalsTestIds.LoadingModal)
@@ -72,7 +77,9 @@ describe("Component: `UploadFilesModals`", () => {
     const popUp = queryByTestId(UploadFilesModalsTestIds.UploadedPopUp)
 
     expect(popUp).toBeInTheDocument()
-    expect(popUp).toHaveTextContent("[value] module.filesManager.uploadingModalInfo")
+    expect(popUp).toHaveTextContent(
+      "[value] module.filesManager.uploadingModalInfo"
+    )
 
     expect(
       queryByTestId(UploadFilesModalsTestIds.LoadingModal)
@@ -90,6 +97,36 @@ describe("Component: `UploadFilesModals`", () => {
 
     expect(
       queryByTestId(UploadFilesModalsTestIds.ErrorModal)
+    ).toBeInTheDocument()
+
+    expect(
+      queryByTestId(UploadFilesModalsTestIds.LoadingModal)
+    ).not.toBeInTheDocument()
+    expect(
+      queryByTestId(UploadFilesModalsTestIds.UploadedPopUp)
+    ).not.toBeInTheDocument()
+  })
+
+  test("displays error modal with `NoSpaceLeft` error if `uploadingFailed` is equal to `true` and error type is equal to `FilesManagerError.NotEnoughSpace`", () => {
+    const { queryByTestId, queryByText } = render({
+      ...defaultProps,
+      uploadingFailed: true,
+      error: new AppError(
+        FilesManagerError.NotEnoughSpace,
+        "Not enough space on your device"
+      ),
+    })
+
+    expect(
+      queryByTestId(UploadFilesModalsTestIds.ErrorModal)
+    ).toBeInTheDocument()
+    expect(
+      queryByText("[value] module.filesManager.uploadingModalNoSpaceErrorTitle")
+    ).toBeInTheDocument()
+    expect(
+      queryByText(
+        "[value] module.filesManager.uploadingModalNoSpaceErrorSubtitle"
+      )
     ).toBeInTheDocument()
 
     expect(

--- a/packages/app/src/files-manager/constants/errors.enum.ts
+++ b/packages/app/src/files-manager/constants/errors.enum.ts
@@ -7,4 +7,5 @@ export enum FilesManagerError {
   GetFiles = "FILES_MANAGER_GET_FILES_ERROR",
   UploadFiles = "FILES_MANAGER_UPLOAD_FILES_ERROR",
   DeleteFiles = "FILES_MANAGER_DELETE_FILES_ERROR",
+  NotEnoughSpace = "FILES_MANGER_NOT_ENOUGH_SPACE_ERROR",
 }

--- a/packages/app/src/files-manager/files-manager.container.tsx
+++ b/packages/app/src/files-manager/files-manager.container.tsx
@@ -25,7 +25,7 @@ const mapStateToProps = (state: RootState & ReduxRootState) => ({
   uploading: state.filesManager.uploading,
   uploadingFileLength: state.filesManager.uploadingFileLength,
   deviceType: state.device.deviceType,
-  error: state.templates.error,
+  error: state.filesManager.error,
   selectedItems: state.filesManager.selectedItems.rows,
   allItemsSelected:
     state.filesManager.selectedItems.rows.length ===

--- a/packages/app/src/files-manager/services/file-manager.service.test.ts
+++ b/packages/app/src/files-manager/services/file-manager.service.test.ts
@@ -179,6 +179,35 @@ describe("Method: uploadFiles", () => {
       )
     })
   })
+
+  describe("when `FileUploadCommand` returns `Result.failed` with `DeviceFileSystemError.NoSpaceLeft` error type", () => {
+    test("returns failed result with `FilesManagerError.NotEnoughSpace` error type", async () => {
+      // AUTO DISABLED - fix me if you like :)
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      fileUploadCommand.exec = jest.fn().mockResolvedValueOnce(
+        new FailedResult({
+          ...new AppError(
+            DeviceFileSystemError.NoSpaceLeft,
+            "Uploading file: no space left on device"
+          ),
+        })
+      )
+
+      const result = await subject.uploadFiles({
+        directory: DeviceDirectory.Music,
+        filePaths: ["/usr/audio/file-1.mp3"],
+      })
+
+      expect(result).toEqual(
+        new FailedResult({
+          ...new AppError(
+            FilesManagerError.NotEnoughSpace,
+            "Not enough space on your device"
+          ),
+        })
+      )
+    })
+  })
 })
 
 describe("Method: deleteFiles", () => {

--- a/packages/app/src/files-manager/services/file-manager.service.ts
+++ b/packages/app/src/files-manager/services/file-manager.service.ts
@@ -12,6 +12,7 @@ import {
   RetrieveFilesCommand,
   FileUploadCommand,
 } from "App/device-file-system/commands"
+import { DeviceFileSystemError } from "App/device-file-system/constants"
 import { FileDeleteCommand } from "App/device-file-system/commands/file-delete.command"
 
 export class FileManagerService {
@@ -60,6 +61,18 @@ export class FileManagerService {
     }
 
     const success = results.every((result) => result.ok)
+    const noSpaceLeft = results.some(
+      (result) => result.error?.type === DeviceFileSystemError.NoSpaceLeft
+    )
+
+    if (noSpaceLeft) {
+      return Result.failed(
+        new AppError(
+          FilesManagerError.NotEnoughSpace,
+          "Not enough space on your device"
+        )
+      )
+    }
 
     if (!success) {
       return Result.failed(

--- a/packages/e2e/src/pure/types/device.types.ts
+++ b/packages/e2e/src/pure/types/device.types.ts
@@ -15,6 +15,7 @@ export enum ResponseStatus {
   Conflict = 409,
   InternalServerError = 500,
   UnprocessableEntity = 422,
+  InsufficientStorage = 507,
 
   // lib status
   ConnectionError = 503,

--- a/packages/pure/src/device/device.types.ts
+++ b/packages/pure/src/device/device.types.ts
@@ -37,6 +37,7 @@ export enum ResponseStatus {
   InternalServerError = 500,
   UnprocessableEntity = 422,
   NotAccepted = 423,
+  InsufficientStorage = 507,
 
   // lib status
   ConnectionError = 503,


### PR DESCRIPTION
Jira: [CP-1605]

**Description**
Implementing `NoSpaceLeft` error

<details>
<summary><b>Screenshots</b></summary>
// put images here
<img width="524" alt="Screen Shot 2022-09-29 at 11 00 27 AM" src="https://user-images.githubusercontent.com/21984930/192989174-d647aa46-fee8-4a5f-9cc6-1d13717e362b.png">

</details>


[CP-1605]: https://appnroll.atlassian.net/browse/CP-1605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ