### PR TITLE
[CP-1611] Hiding application UI if backup restoring failed and devic…

### DIFF
--- a/packages/app/src/device/actions/set-connection-status.action.ts
+++ b/packages/app/src/device/actions/set-connection-status.action.ts
@@ -10,6 +10,7 @@ import { ReduxRootState } from "App/__deprecated__/renderer/store"
 import { State } from "App/core/constants"
 import { setInitState } from "App/device/actions/base.action"
 import { setDataSyncInitState } from "App/data-sync/actions"
+import { readRestoreDeviceDataState } from "App/backup/actions"
 
 export const setConnectionStatus = createAsyncThunk<boolean, boolean>(
   DeviceEvent.SetConnectionState,
@@ -28,8 +29,9 @@ export const setConnectionStatus = createAsyncThunk<boolean, boolean>(
       return payload
     }
 
-    if (!payload) {
+    if (!payload || state.backup.restoringState === State.Failed) {
       dispatch(setInitState())
+      dispatch(readRestoreDeviceDataState())
       void setValue({ key: MetadataKey.DeviceOsVersion, value: null })
       void setValue({ key: MetadataKey.DeviceType, value: null })
     }


### PR DESCRIPTION
Jira: [CP-1611]

**Description**
Hiding application features after backup restoring has been failed and device disconnected

<details>
<summary><b>Screenshots</b></summary>
// put images here
</details>


[CP-1611]: https://appnroll.atlassian.net/browse/CP-1611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ