### PR TITLE
[CP-1847] [Messages] Templates order is chronogically inverted between Center and Pure

### DIFF
--- a/packages/app/src/templates/selectors/templates-list.selector.ts
+++ b/packages/app/src/templates/selectors/templates-list.selector.ts
@@ -11,7 +11,7 @@ const templatesSelector = ({ templates }: ReduxRootState) => templates.data
 
 const sortTemplates = (templates: Template[]): Template[] => {
   return [...templates].sort((a, b) => {
-    return a.order && b.order ? a.order - b.order : -1
+    return a.order && b.order ? a.order - b.order : 1
   })
 }
 


### PR DESCRIPTION
Jira: [CP-1847]

Change templates order.

<details>
<summary><b>Screenshots</b></summary>

![image](https://user-images.githubusercontent.com/37898730/227188209-5e768a69-e7d9-41fe-92b6-dc4a1a3c5a0a.png)

</details>
