### PR TITLE
Workaround to fetch Harmony 1.6.0 release in dev mode

### DIFF
--- a/packages/app/src/overview/components/overview-screens/harmony-overview/harmony-overview.component.tsx
+++ b/packages/app/src/overview/components/overview-screens/harmony-overview/harmony-overview.component.tsx
@@ -89,20 +89,25 @@ export const HarmonyOverview: FunctionComponent<HarmonyOverviewProps> = ({
     }
   }
 
+  const getReleaseForAction = (release?: OsRelease): OsRelease | undefined => {
+    if (release) {
+      return release
+    }
+    return availableReleasesForUpdate && availableReleasesForUpdate.length > 0
+      ? availableReleasesForUpdate[availableReleasesForUpdate.length - 1]
+      : undefined
+  }
+
   // TODO [mw] handle me - scope of CP-1686
   const updateRelease = (release?: OsRelease) => {
-    const releaseToInstall = availableReleasesForUpdate
-      ? availableReleasesForUpdate[availableReleasesForUpdate.length - 1]
-      : release
+    const releaseToInstall = getReleaseForAction(release)
 
     releaseToInstall && startUpdateOs(releaseToInstall.file.name)
   }
 
   // TODO [mw] handle sequential download - scope of CP-1686
   const downloadRelease = (release?: OsRelease) => {
-    const releaseToDownload = availableReleasesForUpdate
-      ? availableReleasesForUpdate[availableReleasesForUpdate.length - 1]
-      : release
+    const releaseToDownload = getReleaseForAction(release)
 
     releaseToDownload && downloadUpdate(releaseToDownload)
   }

--- a/packages/app/src/overview/components/overview-screens/pure-overview/pure-overview.component.tsx
+++ b/packages/app/src/overview/components/overview-screens/pure-overview/pure-overview.component.tsx
@@ -208,21 +208,25 @@ export const PureOverview: FunctionComponent<PureOverviewProps> = ({
     )
   }
 
+  const getReleaseForAction = (release?: OsRelease): OsRelease | undefined => {
+    if (release) {
+      return release
+    }
+    return availableReleasesForUpdate && availableReleasesForUpdate.length > 0
+      ? availableReleasesForUpdate[availableReleasesForUpdate.length - 1]
+      : undefined
+  }
+
   // TODO [mw] handle sequential update - scope of CP-1686
   const updateRelease = (release?: OsRelease) => {
-    const releaseToInstall = availableReleasesForUpdate
-      ? availableReleasesForUpdate[availableReleasesForUpdate.length - 1]
-      : release
+    const releaseToInstall = getReleaseForAction(release)
 
     releaseToInstall && startUpdateOs(releaseToInstall.file.name)
   }
 
   // TODO [mw] handle sequential download - scope of CP-1686
   const downloadRelease = (release?: OsRelease) => {
-    const releaseToDownload = availableReleasesForUpdate
-      ? availableReleasesForUpdate[availableReleasesForUpdate.length - 1]
-      : release
-
+    const releaseToDownload = getReleaseForAction(release)
     releaseToDownload && downloadUpdate(releaseToDownload)
   }
 

--- a/packages/app/src/update/controllers/releases.controller.ts
+++ b/packages/app/src/update/controllers/releases.controller.ts
@@ -22,8 +22,9 @@ export class ReleasesController {
   public async getAllReleases(
     product: Product
   ): Promise<ResultObject<OsRelease[] | undefined>> {
+    // TODO [mw] workaround change needed for QA team. Should be removed when implementing CP-1743
     return flags.get(Feature.DeveloperModeEnabled)
-      ? this.releaseService.getAllReleases(product)
+      ? this.releaseService.getTestReleasesForSOSUfeature(product)
       : Result.success([])
   }
 


### PR DESCRIPTION
**Description**

As suggested by QA team.

![image](https://user-images.githubusercontent.com/41268731/206022973-dcda8c82-d2fa-49a5-803a-54977f662a91.png)

