### PR TITLE
[CP-1714] show correct search title for messages and contacts

### DIFF
--- a/packages/app/src/contacts/components/contact-panel/contact-panel.component.tsx
+++ b/packages/app/src/contacts/components/contact-panel/contact-panel.component.tsx
@@ -70,7 +70,8 @@ interface ContactPanelProps {
   editMode: boolean
   onSearchEnterClick?: () => void
   searchValue: string
-  onSearchValueChange: (value: string) => void
+  searchPreviewValue: string
+  onSearchPreviewValueChange: (value: string) => void
   showSearchResults?: boolean
   results: Contact[]
   onExport: (ids: string[]) => void
@@ -88,7 +89,8 @@ const ContactPanel: FunctionComponent<ContactPanelProps> = ({
   editMode,
   onSearchEnterClick = noop,
   searchValue,
-  onSearchValueChange,
+  searchPreviewValue,
+  onSearchPreviewValueChange,
   showSearchResults = false,
   results,
   onExport,
@@ -168,8 +170,8 @@ const ContactPanel: FunctionComponent<ContactPanelProps> = ({
             <ContactInputSearch
               onContactSelect={onContactSelect}
               onSearchEnterClick={onSearchEnterClick}
-              searchValue={searchValue}
-              onSearchValueChange={onSearchValueChange}
+              searchValue={searchPreviewValue}
+              onSearchValueChange={onSearchPreviewValueChange}
               showSearchResults
               results={results}
             />

--- a/packages/app/src/contacts/components/contact-panel/contact-panel.test.tsx
+++ b/packages/app/src/contacts/components/contact-panel/contact-panel.test.tsx
@@ -46,6 +46,7 @@ const defaultProps: Props = {
   contactsList: contacts,
   editMode: false,
   searchValue: "",
+  searchPreviewValue: "",
   results: contacts,
   allItemsSelected: false,
   onManageButtonClick: jest.fn(),
@@ -55,7 +56,7 @@ const defaultProps: Props = {
   selectedContacts: [],
   deleteContacts: jest.fn(),
   onContactSelect: jest.fn(),
-  onSearchValueChange: jest.fn(),
+  onSearchPreviewValueChange: jest.fn(),
   onExport: jest.fn(),
 }
 
@@ -90,6 +91,7 @@ describe("`ContactPanel` component", () => {
       showSearchResults: true,
       searchValue: "test",
     })
+
     expect(getByTestId(ContactPanelTestIdsEnum.SearchTitle)).toHaveTextContent(
       "[value] module.contacts.searchResultsTitle"
     )

--- a/packages/app/src/contacts/components/contacts/contacts.component.tsx
+++ b/packages/app/src/contacts/components/contacts/contacts.component.tsx
@@ -522,7 +522,6 @@ const Contacts: FunctionComponent<ContactsProps> = ({
   const handleContactSelect = (contact: Contact) => {
     setSelectedContact(contact)
     openSidebar(contact)
-    setShowSearchResults(false)
   }
 
   useEffect(() => {
@@ -605,8 +604,9 @@ const Contacts: FunctionComponent<ContactsProps> = ({
           resetRows={resetAllItems}
           editMode={Boolean(editedContact || newContact)}
           onSearchEnterClick={openSearchResults}
-          searchValue={searchPreviewValue}
-          onSearchValueChange={setSearchPreviewValue}
+          searchValue={searchValue}
+          searchPreviewValue={searchPreviewValue}
+          onSearchPreviewValueChange={setSearchPreviewValue}
           results={resultsPreview}
           showSearchResults={showSearchResults}
           onExport={handleExport}

--- a/packages/app/src/messages/components/messages/messages.component.tsx
+++ b/packages/app/src/messages/components/messages/messages.component.tsx
@@ -140,6 +140,7 @@ const Messages: FunctionComponent<MessagesProps> = ({
   const debouncedContent = useDebounce(content, 1000)
   const [messageToDelete, setMessageToDelete] = useState<string | undefined>()
   const [deletedThreads, setDeletedThreads] = useState<string[]>([])
+  const [searchPreviewValue, setSearchPreviewValue] = useState<string>("")
   const [searchValue, setSearchValue] = useState<string>("")
   const [lastSearchQuery, setLastSearchQuery] = useState<string>("")
   const [searchedMessage, setSearchedMessage] = useState<Message | null>(null)
@@ -148,7 +149,7 @@ const Messages: FunctionComponent<MessagesProps> = ({
   const allItemsSelected = threads.length === selectedItems.rows.length
 
   useEffect(() => {
-    if (searchValue !== "") {
+    if (searchPreviewValue !== "") {
       return
     }
     if (messagesState === MessagesState.SearchResult) {
@@ -156,7 +157,7 @@ const Messages: FunctionComponent<MessagesProps> = ({
     }
     setActiveSearchDropdown(false)
     setSearchedMessage(null)
-  }, [searchValue, messagesState])
+  }, [searchPreviewValue, messagesState])
 
   useEffect(() => {
     messageLayoutNotifications
@@ -642,7 +643,7 @@ const Messages: FunctionComponent<MessagesProps> = ({
   }
 
   const handleSearch = (query: string) => {
-    setSearchValue(query)
+    setSearchPreviewValue(query)
 
     if (query.length > 0) {
       setLastSearchQuery(query)
@@ -661,6 +662,7 @@ const Messages: FunctionComponent<MessagesProps> = ({
   const handleSearchEnter = () => {
     setMessagesState(MessagesState.SearchResult)
     setActiveThread(undefined)
+    setSearchValue(searchPreviewValue)
     handleSearchMessage()
   }
 
@@ -679,7 +681,10 @@ const Messages: FunctionComponent<MessagesProps> = ({
 
   const handleSearchMessage = () => {
     searchMessages({ scope: [DataIndex.Message], query: searchValue })
-    searchMessagesForPreview({ scope: [DataIndex.Message], query: searchValue })
+    searchMessagesForPreview({
+      scope: [DataIndex.Message],
+      query: searchValue,
+    })
   }
   return (
     <>
@@ -711,7 +716,7 @@ const Messages: FunctionComponent<MessagesProps> = ({
         templates={templates}
       />
       <MessagesPanel
-        searchValue={searchValue}
+        searchValue={searchPreviewValue}
         onSearchValueChange={handleSearch}
         onNewMessageClick={handleNewMessageClick}
         buttonDisabled={messagesState === MessagesState.NewMessage}


### PR DESCRIPTION
Jira: [CP-1714]

- display correct text in the search title
- blur event in the search input does not have an impact on search results

<details>
<summary><b>Screenshots</b></summary>

![image](https://user-images.githubusercontent.com/37898730/218093580-053071d6-0c77-42db-895b-6bec768b6695.png)
</details>


[CP-1714]: https://appnroll.atlassian.net/browse/CP-1714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ