### PR TITLE
[CP-1627] by default preserve white spaces on text component

### DIFF
--- a/packages/app/src/__deprecated__/renderer/components/core/text/text.component.tsx
+++ b/packages/app/src/__deprecated__/renderer/components/core/text/text.component.tsx
@@ -110,6 +110,7 @@ const TextWrapper = styled.div<{
   margin: 0;
   ${({ displayStyle }) => getTextStyles(displayStyle)};
   color: ${({ color }) => textColor(color)};
+  white-space: pre-wrap;
 `
 
 export interface TextProps {


### PR DESCRIPTION
Jira: [CP-1627]

**Description**
Needed for translations - for this moment, whitespaces like e.g. new line are not preserved.

<details>
<summary><b>Screenshots</b></summary>
// put images here
</details>
