### PR TITLE
[CP-1742] download now button opens check for update modal

### DIFF
--- a/packages/app/src/overview/components/overview-screens/harmony-overview/harmony-overview.component.interface.ts
+++ b/packages/app/src/overview/components/overview-screens/harmony-overview/harmony-overview.component.interface.ts
@@ -37,6 +37,7 @@ export interface HarmonyOverviewProps {
     deviceType: DeviceType,
     mode: CheckForUpdateMode
   ) => void
+  readonly setCheckForUpdateState: (state: State) => void
   readonly downloadUpdates: (releases: OsRelease[]) => void
   readonly clearUpdateState: () => void
   readonly abortDownload: () => void

--- a/packages/app/src/overview/components/overview-screens/harmony-overview/harmony-overview.component.test.tsx
+++ b/packages/app/src/overview/components/overview-screens/harmony-overview/harmony-overview.component.test.tsx
@@ -55,6 +55,7 @@ const defaultProps: Props = {
   downloadingReleasesProcessStates: null,
   updatingReleasesProcessStates: null,
   areAllReleasesDownloaded: false,
+  setCheckForUpdateState: jest.fn(),
 }
 
 const render = (extraProps?: Partial<Props>) => {

--- a/packages/app/src/overview/components/overview-screens/harmony-overview/harmony-overview.component.tsx
+++ b/packages/app/src/overview/components/overview-screens/harmony-overview/harmony-overview.component.tsx
@@ -47,6 +47,7 @@ export const HarmonyOverview: FunctionComponent<HarmonyOverviewProps> = ({
   updatingReleasesProcessStates,
   silentCheckForUpdateState,
   areAllReleasesDownloaded,
+  setCheckForUpdateState,
 }) => {
   const [osVersionSupported, setOsVersionSupported] = useState(true)
 
@@ -121,6 +122,10 @@ export const HarmonyOverview: FunctionComponent<HarmonyOverviewProps> = ({
     checkForUpdate(DeviceType.MuditaHarmony, CheckForUpdateMode.TryAgain)
   }
 
+  const openCheckForUpdateModal = () => {
+    setCheckForUpdateState(State.Loaded)
+  }
+
   return (
     <>
       <UpdateOsFlow
@@ -168,7 +173,7 @@ export const HarmonyOverview: FunctionComponent<HarmonyOverviewProps> = ({
         pureOsDownloaded={areAllReleasesDownloaded}
         onUpdateCheck={checkForHarmonyUpdate}
         onUpdateInstall={() => updateReleases()}
-        onUpdateDownload={() => downloadReleases()}
+        onUpdateDownload={openCheckForUpdateModal}
         serialNumber={serialNumber}
         checkForUpdateInProgress={
           silentCheckForUpdateState === SilentCheckForUpdateState.Loading

--- a/packages/app/src/overview/components/overview-screens/pure-overview/pure-overview.component.test.tsx
+++ b/packages/app/src/overview/components/overview-screens/pure-overview/pure-overview.component.test.tsx
@@ -76,6 +76,7 @@ const defaultProps: Props = {
   silentCheckForUpdateState: SilentCheckForUpdateState.Initial,
   clearUpdateState: jest.fn(),
   downloadUpdates: jest.fn(),
+  setCheckForUpdateState: jest.fn(),
   availableReleasesForUpdate: null,
   updateOsError: null,
   downloadingReleasesProcessStates: null,

--- a/packages/app/src/overview/components/overview-screens/pure-overview/pure-overview.component.tsx
+++ b/packages/app/src/overview/components/overview-screens/pure-overview/pure-overview.component.tsx
@@ -75,6 +75,7 @@ export const PureOverview: FunctionComponent<PureOverviewProps> = ({
   silentCheckForUpdateState,
   areAllReleasesDownloaded,
   backupError,
+  setCheckForUpdateState,
 }) => {
   const [osVersionSupported, setOsVersionSupported] = useState(true)
   const [openModal, setOpenModal] = useState({
@@ -238,6 +239,10 @@ export const PureOverview: FunctionComponent<PureOverviewProps> = ({
     checkForUpdate(DeviceType.MuditaHarmony, CheckForUpdateMode.TryAgain)
   }
 
+  const openCheckForUpdateModal = () => {
+    setCheckForUpdateState(State.Loaded)
+  }
+
   return (
     <>
       <UpdateOsFlow
@@ -312,7 +317,7 @@ export const PureOverview: FunctionComponent<PureOverviewProps> = ({
         }
         onUpdateCheck={checkForPureUpdate}
         onUpdateInstall={() => updateReleases()}
-        onUpdateDownload={() => downloadReleases()}
+        onUpdateDownload={openCheckForUpdateModal}
         caseColour={caseColour}
         lastBackupDate={lastBackupDate}
         onBackupCreate={handleBackupCreate}

--- a/packages/app/src/overview/components/overview-screens/pure-overview/pure-overview.interface.ts
+++ b/packages/app/src/overview/components/overview-screens/pure-overview/pure-overview.interface.ts
@@ -57,6 +57,7 @@ export interface PureOverviewProps {
     deviceType: DeviceType,
     mode: CheckForUpdateMode
   ) => void
+  readonly setCheckForUpdateState: (state: State) => void
   readonly downloadUpdates: (releases: OsRelease[]) => void
   readonly clearUpdateState: () => void
   readonly abortDownload: () => void

--- a/packages/app/src/overview/components/overview/overview.test.tsx
+++ b/packages/app/src/overview/components/overview/overview.test.tsx
@@ -140,6 +140,7 @@ const defaultProps: Props = {
   updatingReleasesProcessStates: null,
   areAllReleasesDownloaded: false,
   backupError: null,
+  setCheckForUpdateState: jest.fn(),
 }
 
 const render = (extraProps?: Partial<Props>) => {

--- a/packages/app/src/overview/components/system/system.component.tsx
+++ b/packages/app/src/overview/components/system/system.component.tsx
@@ -111,15 +111,12 @@ const System: FunctionComponent<Props> = ({
             (updateAvailable ? (
               <AvailableUpdateText>
                 {updateDownloaded ? (
-                  // Update is available
                   <FormattedMessage {...messages.systemUpdateDownloaded} />
                 ) : (
-                  // Update is available
                   <FormattedMessage {...messages.systemUpdateAvailable} />
                 )}
               </AvailableUpdateText>
             ) : (
-              // You’re up to date.
               <AvailableUpdateText>
                 <FormattedMessage {...messages.systemUpdateUpToDate} />
               </AvailableUpdateText>

--- a/packages/app/src/overview/overview.container.tsx
+++ b/packages/app/src/overview/overview.container.tsx
@@ -26,6 +26,7 @@ import {
   startUpdateOs,
   closeUpdateFlow,
   cancelDownload,
+  setCheckForUpdateState,
 } from "App/update/actions"
 import { State } from "App/core/constants"
 import { OsRelease } from "App/update/dto"
@@ -105,6 +106,10 @@ const mapDispatchToProps = (dispatch: TmpDispatch) => ({
     // AUTO DISABLED - fix me if you like :)
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
     dispatch(checkForUpdate({ deviceType, mode })),
+  setCheckForUpdateState: (state: State) =>
+    // AUTO DISABLED - fix me if you like :)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
+    dispatch(setCheckForUpdateState(state)),
   downloadUpdates: (releases: OsRelease[]) =>
     // AUTO DISABLED - fix me if you like :)
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call

--- a/packages/app/src/update/actions/base.action.ts
+++ b/packages/app/src/update/actions/base.action.ts
@@ -8,6 +8,9 @@ import { State } from "App/core/constants"
 import { ReleaseProcessState, UpdateOsEvent } from "App/update/constants"
 
 export const setUpdateState = createAction<State>(UpdateOsEvent.SetUpdateState)
+export const setCheckForUpdateState = createAction<State>(
+  UpdateOsEvent.SetCheckForUpdateState
+)
 export const closeUpdateFlow = createAction(UpdateOsEvent.CloseUpdateFlow)
 export const clearStateAndData = createAction(UpdateOsEvent.ClearStateAndData)
 export const cancelDownload = createAction(UpdateOsEvent.CancelDownload)

--- a/packages/app/src/update/constants/download-state.constant.ts
+++ b/packages/app/src/update/constants/download-state.constant.ts
@@ -3,10 +3,10 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-export enum SilentCheckForUpdateState {
+export enum DownloadState {
   Initial,
   Loading,
   Loaded,
   Failed,
-  Skipped,
+  Cancelled,
 }

--- a/packages/app/src/update/constants/event.constant.ts
+++ b/packages/app/src/update/constants/event.constant.ts
@@ -8,6 +8,7 @@ export enum UpdateOsEvent {
   CheckForUpdate = "CHECK_FOR_UPDATE",
   DownloadUpdate = "DOWNLOAD_UPDATE",
   SetUpdateState = "DEVICE_SET_UPDATE_STATE",
+  SetCheckForUpdateState = "SET_CHECK_FOR_UPDATE_STATE",
   CancelDownload = "CANCEL_DOWNLOAD",
   CloseUpdateFlow = "CLOSE_UPDATE_FLOW",
   ClearStateAndData = "CLEAR_STATE_AND_DATA",

--- a/packages/app/src/update/constants/silent-check-for-update.constant.ts
+++ b/packages/app/src/update/constants/silent-check-for-update.constant.ts
@@ -3,10 +3,10 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-export enum DownloadState {
+export enum SilentCheckForUpdateState {
   Initial,
   Loading,
   Loaded,
   Failed,
-  Cancelled,
+  Skipped,
 }

--- a/packages/app/src/update/reducers/update-os.reducer.test.ts
+++ b/packages/app/src/update/reducers/update-os.reducer.test.ts
@@ -85,6 +85,30 @@ describe("setUpdateState action", () => {
   })
 })
 
+describe("setCheckForUpdateState action", () => {
+  test("action sets the checking state", () => {
+    expect(
+      updateOsReducer(undefined, {
+        type: UpdateOsEvent.SetCheckForUpdateState,
+        payload: State.Loaded,
+      })
+    ).toEqual({
+      ...initialState,
+      checkForUpdateState: State.Loaded,
+    })
+
+    expect(
+      updateOsReducer(undefined, {
+        type: UpdateOsEvent.SetCheckForUpdateState,
+        payload: State.Failed,
+      })
+    ).toEqual({
+      ...initialState,
+      checkForUpdateState: State.Failed,
+    })
+  })
+})
+
 describe("startUpdateOs action", () => {
   test("pending action sets proper updateOsState", () => {
     expect(

--- a/packages/app/src/update/reducers/update-os.reducer.ts
+++ b/packages/app/src/update/reducers/update-os.reducer.ts
@@ -16,6 +16,7 @@ import {
   setStateForDownloadedRelease,
   setStateForInstalledRelease,
   clearStateAndData,
+  setCheckForUpdateState,
 } from "App/update/actions"
 import {
   CheckForUpdateMode,
@@ -47,6 +48,12 @@ export const updateOsReducer = createReducer<UpdateOsState>(
       return {
         ...state,
         updateOsState: action.payload,
+      }
+    })
+    builder.addCase(setCheckForUpdateState, (state, action) => {
+      return {
+        ...state,
+        checkForUpdateState: action.payload,
       }
     })
     builder.addCase(closeUpdateFlow, (state) => {


### PR DESCRIPTION
Jira: [CP-1742]

**Description**
Scope:
* "Download now" button now opens "check for update" modal (see attached video)

<details>
<summary><b>Screenshots</b></summary>

https://user-images.githubusercontent.com/41268731/211777578-ce53f61b-a814-43f4-b33b-948bb6524f8b.mov

</details>


[CP-1742]: https://appnroll.atlassian.net/browse/CP-1742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ