### PR TITLE
refactored imports of the Pure package to support ts-node with ESM (UNTESTED)

### DIFF
--- a/packages/pure/package-lock.json
+++ b/packages/pure/package-lock.json
@@ -531,9 +531,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "ci-info": {
@@ -1842,7 +1842,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "convert-source-map": {
@@ -3224,8 +3224,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "resolved": "",
           "dev": true
         },
         "ci-info": {
@@ -3991,8 +3990,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "resolved": "",
           "dev": true
         },
         "ci-info": {
@@ -4597,18 +4595,18 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
       "dev": true
     },
     "minimist-options": {
@@ -5222,9 +5220,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         }
       }
@@ -6036,9 +6034,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "strip-ansi": {
@@ -6171,9 +6169,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "debug": {
@@ -6321,8 +6319,7 @@
         },
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "resolved": "",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -6387,9 +6384,9 @@
       "dev": true
     },
     "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "to-fast-properties": {
@@ -6881,9 +6878,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "is-fullwidth-code-point": {

--- a/packages/pure/package.json
+++ b/packages/pure/package.json
@@ -7,6 +7,7 @@
   },
   "license": "ISC",
   "main": "dist/index.js",
+  "type": "module",
   "types": "dist/index.d.ts",
   "scripts": {
     "clean": "rm -rf ./dist",

--- a/packages/pure/scripts/establish-connection.ts
+++ b/packages/pure/scripts/establish-connection.ts
@@ -1,5 +1,6 @@
-import MuditaDeviceManager, { MuditaDevice } from "../src"
-import { ResponseStatus } from "../dist"
+import MuditaDeviceManager from "../src/device-manager.js"
+import { MuditaDevice } from "../src/device/device.js"
+import { ResponseStatus } from "../src/device/device.types.js"
 
 export const establishConnection = async (
   command: (device: MuditaDevice) => void

--- a/packages/pure/scripts/index.ts
+++ b/packages/pure/scripts/index.ts
@@ -1,9 +1,10 @@
 import { Argv } from "yargs"
-import request from "./request"
-import requests from "./requests"
+import yargs from "yargs"
+import request from "./request.js"
+import requests from "./requests.js"
 
-require("yargs")
-  .command(
+// require("yargs")
+yargs(process.argv.slice(2)).command(
     "request <request-config-string>",
     "This command allows you to send a single request to the Pure phone",
     (yargs: Argv) => {

--- a/packages/pure/scripts/request.ts
+++ b/packages/pure/scripts/request.ts
@@ -1,4 +1,4 @@
-import requests from "./requests"
+import requests from "./requests.js"
 
 interface Arguments {
   requestConfigString: string

--- a/packages/pure/scripts/requests.ts
+++ b/packages/pure/scripts/requests.ts
@@ -1,6 +1,6 @@
-import { establishConnection } from "./establish-connection"
-import singleRequest from "./single-request"
-import parseRequestConfigs from "./parse-request-configs"
+import { establishConnection } from "./establish-connection.js"
+import singleRequest from "./single-request.js"
+import parseRequestConfigs from "./parse-request-configs.js"
 
 interface Arguments {
   requestConfigsString: string

--- a/packages/pure/src/device-manager.ts
+++ b/packages/pure/src/device-manager.ts
@@ -5,15 +5,13 @@
 
 import { EventEmitter } from "events"
 import SerialPort, { PortInfo } from "serialport"
-import UsbDetector from "./usb-detector"
-import {
-  MuditaDevice,
-  PortInfoValidator,
-  DeviceResolverService,
-} from "./device"
-import log, { LogConfig } from "./logger/log-decorator"
-import { LoggerFactory } from "./logger/logger-factory"
-import { ConsoleLogger, PureLogger } from "./logger/logger"
+import UsbDetector from "./usb-detector.js"
+import { MuditaDevice } from "./device/index.js"
+import { PortInfoValidator } from "./device/validators/port-info.validator.js"
+import { DeviceResolverService } from "./device/services/device-resolver.service.js"
+import log, { LogConfig } from "./logger/log-decorator.js"
+import { LoggerFactory } from "./logger/logger-factory.js"
+import { ConsoleLogger, PureLogger } from "./logger/logger.js"
 
 const logger: PureLogger = LoggerFactory.getInstance()
 

--- a/packages/pure/src/device/base-device.ts
+++ b/packages/pure/src/device/base-device.ts
@@ -13,13 +13,13 @@ import {
   RequestPayload,
   Response,
   ResponseStatus,
-} from "./device.types"
-import { DeviceType } from "./constants"
-import { SerialPortParser } from "./serial-port-parser/serial-port-parser"
-import { isApiRequestPayload } from "./device-helper"
+} from "./device.types.js"
+import { DeviceType } from "./constants/index.js"
+import { SerialPortParser } from "./serial-port-parser/serial-port-parser.js"
+import { isApiRequestPayload } from "./device-helper.js"
 import PQueue from "p-queue"
-import log, { LogConfig } from "../logger/log-decorator"
-import { timeout } from "../timeout"
+import log, { LogConfig } from "../logger/log-decorator.js"
+import { timeout } from "../timeout.js"
 export const timeoutMs = 30000
 
 class BaseDevice implements MuditaDevice {

--- a/packages/pure/src/device/constants/index.ts
+++ b/packages/pure/src/device/constants/index.ts
@@ -3,6 +3,6 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-export * from "./device-type.enum"
-export * from "./manufactures.enum"
-export * from "./product-identifier"
+export * from "./device-type.enum.js"
+export * from "./manufactures.enum.js"
+export * from "./product-identifier.js"

--- a/packages/pure/src/device/descriptors/device-descriptor.ts
+++ b/packages/pure/src/device/descriptors/device-descriptor.ts
@@ -3,8 +3,8 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { Manufacture, VendorID, ProductID, DeviceType } from "../constants"
-import { PureStrategy, HarmonyStrategy } from "../strategies"
+import { Manufacture, VendorID, ProductID, DeviceType } from "../constants/index.js"
+import { PureStrategy, HarmonyStrategy } from "../strategies/index.js"
 
 export interface DeviceDescriptor {
   manufacturer: Manufacture

--- a/packages/pure/src/device/descriptors/index.ts
+++ b/packages/pure/src/device/descriptors/index.ts
@@ -3,6 +3,6 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-export * from "./mudita-pure.descriptor"
-export * from "./mudita-harmony.descriptor"
-export * from "./device-descriptor"
+export * from "./mudita-pure.descriptor.js"
+export * from "./mudita-harmony.descriptor.js"
+export * from "./device-descriptor.js"

--- a/packages/pure/src/device/descriptors/mudita-harmony.descriptor.ts
+++ b/packages/pure/src/device/descriptors/mudita-harmony.descriptor.ts
@@ -3,8 +3,8 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { Manufacture, VendorID, ProductID, DeviceType } from "../constants"
-import { HarmonyStrategy } from "../strategies"
+import { Manufacture, VendorID, ProductID, DeviceType } from "../constants/index.js"
+import { HarmonyStrategy } from "../strategies/index.js"
 
 export class MuditaHarmonyDescriptor {
   static manufacturer = Manufacture.Mudita

--- a/packages/pure/src/device/descriptors/mudita-pure.descriptor.ts
+++ b/packages/pure/src/device/descriptors/mudita-pure.descriptor.ts
@@ -3,8 +3,8 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { Manufacture, VendorID, ProductID, DeviceType } from "../constants"
-import { PureStrategy } from "../strategies"
+import { Manufacture, VendorID, ProductID, DeviceType } from "../constants/index.js"
+import { PureStrategy } from "../strategies/index.js"
 
 export class MuditaPureDescriptor {
   static manufacturer = Manufacture.Mudita

--- a/packages/pure/src/device/device-helper.ts
+++ b/packages/pure/src/device/device-helper.ts
@@ -8,7 +8,7 @@ import {
   Endpoint,
   Method,
   RequestPayload,
-} from "./device.types"
+} from "./device.types.js"
 
 export const isApiRequestPayload = (
   config: RequestPayload

--- a/packages/pure/src/device/device.test.ts
+++ b/packages/pure/src/device/device.test.ts
@@ -3,14 +3,15 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import mockSerialPort from "../mock-serial-port"
-import PureNode, { MuditaDevice, RequestConfig } from "../index"
+import mockSerialPort from "../mock-serial-port.js"
+import PureNode from "../device-manager.js"
+import { MuditaDevice, RequestConfig } from "./index.js"
 import {
   DeviceEventName,
   Endpoint,
   Method,
   ResponseStatus,
-} from "./device.types"
+} from "./device.types.js"
 
 let device: MuditaDevice
 

--- a/packages/pure/src/device/device.ts
+++ b/packages/pure/src/device/device.ts
@@ -8,9 +8,9 @@ import {
   Response,
   MuditaDevice,
   DeviceEventName,
-} from "./device.types"
-import { DeviceType } from "./constants"
-import { HarmonyStrategy, PureStrategy } from "./strategies"
+} from "./device.types.js"
+import { DeviceType } from "./constants/index.js"
+import { HarmonyStrategy, PureStrategy } from "./strategies/index.js"
 
 export class Device implements MuditaDevice {
   public path: string

--- a/packages/pure/src/device/device.types.ts
+++ b/packages/pure/src/device/device.types.ts
@@ -3,8 +3,8 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { DeviceType } from "./constants"
-import { SerialPortParser } from "./serial-port-parser/serial-port-parser"
+import { DeviceType } from "./constants/index.js"
+import { SerialPortParser } from "./serial-port-parser/serial-port-parser.js"
 
 export interface MuditaDevice {
   path: string

--- a/packages/pure/src/device/index.ts
+++ b/packages/pure/src/device/index.ts
@@ -3,11 +3,11 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-export * from "./base-device"
-export * from "./device"
-export * from "./device.types"
-export * from "./constants"
-export * from "./descriptors"
-export * from "./services"
-export * from "./validators"
-export * from "./strategies"
+export * from "./base-device.js"
+export * from "./device.js"
+export * from "./device.types.js"
+export * from "./constants/index.js"
+export * from "./descriptors/index.js"
+export * from "./services/index.js"
+export * from "./validators/index.js"
+export * from "./strategies/index.js"

--- a/packages/pure/src/device/serial-port-parser/serial-port-parser.test.ts
+++ b/packages/pure/src/device/serial-port-parser/serial-port-parser.test.ts
@@ -3,8 +3,8 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { SerialPortParser } from "./serial-port-parser"
-import { RequestPayload } from "../device.types"
+import { SerialPortParser } from "./serial-port-parser.js"
+import { RequestPayload } from "../device.types.js"
 
 describe("`Parser.createValidRequest`", () => {
   test("`payload` created properly ", () => {

--- a/packages/pure/src/device/serial-port-parser/serial-port-parser.ts
+++ b/packages/pure/src/device/serial-port-parser/serial-port-parser.ts
@@ -9,7 +9,7 @@
  */
 
 import { TextEncoder } from "util"
-import { RequestPayload, Response } from "../device.types"
+import { RequestPayload, Response } from "../device.types.js"
 
 enum PacketType {
   Invalid = '"',

--- a/packages/pure/src/device/services/device-resolver.service.test.ts
+++ b/packages/pure/src/device/services/device-resolver.service.test.ts
@@ -3,8 +3,8 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { DeviceResolverService } from "./device-resolver.service"
-import { ProductID, DeviceType } from "../constants"
+import { DeviceResolverService } from "./device-resolver.service.js"
+import { ProductID, DeviceType } from "../constants/index.js"
 
 const subject = new DeviceResolverService()
 

--- a/packages/pure/src/device/services/device-resolver.service.ts
+++ b/packages/pure/src/device/services/device-resolver.service.ts
@@ -3,11 +3,11 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { MuditaPureDescriptor, MuditaHarmonyDescriptor } from "../descriptors"
-import { Device } from "../device"
-import { MuditaDevice } from "../device.types"
+import { MuditaPureDescriptor, MuditaHarmonyDescriptor } from "../descriptors/index.js"
+import { Device } from "../device.js"
+import { MuditaDevice } from "../device.types.js"
 import { PortInfo } from "serialport"
-import { SerialPortParser } from "../serial-port-parser/serial-port-parser"
+import { SerialPortParser } from "../serial-port-parser/serial-port-parser.js"
 
 export class DeviceResolverService {
   private eligibleDevices = [MuditaPureDescriptor, MuditaHarmonyDescriptor]

--- a/packages/pure/src/device/services/index.ts
+++ b/packages/pure/src/device/services/index.ts
@@ -3,4 +3,4 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-export * from "./device-resolver.service"
+export * from "./device-resolver.service.js"

--- a/packages/pure/src/device/strategies/harmony.strategy.ts
+++ b/packages/pure/src/device/strategies/harmony.strategy.ts
@@ -3,7 +3,7 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import BaseDevice from "../base-device"
+import BaseDevice from "../base-device.js"
 import {
   CreateDeviceStrategy,
   Endpoint,
@@ -11,12 +11,12 @@ import {
   RequestConfig,
   Response,
   ResponseStatus,
-} from "../device.types"
-import { DeviceType } from "../constants"
-import { DeviceInfo } from "../../endpoints"
-import { Formatter } from "../../formatter/formatter"
-import { FormatterFactory } from "../../formatter/formatter-factory"
-import { SerialPortParser } from "../serial-port-parser/serial-port-parser"
+} from "../device.types.js"
+import { DeviceType } from "../constants/index.js"
+import { DeviceInfo } from "../../endpoints/index.js"
+import { Formatter } from "../../formatter/formatter.js"
+import { FormatterFactory } from "../../formatter/formatter-factory.js"
+import { SerialPortParser } from "../serial-port-parser/serial-port-parser.js"
 
 export class HarmonyStrategy extends BaseDevice {
   #formatter: Formatter = FormatterFactory.create()

--- a/packages/pure/src/device/strategies/index.ts
+++ b/packages/pure/src/device/strategies/index.ts
@@ -3,5 +3,5 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-export * from "./harmony.strategy"
-export * from "./pure.strategy"
+export * from "./harmony.strategy.js"
+export * from "./pure.strategy.js"

--- a/packages/pure/src/device/strategies/pure.strategy.ts
+++ b/packages/pure/src/device/strategies/pure.strategy.ts
@@ -3,7 +3,7 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import BaseDevice from "../base-device"
+import BaseDevice from "../base-device.js"
 import {
   CreateDeviceStrategy,
   Endpoint,
@@ -11,8 +11,8 @@ import {
   RequestConfig,
   Response,
   ResponseStatus,
-} from "../device.types"
-import { DeviceType } from "../constants"
+} from "../device.types.js"
+import { DeviceType } from "../constants/index.js"
 import {
   Contact,
   DeviceInfo,
@@ -53,9 +53,9 @@ import {
   GetEntriesResponseBody,
   GetEntriesRequestConfig,
   GetThreadsBody,
-} from "../../endpoints"
-import { Formatter, FormatterFactory } from "../../formatter"
-import { SerialPortParser } from "../serial-port-parser/serial-port-parser"
+} from "../../endpoints/index.js"
+import { Formatter, FormatterFactory } from "../../formatter/index.js"
+import { SerialPortParser } from "../serial-port-parser/serial-port-parser.js"
 
 export class PureStrategy extends BaseDevice {
   #formatter: Formatter = FormatterFactory.create()

--- a/packages/pure/src/device/validators/index.ts
+++ b/packages/pure/src/device/validators/index.ts
@@ -3,4 +3,4 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-export * from "./port-info.validator"
+export * from "./port-info.validator.js"

--- a/packages/pure/src/device/validators/port-info.validator.test.ts
+++ b/packages/pure/src/device/validators/port-info.validator.test.ts
@@ -3,7 +3,7 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { PortInfoValidator } from "./port-info.validator"
+import { PortInfoValidator } from "./port-info.validator.js"
 
 test("isVendorId function works properly", () => {
   expect(PortInfoValidator.isVendorIdValid({ vendorId: "3310" })).toBeTruthy()

--- a/packages/pure/src/device/validators/port-info.validator.ts
+++ b/packages/pure/src/device/validators/port-info.validator.ts
@@ -4,7 +4,7 @@
  */
 
 import { PortInfo } from "serialport"
-import { MuditaPureDescriptor, MuditaHarmonyDescriptor } from "../descriptors"
+import { MuditaPureDescriptor, MuditaHarmonyDescriptor } from "../descriptors/index.js"
 
 export class PortInfoValidator {
   static eligibleDevices = [MuditaPureDescriptor, MuditaHarmonyDescriptor]

--- a/packages/pure/src/endpoints/backup.types.ts
+++ b/packages/pure/src/endpoints/backup.types.ts
@@ -3,7 +3,7 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { Endpoint, Method, RequestConfig } from "../device"
+import { Endpoint, Method, RequestConfig } from "../device/index.js"
 
 export enum BackupCategory {
   Sync = "sync",

--- a/packages/pure/src/endpoints/device-update.types.ts
+++ b/packages/pure/src/endpoints/device-update.types.ts
@@ -3,7 +3,7 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { Response, ResponseStatus } from "../device/device.types"
+import { Response, ResponseStatus } from "../device/device.types.js"
 
 export enum DeviceUpdateError {
   NoError = "NoError",

--- a/packages/pure/src/endpoints/file-system.ts
+++ b/packages/pure/src/endpoints/file-system.ts
@@ -9,7 +9,7 @@ import {
   RequestConfig,
   Response,
   ResponseStatus,
-} from "../device"
+} from "../device/index.js"
 
 export interface PutFileSystemRequestConfig
   extends RequestConfig<{

--- a/packages/pure/src/endpoints/index.ts
+++ b/packages/pure/src/endpoints/index.ts
@@ -3,11 +3,11 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-export * from "./backup.types"
-export * from "./contact.types"
-export * from "./device-info.types"
-export * from "./device-update.types"
-export * from "./file-system"
-export * from "./messages.types"
-export * from "./outbox.types"
-export * from "./restore.types"
+export * from "./backup.types.js"
+export * from "./contact.types.js"
+export * from "./device-info.types.js"
+export * from "./device-update.types.js"
+export * from "./file-system.js"
+export * from "./messages.types.js"
+export * from "./outbox.types.js"
+export * from "./restore.types.js"

--- a/packages/pure/src/endpoints/messages.types.ts
+++ b/packages/pure/src/endpoints/messages.types.ts
@@ -3,7 +3,7 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { PaginationBody } from "../device"
+import { PaginationBody } from "../device/index.js"
 
 export enum MessagesCategory {
   thread = "thread",

--- a/packages/pure/src/endpoints/outbox.types.ts
+++ b/packages/pure/src/endpoints/outbox.types.ts
@@ -3,7 +3,7 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { Endpoint, Method, RequestConfig } from "../device"
+import { Endpoint, Method, RequestConfig } from "../device/index.js"
 
 export enum OutboxEntryType {
   Message = 1,

--- a/packages/pure/src/endpoints/restore.types.ts
+++ b/packages/pure/src/endpoints/restore.types.ts
@@ -3,7 +3,7 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { Endpoint, Method, RequestConfig } from "../device"
+import { Endpoint, Method, RequestConfig } from "../device/index.js"
 
 type backupId = string
 

--- a/packages/pure/src/formatter/formatter-factory.ts
+++ b/packages/pure/src/formatter/formatter-factory.ts
@@ -3,8 +3,8 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { PureV1Formatter } from "./pure-v1.formatter"
-import { Formatter } from "./formatter"
+import { PureV1Formatter } from "./pure-v1.formatter.js"
+import { Formatter } from "./formatter.js"
 
 const formatterMap: { [key: number]: Formatter } = {
   1: new PureV1Formatter(),

--- a/packages/pure/src/formatter/formatter.ts
+++ b/packages/pure/src/formatter/formatter.ts
@@ -3,7 +3,7 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { Method, Response } from "../device/device.types"
+import { Method, Response } from "../device/device.types.js"
 
 export abstract class Formatter {
   abstract formatResponse(

--- a/packages/pure/src/formatter/index.ts
+++ b/packages/pure/src/formatter/index.ts
@@ -3,6 +3,6 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-export * from "./pure-v1.formatter"
-export * from "./formatter"
-export * from "./formatter-factory"
+export * from "./pure-v1.formatter.js"
+export * from "./formatter.js"
+export * from "./formatter-factory.js"

--- a/packages/pure/src/formatter/pure-v1.formatter.test.ts
+++ b/packages/pure/src/formatter/pure-v1.formatter.test.ts
@@ -3,8 +3,8 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { PureV1Formatter } from "./pure-v1.formatter"
-import { Endpoint, Method, ResponseStatus } from "../device"
+import { PureV1Formatter } from "./pure-v1.formatter.js"
+import { Endpoint, Method, ResponseStatus } from "../device/index.js"
 
 const updateErrorResponse = {
   status: ResponseStatus.BadRequest,

--- a/packages/pure/src/formatter/pure-v1.formatter.ts
+++ b/packages/pure/src/formatter/pure-v1.formatter.ts
@@ -3,9 +3,9 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { Endpoint, Method, Response } from "../device/device.types"
-import { Formatter } from "./formatter"
-import { DeviceUpdateError, deviceUpdateErrorCodeMap } from "../endpoints"
+import { Endpoint, Method, Response } from "../device/device.types.js"
+import { Formatter } from "./formatter.js"
+import { DeviceUpdateError, deviceUpdateErrorCodeMap } from "../endpoints/index.js"
 
 export class PureV1Formatter extends Formatter {
   // AUTO DISABLED - fix me if you like :)

--- a/packages/pure/src/index.ts
+++ b/packages/pure/src/index.ts
@@ -3,12 +3,12 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-export * from "./device"
-export * from "./logger"
-export * from "./endpoints"
-export * from "./formatter"
-export * from "./device-manager"
-export * from "./timeout"
+export * from "./device/index.js"
+export * from "./logger/index.js"
+export * from "./endpoints/index.js"
+export * from "./formatter/index.js"
+export * from "./device-manager.js"
+export * from "./timeout.js"
 
-import PureNode from "./device-manager"
+import PureNode from "./device-manager.js"
 export default PureNode

--- a/packages/pure/src/logger/index.ts
+++ b/packages/pure/src/logger/index.ts
@@ -3,6 +3,6 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-export * from "./log-decorator"
-export * from "./logger"
-export * from "./logger-factory"
+export * from "./log-decorator.js"
+export * from "./logger.js"
+export * from "./logger-factory.js"

--- a/packages/pure/src/logger/log-decorator.ts
+++ b/packages/pure/src/logger/log-decorator.ts
@@ -3,7 +3,7 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { LoggerFactory } from "./logger-factory"
+import { LoggerFactory } from "./logger-factory.js"
 
 export enum LogConfig {
   Args,

--- a/packages/pure/src/logger/logger-factory.ts
+++ b/packages/pure/src/logger/logger-factory.ts
@@ -3,7 +3,7 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import Logger, { PureLogger } from "./logger"
+import Logger, { PureLogger } from "./logger.js"
 
 let logger: PureLogger
 

--- a/packages/pure/src/logger/logger.test.ts
+++ b/packages/pure/src/logger/logger.test.ts
@@ -3,7 +3,7 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import Logger, { PureLogger, ConsoleLogger } from "./logger"
+import Logger, { PureLogger, ConsoleLogger } from "./logger.js"
 
 let logger: PureLogger
 

--- a/packages/pure/src/mock-serial-port.ts
+++ b/packages/pure/src/mock-serial-port.ts
@@ -4,7 +4,7 @@
  */
 
 import SerialPort = require("serialport")
-import { ProductID, VendorID, Manufacture } from "./device"
+import { ProductID, VendorID, Manufacture } from "./device/constants/index.js"
 // AUTO DISABLED - fix me if you like :)
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const MockBinding = require("@serialport/binding-mock")

--- a/packages/pure/src/usb-detector.ts
+++ b/packages/pure/src/usb-detector.ts
@@ -6,7 +6,7 @@
 import usb from "usb"
 import { EventEmitter } from "events"
 import { PortInfo } from "serialport"
-import log, { LogConfig } from "./logger/log-decorator"
+import log, { LogConfig } from "./logger/log-decorator.js"
 
 type UsbDetectorPortInfo = Omit<PortInfo, "path">
 

--- a/packages/pure/tsconfig.json
+++ b/packages/pure/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "ES2018",
-    "module": "commonjs",
-    "lib": ["ES2018"],
+    "target": "es2020",
+    "module": "node16",
+    "moduleResolution": "node16",
+    "lib": ["es2020"],
     "declaration": true,
     "strict": true,
     "esModuleInterop": true,
@@ -15,5 +16,11 @@
     "outDir": "./dist"
   },
   "exclude": ["node_modules"],
-  "include": ["src"]
+  "include": ["src"],
+  "ts-node": {
+    "esm": true,
+    "transpileOnly": true,
+    "files": true,
+    "experimentalResolver": true
+  }
 }


### PR DESCRIPTION
It builds fine. Jest doesn't like my changes. It seems like I need to include 

```js
import { describe, expect, test } from '@jest/globals';
```

to every test file... and figure out a way to have it change the `.js` back to a `.ts` extension.

Feel free to completely ignore this draft pull request. Not sure if it was appropriate.
