### PR TITLE
[CP-1742] add loading button to pure and harmony overview

### DIFF
--- a/packages/app/src/__deprecated__/renderer/components/core/button-toggler/button-toggler.component.tsx
+++ b/packages/app/src/__deprecated__/renderer/components/core/button-toggler/button-toggler.component.tsx
@@ -55,7 +55,12 @@ const WrappedButton: FunctionComponent<ComponentProps<typeof ButtonComponent>> =
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const ButtonTogglerItem = styled(
   WrappedButton
-).attrs<ButtonTogglerItemProps>(({ filled, active }) => {
+).attrs<ButtonTogglerItemProps>(({ filled, active, loading, disabled }) => {
+  if (loading && disabled) {
+    return {
+      displayStyle: DisplayStyle.Primary,
+    }
+  }
   const displayStyle =
     active && filled ? DisplayStyle.Primary : DisplayStyle.Secondary
   return {

--- a/packages/app/src/__deprecated__/renderer/components/core/button-toggler/button-toggler.interface.tsx
+++ b/packages/app/src/__deprecated__/renderer/components/core/button-toggler/button-toggler.interface.tsx
@@ -8,6 +8,7 @@ import { Message as MessageInterface } from "App/__deprecated__/renderer/interfa
 export interface ButtonTogglerItemProps {
   filled?: boolean
   active?: boolean
+  loading?: boolean
 }
 
 export interface ButtonTogglerProps {

--- a/packages/app/src/__deprecated__/renderer/components/core/button-toggler/button-toggler.stories.tsx
+++ b/packages/app/src/__deprecated__/renderer/components/core/button-toggler/button-toggler.stories.tsx
@@ -29,6 +29,16 @@ storiesOf("Components|Core/Button Toggler", module)
             <ButtonTogglerItem label="Turn on" />
           </ButtonToggler>
         </Story>
+        <Story title="Disabled">
+          <ButtonToggler>
+            <ButtonTogglerItem label="Turn on" disabled />
+          </ButtonToggler>
+        </Story>
+        <Story title="Disabled with loading">
+          <ButtonToggler>
+            <ButtonTogglerItem label="Turn on" disabled loading />
+          </ButtonToggler>
+        </Story>
         <Story title="Two buttons">
           <ButtonToggler>
             <ButtonTogglerItem label="Yes" active />

--- a/packages/app/src/__deprecated__/renderer/components/core/button/button.component.tsx
+++ b/packages/app/src/__deprecated__/renderer/components/core/button/button.component.tsx
@@ -39,6 +39,7 @@ export interface ButtonComponentProps {
   to?: string
   type?: Type
   buttonRef?: Ref<HTMLElement>
+  loading?: boolean
 }
 
 const ButtonText = styled(Text)`
@@ -62,6 +63,7 @@ const ButtonComponent: FunctionComponent<ButtonComponentProps> = ({
   to,
   type = Type.Button,
   buttonRef,
+  loading,
   ...rest
 }) => {
   // AUTO DISABLED - fix me if you like :)
@@ -135,6 +137,15 @@ const ButtonComponent: FunctionComponent<ButtonComponentProps> = ({
       size={size}
       disabled={disabled}
     >
+      {loading && (
+        <StyledIcon
+          displayStyle={displayStyle}
+          withMargin={Boolean(label || labelMessage)}
+          type={IconType.Refresh}
+          size={IconSize.Medium}
+          rotate
+        />
+      )}
       {Icon && (
         <StyledIcon
           displayStyle={displayStyle}

--- a/packages/app/src/__deprecated__/renderer/components/core/button/button.stories.tsx
+++ b/packages/app/src/__deprecated__/renderer/components/core/button/button.stories.tsx
@@ -62,7 +62,11 @@ storiesOf("Components|Core/Button", module)
       </StoryContainer>
       <StoryContainer title="Modifiers (icon)">
         <Story title="Primary (default)">
-          <Button Icon={IconType.Upload} label="Button" iconSize={IconSize.Small} />
+          <Button
+            Icon={IconType.Upload}
+            label="Button"
+            iconSize={IconSize.Small}
+          />
         </Story>
         <Story title="Primary disabled">
           <Button
@@ -88,6 +92,9 @@ storiesOf("Components|Core/Button", module)
             label="Button"
             iconSize={IconSize.Small}
           />
+        </Story>
+        <Story title="Loading">
+          <Button label="Button" loading disabled />
         </Story>
       </StoryContainer>
     </>

--- a/packages/app/src/__deprecated__/renderer/components/core/button/button.styled.elements.tsx
+++ b/packages/app/src/__deprecated__/renderer/components/core/button/button.styled.elements.tsx
@@ -16,7 +16,7 @@ import {
   transitionTimingFunction,
   width,
 } from "App/__deprecated__/renderer/styles/theming/theme-getters"
-import styled, { css } from "styled-components"
+import styled, { css, keyframes } from "styled-components"
 import { DisplayStyle, Size } from "./button.config"
 import Icon from "App/__deprecated__/renderer/components/core/icon/icon.component"
 import { Theme } from "App/__deprecated__/renderer/styles/theming/theme"
@@ -372,9 +372,20 @@ export const StyledButton = styled.button<{
 }>`
   ${buttonStyles}
 `
+
+const rotateAnimation = keyframes`
+  from {
+    transform: rotateZ(0deg)
+  }
+  to {
+    transform: rotateZ(360deg)
+  }
+`
+
 export const StyledIcon = styled(Icon)<{
   displayStyle: DisplayStyle
   withMargin: boolean
+  rotate?: boolean
 }>`
   ${({ displayStyle, withMargin }) => {
     if (withMargin) {
@@ -399,5 +410,11 @@ export const StyledIcon = styled(Icon)<{
     css`
       width: 100%;
       height: 100%;
+    `};
+
+  ${({ rotate }) =>
+    rotate &&
+    css`
+      animation: ${rotateAnimation} 2s infinite linear;
     `};
 `

--- a/packages/app/src/overview/components/system/system.component.tsx
+++ b/packages/app/src/overview/components/system/system.component.tsx
@@ -139,6 +139,7 @@ const System: FunctionComponent<Props> = ({
             <CardActionButton
               active={!checkForUpdateInProgress}
               disabled={checkForUpdateInProgress}
+              loading={checkForUpdateInProgress}
               labelMessage={messages.systemCheckForUpdates}
               onClick={onUpdateCheck}
             />


### PR DESCRIPTION
Jira: [CP-1742]

**Description**
Scope:
* added loading button to pure and harmony overview views (see attached movie)

Awaiting for https://github.com/mudita/mudita-center/pull/1082 to be merged

<details>
<summary><b>Screenshots</b></summary>

https://user-images.githubusercontent.com/41268731/211549209-eb6787e1-af5f-446f-8645-34741dc0c00d.mov

</details>


[CP-1742]: https://appnroll.atlassian.net/browse/CP-1742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ