### PR TITLE
[CP-1804] do not allow to exit force update with unlock feature

### DIFF
--- a/packages/app/src/__deprecated__/renderer/components/rest/menu/menu.container.tsx
+++ b/packages/app/src/__deprecated__/renderer/components/rest/menu/menu.container.tsx
@@ -12,6 +12,7 @@ const mapStateToProps = (state: RootState & ReduxRootState) => ({
   deviceFeaturesVisible:
     (state.device.status.connected &&
       state.device.status.unlocked &&
+      state.update.checkedForForceUpdateNeed &&
       !(
         state.update.needsForceUpdate &&
         state.update.checkForUpdateState === State.Failed

--- a/packages/app/src/device/reducers/device.reducer.test.ts
+++ b/packages/app/src/device/reducers/device.reducer.test.ts
@@ -227,6 +227,28 @@ describe("Lock/Unlock functionality", () => {
     })
   })
 
+  test("Event: Locked event changes loaded state to false", () => {
+    expect(
+      deviceReducer(
+        {
+          ...initialState,
+          deviceType: DeviceType.MuditaPure,
+        },
+        {
+          type: fulfilledAction(DeviceEvent.Locked),
+        }
+      )
+    ).toEqual({
+      ...initialState,
+      deviceType: DeviceType.MuditaPure,
+      status: {
+        ...initialState.status,
+        unlocked: false,
+        loaded: false,
+      },
+    })
+  })
+
   test("Event: SetLockTime set deviceLockTime", () => {
     expect(
       deviceReducer(undefined, {

--- a/packages/app/src/device/reducers/device.reducer.ts
+++ b/packages/app/src/device/reducers/device.reducer.ts
@@ -148,6 +148,7 @@ export const deviceReducer = createReducer<DeviceState>(
           status: {
             ...state.status,
             unlocked: state.deviceType === DeviceType.MuditaHarmony,
+            loaded: false,
           },
         }
       })

--- a/packages/app/src/update/reducers/update-os.interface.ts
+++ b/packages/app/src/update/reducers/update-os.interface.ts
@@ -20,6 +20,7 @@ export interface UpdateOsState {
   silentCheckForUpdate: SilentCheckForUpdateState
   error: AppError<UpdateError> | null
   needsForceUpdate: boolean
+  checkedForForceUpdateNeed: boolean
   data: {
     allReleases: OsRelease[] | null
     availableReleasesForUpdate: OsRelease[] | null

--- a/packages/app/src/update/reducers/update-os.reducer.test.ts
+++ b/packages/app/src/update/reducers/update-os.reducer.test.ts
@@ -47,6 +47,7 @@ test("empty event returns initial state", () => {
   expect(updateOsReducer(undefined, {} as any)).toMatchInlineSnapshot(`
     Object {
       "checkForUpdateState": 0,
+      "checkedForForceUpdateNeed": false,
       "data": Object {
         "allReleases": null,
         "availableReleasesForUpdate": null,
@@ -594,7 +595,7 @@ describe("clearStateAndData", () => {
 })
 
 describe("checkForForceUpdateNeed", () => {
-  test("sets needsForceUpdate according to the action result", () => {
+  test("sets needsForceUpdate according to the action result and checkedForForceUpdateNeed as true", () => {
     expect(
       updateOsReducer(
         {
@@ -608,6 +609,7 @@ describe("checkForForceUpdateNeed", () => {
     ).toEqual({
       ...initialState,
       needsForceUpdate: true,
+      checkedForForceUpdateNeed: true,
     })
 
     expect(
@@ -623,6 +625,7 @@ describe("checkForForceUpdateNeed", () => {
     ).toEqual({
       ...initialState,
       needsForceUpdate: false,
+      checkedForForceUpdateNeed: true,
     })
   })
 })

--- a/packages/app/src/update/reducers/update-os.reducer.ts
+++ b/packages/app/src/update/reducers/update-os.reducer.ts
@@ -38,6 +38,7 @@ export const initialState: UpdateOsState = {
   forceUpdateState: State.Initial,
   error: null,
   needsForceUpdate: false,
+  checkedForForceUpdateNeed: false,
   data: {
     allReleases: null,
     availableReleasesForUpdate: null,
@@ -239,6 +240,7 @@ export const updateOsReducer = createReducer<UpdateOsState>(
     })
     builder.addCase(checkForForceUpdateNeed.fulfilled, (state, action) => {
       state.needsForceUpdate = action.payload
+      state.checkedForForceUpdateNeed = true
     })
 
     builder.addCase(forceUpdate.pending, (state, action) => {


### PR DESCRIPTION
Jira: [CP-1804]

**Description**
Scope:
* do not allow to exit force update feature with unlock phone feature (see movie attached to the task)

See attached movie

<details>
<summary><b>Screenshots</b></summary>

https://user-images.githubusercontent.com/41268731/215456928-ce66e25e-b3f2-4782-8c58-09bc3f24b98e.mov

</details>


[CP-1804]: https://appnroll.atlassian.net/browse/CP-1804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ