### PR TITLE
[CP-1809] fixes

### DIFF
--- a/packages/app/src/update/actions/handle-device-attached/handle-device-attached.action.ts
+++ b/packages/app/src/update/actions/handle-device-attached/handle-device-attached.action.ts
@@ -12,9 +12,13 @@ import { ReduxRootState, RootState } from "App/__deprecated__/renderer/store"
 export const handleDeviceAttached = createAsyncThunk<void, void>(
   UpdateOsEvent.HandleDeviceAttached,
   (_, { dispatch, getState }) => {
-    const { update } = getState() as RootState & ReduxRootState
+    const { update, backup } = getState() as RootState & ReduxRootState
 
-    if (update.updateOsState === State.Loading) {
+    if (
+      update.updateOsState === State.Loading ||
+      backup.restoringState === State.Loading ||
+      backup.backingUpState === State.Loading
+    ) {
       return
     }
 

--- a/packages/app/src/update/reducers/update-os.reducer.test.ts
+++ b/packages/app/src/update/reducers/update-os.reducer.test.ts
@@ -312,6 +312,32 @@ describe("checkForUpdate", () => {
       })
     })
   })
+
+  describe("when check for update action is aborted and mode equals to silent check", () => {
+    test("state is set as initial", () => {
+      expect(
+        updateOsReducer(
+          {
+            ...initialState,
+            error: exampleError,
+          },
+          {
+            type: rejectedAction(UpdateOsEvent.CheckForUpdate),
+            meta: {
+              aborted: true,
+              arg: {
+                mode: CheckForUpdateMode.SilentCheck,
+              },
+            },
+          }
+        )
+      ).toEqual({
+        ...initialState,
+        silentCheckForUpdate: SilentCheckForUpdateState.Initial,
+        error: null,
+      })
+    })
+  })
 })
 
 describe("downloadUpdate", () => {

--- a/packages/app/src/update/reducers/update-os.reducer.ts
+++ b/packages/app/src/update/reducers/update-os.reducer.ts
@@ -177,13 +177,20 @@ export const updateOsReducer = createReducer<UpdateOsState>(
       }
     })
     builder.addCase(checkForUpdate.rejected, (state, action) => {
-      if (action.meta.arg.mode === CheckForUpdateMode.SilentCheck) {
+      let error: AppError<UpdateError> | null =
+        action.payload as AppError<UpdateError>
+      if (
+        action.meta.aborted &&
+        action.meta.arg.mode === CheckForUpdateMode.SilentCheck
+      ) {
+        state.silentCheckForUpdate = SilentCheckForUpdateState.Initial
+        error = null
+      } else if (action.meta.arg.mode === CheckForUpdateMode.SilentCheck) {
         state.silentCheckForUpdate = SilentCheckForUpdateState.Failed
       } else {
         state.checkForUpdateState = State.Failed
       }
-
-      state.error = action.payload as AppError<UpdateError>
+      state.error = error
     })
 
     builder.addCase(downloadUpdates.pending, (state, action) => {


### PR DESCRIPTION
Jira: [CP-1809]

**Description**
Scope:
* quick switching between tabs do not display "check for update failed" modal - see attached video
* update state is not reseted during backup or restore process (those processes restarts the device) - see attached video

<details>
<summary><b>Screenshots</b></summary>
// put images here

https://user-images.githubusercontent.com/41268731/216267864-b22b16e9-fb15-4002-85e7-735e35766fa1.mov


https://user-images.githubusercontent.com/41268731/216279319-c1dacb73-9958-4b3f-9ebc-6e6913e05fd7.mov




</details>


[CP-1809]: https://appnroll.atlassian.net/browse/CP-1809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ