### PR TITLE
[CP-1846] [News] Random latest News dates

### DIFF
--- a/packages/app/src/__deprecated__/calendar/components/events-list-date/events-list-date.test.tsx
+++ b/packages/app/src/__deprecated__/calendar/components/events-list-date/events-list-date.test.tsx
@@ -20,7 +20,7 @@ const multiDaysEvent = {
   endDate: "2020-02-14T11:00:00.000Z",
 }
 const oneDayResult = `Wednesday, February 12, 2020, 10:00 AM - 11:00 AM`
-const multiDaysResult = `February 12, 2020 at 10:00 AM - February 14, 2020 at 11:00 AM`
+const multiDaysResult = `February 12, 2020, 10:00 AM - February 14, 2020, 11:00 AM`
 
 test("show one day event date", () => {
   const { container } = renderWithThemeAndIntl(

--- a/packages/app/src/__deprecated__/calendar/components/events-list-date/events-list-date.test.tsx
+++ b/packages/app/src/__deprecated__/calendar/components/events-list-date/events-list-date.test.tsx
@@ -20,7 +20,7 @@ const multiDaysEvent = {
   endDate: "2020-02-14T11:00:00.000Z",
 }
 const oneDayResult = `Wednesday, February 12, 2020, 10:00 AM - 11:00 AM`
-const multiDaysResult = `February 12, 2020, 10:00 AM - February 14, 2020, 11:00 AM`
+const multiDaysResult = `February 12, 2020 at 10:00 AM - February 14, 2020 at 11:00 AM`
 
 test("show one day event date", () => {
   const { container } = renderWithThemeAndIntl(

--- a/packages/app/src/__deprecated__/main/functions/register-news-listener/get-updated-news.test.ts
+++ b/packages/app/src/__deprecated__/main/functions/register-news-listener/get-updated-news.test.ts
@@ -88,7 +88,7 @@ beforeEach(() => {
 })
 
 describe("when news are not found", () => {
-  let result: unknown
+  let result: { newsItems: NewsEntry[], lastUpdate: string } | null
 
   beforeEach(async () => {
     jest.spyOn(CreateClientModule, "createClient").mockImplementation(() => {
@@ -100,12 +100,12 @@ describe("when news are not found", () => {
     result = await getUpdatedNews(mockedPath)
   })
 
-  test("null is returned", () => {
-    expect(result).toEqual(null)
+  test("empty array is returned", () => {
+    expect(result?.newsItems).toStrictEqual([])
   })
 
-  test("updated news are not saved to file", () => {
-    expect(writeJsonSpy).not.toHaveBeenCalled()
+  test("updated news are saved to file", () => {
+    expect(writeJsonSpy).toHaveBeenCalled()
   })
 })
 

--- a/packages/app/src/__deprecated__/main/functions/register-news-listener/get-updated-news.ts
+++ b/packages/app/src/__deprecated__/main/functions/register-news-listener/get-updated-news.ts
@@ -9,7 +9,7 @@ import { NewsEntry } from "App/news/dto"
 import { Entry, EntryCollection } from "contentful"
 import fs from "fs-extra"
 import { normalizeContentfulData } from "App/news/helpers"
-import _ from "lodash"
+import { isEqual } from "lodash"
 
 const checkForUpdateAndGetNewData = async (
   newsFilePath: string
@@ -76,7 +76,7 @@ const isOnlineNewsDifferentFromLocal = (
   const onlineNewsDates = online.items.map(
     (item: Entry<NewsEntry>) => new Date(item.fields.date)
   )
-  return !_.isEqual(onlineNewsDates, localNewsDates)
+  return !isEqual(onlineNewsDates, localNewsDates)
 }
 
 // AUTO DISABLED - fix me if you like :)

--- a/packages/app/src/__deprecated__/main/functions/register-news-listener/get-updated-news.ts
+++ b/packages/app/src/__deprecated__/main/functions/register-news-listener/get-updated-news.ts
@@ -9,34 +9,23 @@ import { NewsEntry } from "App/news/dto"
 import { Entry, EntryCollection } from "contentful"
 import fs from "fs-extra"
 import { normalizeContentfulData } from "App/news/helpers"
+import _ from "lodash"
 
 const checkForUpdateAndGetNewData = async (
   newsFilePath: string
 ): Promise<boolean | EntryCollection<NewsEntry>> => {
   // AUTO DISABLED - fix me if you like :)
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const { newsItems } = await fs.readJson(newsFilePath)
-  const newestLocalItemDate = Math.max(
-    // AUTO DISABLED - fix me if you like :)
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    ...newsItems.map((item: NewsEntry) => {
-      return new Date(item.updatedAt).getTime()
-    })
-  )
+  const { newsItems: localNews } = await fs.readJson(newsFilePath)
 
   try {
     const client = createClient()
-    const data: EntryCollection<NewsEntry> = await client.getNews({
+    const onlineNews: EntryCollection<NewsEntry> = await client.getNews({
       limit: 6,
     })
 
-    const newestOnlineItemDate = Math.max(
-      ...data.items.map((item: Entry<NewsEntry>) => {
-        return new Date(item.sys.updatedAt).getTime()
-      })
-    )
-    if (newestOnlineItemDate > newestLocalItemDate) {
-      return data
+    if (shouldUpdateNews(localNews, onlineNews)) {
+      return onlineNews
     }
 
     return false
@@ -48,6 +37,46 @@ const checkForUpdateAndGetNewData = async (
     )
     return false
   }
+}
+
+const shouldUpdateNews = (
+  local: NewsEntry[],
+  online: EntryCollection<NewsEntry>
+) => {
+  return (
+    isOnlineNewsNewerUpdateAt(local, online) ||
+    isOnlineNewsDifferentFromLocal(local, online)
+  )
+}
+
+const isOnlineNewsNewerUpdateAt = (
+  local: NewsEntry[],
+  online: EntryCollection<NewsEntry>
+) => {
+  const newestLocalItemUpdatedAt = Math.max(
+    // AUTO DISABLED - fix me if you like :)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    ...local.map((item: NewsEntry) => {
+      return new Date(item.updatedAt).getTime()
+    })
+  )
+  const newestOnlineItemUpdatedAt = Math.max(
+    ...online.items.map((item: Entry<NewsEntry>) => {
+      return new Date(item.sys.updatedAt).getTime()
+    })
+  )
+  return newestOnlineItemUpdatedAt > newestLocalItemUpdatedAt
+}
+
+const isOnlineNewsDifferentFromLocal = (
+  local: NewsEntry[],
+  online: EntryCollection<NewsEntry>
+) => {
+  const localNewsDates = local.map((item: NewsEntry) => new Date(item.date))
+  const onlineNewsDates = online.items.map(
+    (item: Entry<NewsEntry>) => new Date(item.fields.date)
+  )
+  return !_.isEqual(onlineNewsDates, localNewsDates)
 }
 
 // AUTO DISABLED - fix me if you like :)

--- a/packages/app/src/news/helpers/sort-by-creation-date-in-descending-order/sort-by-creation-date-in-descending-order.helper.test.ts
+++ b/packages/app/src/news/helpers/sort-by-creation-date-in-descending-order/sort-by-creation-date-in-descending-order.helper.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { NewsEntry } from "App/news/dto"
-import { sortByCreationDateInDescendingOrder } from "./sort-by-creation-date-in-descending-order.helper"
+import { sortByDateInDescendingOrder } from "./sort-by-creation-date-in-descending-order.helper"
 
 const newsEntityMock: NewsEntry[] = [
   {
@@ -49,7 +49,7 @@ const newsEntityMock: NewsEntry[] = [
 ]
 
 test("returns sorted news entities", () => {
-  const result = sortByCreationDateInDescendingOrder([...newsEntityMock])
+  const result = sortByDateInDescendingOrder([...newsEntityMock])
   expect(result).toHaveLength(2)
   expect(result[0].newsId).toEqual(newsEntityMock[1].newsId)
   expect(result[1].newsId).toEqual(newsEntityMock[0].newsId)

--- a/packages/app/src/news/helpers/sort-by-creation-date-in-descending-order/sort-by-creation-date-in-descending-order.helper.test.ts
+++ b/packages/app/src/news/helpers/sort-by-creation-date-in-descending-order/sort-by-creation-date-in-descending-order.helper.test.ts
@@ -9,6 +9,25 @@ import { sortByDateInDescendingOrder } from "./sort-by-creation-date-in-descendi
 const newsEntityMock: NewsEntry[] = [
   {
     category: "Blog",
+    title: "Remote work",
+    content:
+      "What started as a way to keep employees safe, morphed into the world’s largest work-from-home experiment.",
+    image: {
+      sys: undefined,
+    },
+    communityLink: "https://forum.mudita.com/t/the-future-of-work/2632",
+    link: "https://mudita.com/community/blog/is-remote-work-here-to-stay/",
+    discussionId: "2632",
+    commentsCount: 1,
+    date: "2021-06-02T13:16+00:00",
+    newsId: "3oanllPiOTmu6GD72CTZFD",
+    updatedAt: "2021-07-27T13:07:31.243Z",
+    createdAt: "2021-07-27T13:07:15.756Z",
+    imageAlt: "Remote work",
+    imageSource: "",
+  },
+  {
+    category: "Blog",
     title: "Testing Mudita Pure",
     content:
       "Recently, our Team had the exciting opportunity to test Mudita Pure for an entire week.",
@@ -25,25 +44,6 @@ const newsEntityMock: NewsEntry[] = [
     updatedAt: "2021-07-27T12:58:23.083Z",
     createdAt: "2021-07-27T12:58:23.083Z",
     imageAlt: "Pure testing videos",
-    imageSource: "",
-  },
-  {
-    category: "Blog",
-    title: "Remote work",
-    content:
-      "What started as a way to keep employees safe, morphed into the world’s largest work-from-home experiment.",
-    image: {
-      sys: undefined,
-    },
-    communityLink: "https://forum.mudita.com/t/the-future-of-work/2632",
-    link: "https://mudita.com/community/blog/is-remote-work-here-to-stay/",
-    discussionId: "2632",
-    commentsCount: 1,
-    date: "2021-06-02T13:16+00:00",
-    newsId: "3oanllPiOTmu6GD72CTZFD",
-    updatedAt: "2021-07-27T13:07:31.243Z",
-    createdAt: "2021-07-27T13:07:15.756Z",
-    imageAlt: "Remote work",
     imageSource: "",
   },
 ]

--- a/packages/app/src/news/helpers/sort-by-creation-date-in-descending-order/sort-by-creation-date-in-descending-order.helper.ts
+++ b/packages/app/src/news/helpers/sort-by-creation-date-in-descending-order/sort-by-creation-date-in-descending-order.helper.ts
@@ -7,10 +7,8 @@ import { NewsEntry } from "App/news/dto"
 
 // AUTO DISABLED - fix me if you like :)
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export const sortByCreationDateInDescendingOrder = (newsItems: NewsEntry[]) => {
+export const sortByDateInDescendingOrder = (newsItems: NewsEntry[]) => {
   return [...newsItems].sort((firstId, secondId) => {
-    return (
-      Number(new Date(secondId.createdAt)) - Number(new Date(firstId.createdAt))
-    )
+    return Number(new Date(secondId.date)) - Number(new Date(firstId.date))
   })
 }

--- a/packages/app/src/news/selectors/news-sorted-by-creation-date/news-sorted-by-creation-date.selector.test.ts
+++ b/packages/app/src/news/selectors/news-sorted-by-creation-date/news-sorted-by-creation-date.selector.test.ts
@@ -11,15 +11,15 @@ import { ReduxRootState } from "App/__deprecated__/renderer/store"
 const newsToBeSorted = [
   {
     ...mockedNewsItems[0],
-    createdAt: "2019-07-11T09:48:32.097Z",
+    date: "2019-07-11T09:48:32.097Z",
   },
   {
     ...mockedNewsItems[1],
-    createdAt: "2022-07-11T09:48:32.097Z",
+    date: "2022-07-11T09:48:32.097Z",
   },
   {
     ...mockedNewsItems[2],
-    createdAt: "2013-07-11T09:48:32.097Z",
+    date: "2013-07-11T09:48:32.097Z",
   },
 ]
 

--- a/packages/app/src/news/selectors/news-sorted-by-creation-date/news-sorted-by-creation-date.selector.ts
+++ b/packages/app/src/news/selectors/news-sorted-by-creation-date/news-sorted-by-creation-date.selector.ts
@@ -4,7 +4,7 @@
  */
 
 import { NewsEntry } from "App/news/dto"
-import { sortByCreationDateInDescendingOrder } from "App/news/helpers"
+import { sortByDateInDescendingOrder } from "App/news/helpers"
 import { NewsState } from "App/news/reducers"
 import { newsStateSelector } from "App/news/selectors/news-state/news-state.selector"
 import { ReduxRootState } from "App/__deprecated__/renderer/store"
@@ -15,5 +15,5 @@ export const newsSortedByCreationDateSelector = createSelector<
   NewsState,
   NewsEntry[]
 >(newsStateSelector, (state) => {
-  return sortByCreationDateInDescendingOrder(state.newsItems)
+  return sortByDateInDescendingOrder(state.newsItems)
 })


### PR DESCRIPTION
Jira: [CP-1846]

**Description**
- changed sorting news, now are sorted by date (date that is shown to the user)
- added new check for updating news from online source - if news' dates are different then local data is not valid and we update it :)
- some refactoring


[CP-1846]: https://appnroll.atlassian.net/browse/CP-1846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ