### PR TITLE
[CP -1714] Search different behaviour for result display 

### DIFF
--- a/packages/app/src/contacts/components/contacts/contacts.component.test.tsx
+++ b/packages/app/src/contacts/components/contacts/contacts.component.test.tsx
@@ -17,6 +17,16 @@ import { ExportContactFailedModalTestIds } from "App/contacts/components/export-
 import { ExportContactsResult } from "App/contacts/constants"
 import { VirtualizedContactListItemTestIds } from "App/contacts/components/virtualized-contact-list-item/virtualized-contact-list-item-test-ids"
 import { VirtuosoMockContext } from "react-virtuoso"
+import { ContactSearchResultsTestIdsEnum } from "../contact-search-results/contact-search-results-test-ids.enum"
+
+const intersectionObserverMock = () => ({
+  observe: () => null,
+  disconnect: () => null,
+  unobserve: () => null,
+})
+window.IntersectionObserver = jest
+  .fn()
+  .mockImplementation(intersectionObserverMock)
 
 type Props = ComponentProps<typeof Contacts>
 
@@ -317,5 +327,40 @@ describe("contact export", () => {
     expect(
       queryByTestId(ExportContactFailedModalTestIds.Description)
     ).not.toBeInTheDocument()
+  })
+})
+
+describe("search preview", () => {
+  test("preview list should be independent of search results", () => {
+    const { queryByTestId, getByTestId, queryAllByTestId } = renderer({
+      flatList: [contactOne, contactTwo],
+    })
+    const input = queryByTestId(
+      ContactInputSelectTestIds.Input
+    ) as HTMLInputElement
+    fireEvent.change(input, { target: { value: "Luke Skywalker" } })
+
+    expect(
+      queryAllByTestId(VirtualizedContactListItemTestIds.ContactRow)
+    ).toHaveLength(2)
+
+    fireEvent.keyDown(input, {
+      key: "Enter",
+      code: "Enter",
+      keyCode: 13,
+      charCode: 13,
+    })
+
+    expect(
+      getByTestId(ContactSearchResultsTestIdsEnum.Table).childNodes
+    ).toHaveLength(1)
+
+    fireEvent.change(input, { target: { value: "S" } })
+
+    expect(
+      getByTestId(ContactSearchResultsTestIdsEnum.Table).childNodes
+    ).toHaveLength(1)
+
+    expect(queryAllByTestId(InputSearchTestIds.ListItem)).toHaveLength(2)
   })
 })

--- a/packages/app/src/contacts/components/contacts/contacts.component.tsx
+++ b/packages/app/src/contacts/components/contacts/contacts.component.tsx
@@ -154,7 +154,7 @@ const Contacts: FunctionComponent<ContactsProps> = ({
     closeSidebar()
     setNewContact(defaultContact)
     setShowSearchResults(false)
-    setSearchValue("")
+    setSearchPreviewValue("")
   }
 
   const cancelOrCloseContactHandler = () => {
@@ -516,6 +516,7 @@ const Contacts: FunctionComponent<ContactsProps> = ({
   }
 
   const [showSearchResults, setShowSearchResults] = useState<boolean>(false)
+  const [searchPreviewValue, setSearchPreviewValue] = useState<string>("")
   const [searchValue, setSearchValue] = useState<string>("")
 
   const handleContactSelect = (contact: Contact) => {
@@ -525,14 +526,14 @@ const Contacts: FunctionComponent<ContactsProps> = ({
   }
 
   useEffect(() => {
-    if (searchValue === "") {
+    if (searchPreviewValue === "") {
       setShowSearchResults(false)
     }
-  }, [searchValue])
+  }, [searchPreviewValue])
 
   useEffect(() => {
     if (detailsEnabled === true) {
-      setSearchValue("")
+      setSearchPreviewValue("")
     }
   }, [detailsEnabled])
 
@@ -540,10 +541,14 @@ const Contacts: FunctionComponent<ContactsProps> = ({
     setShowSearchResults(true)
     setEditedContact(undefined)
     setNewContact(undefined)
+    setSearchValue(searchPreviewValue)
   }
 
   const results = flatList.filter((item) =>
     contactsFilter(item, searchValue || "")
+  )
+  const resultsPreview = flatList.filter((item) =>
+    contactsFilter(item, searchPreviewValue || "")
   )
 
   const handleExport = async (ids: string[]): Promise<void> => {
@@ -600,9 +605,9 @@ const Contacts: FunctionComponent<ContactsProps> = ({
           resetRows={resetAllItems}
           editMode={Boolean(editedContact || newContact)}
           onSearchEnterClick={openSearchResults}
-          searchValue={searchValue}
-          onSearchValueChange={setSearchValue}
-          results={results}
+          searchValue={searchPreviewValue}
+          onSearchValueChange={setSearchPreviewValue}
+          results={resultsPreview}
           showSearchResults={showSearchResults}
           onExport={handleExport}
         />

--- a/packages/app/src/messages/components/messages/messages.component.tsx
+++ b/packages/app/src/messages/components/messages/messages.component.tsx
@@ -109,7 +109,9 @@ const Messages: FunctionComponent<MessagesProps> = ({
   selectAllItems,
   resetItems,
   searchMessages,
+  searchMessagesForPreview,
   searchResult,
+  searchPreviewResult,
   state,
 }) => {
   const { states, updateFieldState } = useLoadingState<MessagesServiceState>({
@@ -645,7 +647,7 @@ const Messages: FunctionComponent<MessagesProps> = ({
     if (query.length > 0) {
       setLastSearchQuery(query)
       setActiveSearchDropdown(true)
-      searchMessages({
+      searchMessagesForPreview({
         scope: [DataIndex.Message, DataIndex.Thread],
         query: query,
       })
@@ -677,6 +679,7 @@ const Messages: FunctionComponent<MessagesProps> = ({
 
   const handleSearchMessage = () => {
     searchMessages({ scope: [DataIndex.Message], query: searchValue })
+    searchMessagesForPreview({ scope: [DataIndex.Message], query: searchValue })
   }
   return (
     <>
@@ -716,7 +719,7 @@ const Messages: FunctionComponent<MessagesProps> = ({
         allItemsSelected={allItemsSelected}
         toggleAll={handleToggleAllCheckboxes}
         onDeleteClick={handleDeleteThreads}
-        results={searchResult}
+        results={searchPreviewResult}
         onSelect={handleSearchSelect}
         onSearchEnterClick={handleSearchEnter}
         showSearchResults={activeSearchDropdown}

--- a/packages/app/src/messages/components/messages/messages.interface.ts
+++ b/packages/app/src/messages/components/messages/messages.interface.ts
@@ -71,6 +71,8 @@ export interface MessagesProps extends Pick<Settings, "language"> {
   selectAllItems: () => void
   resetItems: () => void
   searchMessages: (searchParams: SearchParams) => void
+  searchMessagesForPreview: (searchParams: SearchParams) => void
   searchResult: SearchResult
+  searchPreviewResult: SearchResult
   state: State
 }

--- a/packages/app/src/messages/components/messages/messages.stories.tsx
+++ b/packages/app/src/messages/components/messages/messages.stories.tsx
@@ -170,7 +170,9 @@ storiesOf("Views|Messages", module).add("Messages", () => (
         selectAllItems={jest.fn()}
         resetItems={jest.fn()}
         searchMessages={jest.fn()}
+        searchMessagesForPreview={jest.fn()}
         searchResult={{}}
+        searchPreviewResult={{}}
         state={State.Initial}
       />
     </div>

--- a/packages/app/src/messages/components/messages/messages.test.tsx
+++ b/packages/app/src/messages/components/messages/messages.test.tsx
@@ -176,7 +176,9 @@ const defaultProps: Props = {
   selectAllItems: jest.fn(),
   resetItems: jest.fn(),
   searchMessages: jest.fn(),
+  searchMessagesForPreview: jest.fn(),
   searchResult: {},
+  searchPreviewResult: {},
   state: State.Initial,
 }
 

--- a/packages/app/src/messages/messages.container.tsx
+++ b/packages/app/src/messages/messages.container.tsx
@@ -47,7 +47,7 @@ import {
 } from "./actions"
 import { CreateMessageDataResponse } from "App/messages/services"
 import { PayloadAction } from "@reduxjs/toolkit"
-import { search } from "App/search/actions"
+import { search, searchPreview } from "App/search/actions"
 import { SearchParams } from "App/search/dto"
 
 const mapStateToProps = (state: RootState & ReduxRootState) => ({
@@ -73,6 +73,7 @@ const mapStateToProps = (state: RootState & ReduxRootState) => ({
   templates: state.templates.data,
   selectedItems: state.messages.selectedItems,
   searchResult: state.messages.data.searchResult,
+  searchPreviewResult: state.messages.data.searchPreviewResult,
   state: state.messages.state,
 })
 
@@ -136,6 +137,10 @@ const mapDispatchToProps = (dispatch: TmpDispatch) => ({
     // AUTO DISABLED - fix me if you like :)
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
     dispatch(search(searchParams)),
+  searchMessagesForPreview: (searchParams: SearchParams) =>
+    // AUTO DISABLED - fix me if you like :)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
+    dispatch(searchPreview(searchParams)),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(Messages)

--- a/packages/app/src/messages/reducers/messages.interface.ts
+++ b/packages/app/src/messages/reducers/messages.interface.ts
@@ -37,6 +37,7 @@ export type MessagesState = Readonly<{
     threadsState: ResultState
     currentlyDeletingMessageId: MessageId | null
     searchResult: SearchResult
+    searchPreviewResult: SearchResult
   }
   selectedItems: { rows: string[] }
   error: AppError | null
@@ -143,6 +144,6 @@ export type ChangeSearchValueAction = PayloadAction<
 >
 
 export type SearchMessagesAction = PayloadAction<
-  SearchResult,
-  SearchEvent.SearchData
+  SearchResult | undefined,
+  SearchEvent
 >

--- a/packages/app/src/messages/reducers/messages.reducer.test.ts
+++ b/packages/app/src/messages/reducers/messages.reducer.test.ts
@@ -792,6 +792,28 @@ describe("Searching messages", () => {
     })
   })
 })
+describe("Searching preview messages", () => {
+  test("Searching by message content returns proper value", () => {
+    const searchMessagesAction: PayloadAction<SearchResult> = {
+      type: fulfilledAction(SearchEvent.SearchDataPreview),
+      payload: { message: [messageOne], thread: [thread] },
+    }
+    expect(
+      messagesReducer(
+        {
+          ...initialState,
+        },
+        searchMessagesAction
+      )
+    ).toEqual({
+      ...initialState,
+      data: {
+        ...initialState.data,
+        searchPreviewResult: { message: [messageOne], thread: [thread] },
+      },
+    })
+  })
+})
 
 describe("ResendMessage", () => {
   test("ResendMessage/pending clears error state", () => {

--- a/packages/app/src/messages/reducers/messages.reducer.ts
+++ b/packages/app/src/messages/reducers/messages.reducer.ts
@@ -44,6 +44,7 @@ import assert from "assert"
 import { SearchEvent } from "App/search/constants"
 import { State } from "App/core/constants"
 import { AppError } from "App/core/errors"
+import { search, searchPreview } from "App/search/actions/search.action"
 
 export const initialState: MessagesState = {
   data: {
@@ -53,6 +54,7 @@ export const initialState: MessagesState = {
     messagesStateMap: {},
     currentlyDeletingMessageId: null,
     searchResult: {},
+    searchPreviewResult: {},
     searchValue: "",
     threadsState: ResultState.Empty,
     visibilityFilter: VisibilityFilter.All,
@@ -433,17 +435,11 @@ export const messagesReducer = createReducer<MessagesState>(
           selectedItems: { rows: [] },
         }
       })
-      .addCase(
-        fulfilledAction(SearchEvent.SearchData),
-        (state, action: SearchMessagesAction) => {
-          return {
-            ...state,
-            data: {
-              ...state.data,
-              searchResult: action.payload,
-            },
-          }
-        }
-      )
+      .addCase(search.fulfilled, (state, action) => {
+        state.data.searchResult = action.payload ?? {}
+      })
+      .addCase(searchPreview.fulfilled, (state, action) => {
+        state.data.searchPreviewResult = action.payload ?? {}
+      })
   }
 )

--- a/packages/app/src/messages/reducers/messages.reducer.ts
+++ b/packages/app/src/messages/reducers/messages.reducer.ts
@@ -27,7 +27,6 @@ import {
   DeleteMessageAction,
   DeleteMessagePendingAction,
   DeleteMessageRejectedAction,
-  SearchMessagesAction,
   DeleteThreadsRejectedAction,
 } from "App/messages/reducers/messages.interface"
 import {
@@ -41,7 +40,6 @@ import { ReadAllIndexesAction } from "App/data-sync/reducers"
 import { markThreadsReadStatus } from "App/messages/reducers/messages-reducer.helpers"
 import { changeLocation } from "App/core/actions"
 import assert from "assert"
-import { SearchEvent } from "App/search/constants"
 import { State } from "App/core/constants"
 import { AppError } from "App/core/errors"
 import { search, searchPreview } from "App/search/actions/search.action"

--- a/packages/app/src/messages/selectors/get-active-messages-by-thread-id.selector.test.ts
+++ b/packages/app/src/messages/selectors/get-active-messages-by-thread-id.selector.test.ts
@@ -72,6 +72,7 @@ const messagesState: MessagesState = {
     threadsState: ResultState.Empty,
     currentlyDeletingMessageId: null,
     searchResult: {},
+    searchPreviewResult: {},
   },
   selectedItems: { rows: [] },
   error: null,

--- a/packages/app/src/messages/selectors/get-thread-draft-message.selector.test.ts
+++ b/packages/app/src/messages/selectors/get-thread-draft-message.selector.test.ts
@@ -75,6 +75,7 @@ const messagesState: MessagesState = {
     threadsState: ResultState.Empty,
     currentlyDeletingMessageId: null,
     searchResult: {},
+    searchPreviewResult: {},
   },
   selectedItems: { rows: [] },
   error: null,

--- a/packages/app/src/search/actions/search.action.ts
+++ b/packages/app/src/search/actions/search.action.ts
@@ -8,10 +8,16 @@ import { SearchEvent } from "App/search/constants"
 import { SearchParams, SearchResult } from "App/search/dto"
 import { searchRequest } from "App/search/requests"
 
-export const search = createAsyncThunk<SearchResult | undefined, SearchParams>(
-  SearchEvent.SearchData,
-  async (payload) => {
-    const result = await searchRequest(payload)
-    return result.ok ? result.data : undefined
-  }
+const searchActionGenerator = (searchAction: SearchEvent) =>
+  createAsyncThunk<SearchResult | undefined, SearchParams>(
+    searchAction,
+    async (payload) => {
+      const result = await searchRequest(payload)
+      return result.ok ? result.data : undefined
+    }
+  )
+
+export const search = searchActionGenerator(SearchEvent.SearchData)
+export const searchPreview = searchActionGenerator(
+  SearchEvent.SearchDataPreview
 )

--- a/packages/app/src/search/constants/event.constant.ts
+++ b/packages/app/src/search/constants/event.constant.ts
@@ -5,4 +5,5 @@
 
 export enum SearchEvent {
   SearchData = "SEARCH_DATA",
+  SearchDataPreview = "SEARCH_DATA_PREVIEW",
 }


### PR DESCRIPTION
Jira: [CP-1714]

split search results from search preview for contacts and messages view

<details>
<summary><b>Screenshots</b></summary>
// put images here
</details>


[CP-1714]: https://appnroll.atlassian.net/browse/CP-1714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ