### PR TITLE
[CP-1742] show label and button proper state after update os process

### DIFF
--- a/packages/app/src/update/reducers/update-os.reducer.test.ts
+++ b/packages/app/src/update/reducers/update-os.reducer.test.ts
@@ -37,7 +37,7 @@ const mockedRelease: OsRelease = {
   },
   product: Product.PurePhone,
   type: OsReleaseType.Daily,
-  version: "123",
+  version: "1.1.0",
   mandatoryVersions: [],
 }
 
@@ -149,6 +149,12 @@ describe("startUpdateOs action", () => {
     ).toEqual({
       ...initialState,
       updateOsState: State.Loaded,
+      data: {
+        ...initialState.data,
+        availableReleasesForUpdate: [],
+        downloadedProcessedReleases: [],
+        updateProcessedReleases: [],
+      },
     })
   })
   test("rejected action sets proper updateOsState and error", () => {
@@ -459,8 +465,49 @@ describe("setStateForInstalledRelease", () => {
           ...initialState,
           data: {
             ...initialState.data,
+            availableReleasesForUpdate: [mockedRelease],
             updateProcessedReleases: [
               { release: mockedRelease, state: ReleaseProcessState.Initial },
+            ],
+          },
+        },
+        {
+          type: UpdateOsEvent.SetStateForInstalledRelease,
+          payload: {
+            version: mockedRelease.version,
+            state: ReleaseProcessState.InProgress,
+          },
+        }
+      )
+    ).toEqual({
+      ...initialState,
+      data: {
+        ...initialState.data,
+        availableReleasesForUpdate: [mockedRelease],
+        updateProcessedReleases: [
+          { release: mockedRelease, state: ReleaseProcessState.InProgress },
+        ],
+      },
+    })
+  })
+  test("removes release from availableReleasesForUpdate if payload state equals to 'done'", () => {
+    const anotherMockedRelease: OsRelease = {
+      ...mockedRelease,
+      version: "1.2.0",
+    }
+    expect(
+      updateOsReducer(
+        {
+          ...initialState,
+          data: {
+            ...initialState.data,
+            availableReleasesForUpdate: [mockedRelease, anotherMockedRelease],
+            updateProcessedReleases: [
+              { release: mockedRelease, state: ReleaseProcessState.Initial },
+              {
+                release: anotherMockedRelease,
+                state: ReleaseProcessState.Initial,
+              },
             ],
           },
         },
@@ -478,7 +525,9 @@ describe("setStateForInstalledRelease", () => {
         ...initialState.data,
         updateProcessedReleases: [
           { release: mockedRelease, state: ReleaseProcessState.Done },
+          { release: anotherMockedRelease, state: ReleaseProcessState.Initial },
         ],
+        availableReleasesForUpdate: [anotherMockedRelease],
       },
     })
   })

--- a/packages/app/src/update/reducers/update-os.reducer.ts
+++ b/packages/app/src/update/reducers/update-os.reducer.ts
@@ -108,11 +108,22 @@ export const updateOsReducer = createReducer<UpdateOsState>(
           : item
       )
 
+      const newAvailableReleasesForUpdate = (
+        state.data.availableReleasesForUpdate ?? []
+      ).filter(
+        (release) =>
+          !(
+            release.version === version &&
+            newReleaseState === ReleaseProcessState.Done
+          )
+      )
+
       return {
         ...state,
         data: {
           ...state.data,
           updateProcessedReleases: newUpdateProcessedReleases,
+          availableReleasesForUpdate: newAvailableReleasesForUpdate,
         },
       }
     })
@@ -209,6 +220,12 @@ export const updateOsReducer = createReducer<UpdateOsState>(
     })
     builder.addCase(startUpdateOs.fulfilled, (state) => {
       state.updateOsState = State.Loaded
+      state.data = {
+        ...state.data,
+        availableReleasesForUpdate: [],
+        downloadedProcessedReleases: [],
+        updateProcessedReleases: [],
+      }
       state.error = null
     })
     builder.addCase(startUpdateOs.rejected, (state, action) => {


### PR DESCRIPTION
Jira: [CP-1742][CP-1796]

**Description**
Scope:
* this PR solves problem described in https://appnroll.atlassian.net/browse/CP-1796 (invalid button state and label after successful update) - see attached movie with mocked update process
* another problem solved (not reported by QA) - handling situation when one of the updates succeeds but the next one fails. Previously restarting the process would cause to start installation of already installed update - see attached movie with mocked update process

<details>
<summary><b>Screenshots</b></summary>

https://user-images.githubusercontent.com/41268731/213662771-27e0c415-ca8a-454a-9e05-d281ab3a512b.mov

https://user-images.githubusercontent.com/41268731/213663035-c72e66b1-0adb-4ef5-99fa-367e14c8c64d.mov

</details>


[CP-1742]: https://appnroll.atlassian.net/browse/CP-1742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ