### PR TITLE
[CP-1933] [File manager] status popup enables Upload button allowing parallel upload attempt

### DIFF
--- a/packages/app/src/files-manager/actions/base.action.test.ts
+++ b/packages/app/src/files-manager/actions/base.action.test.ts
@@ -13,6 +13,7 @@ import {
   setUploadBlocked,
   setDeletingFileCount,
   setUploadingFileCount,
+  resetUploadingStateAfterSuccess,
 } from "App/files-manager/actions/base.action"
 import { FilesManagerEvent } from "App/files-manager/constants"
 
@@ -52,6 +53,18 @@ describe("Action: `resetUploadingState`", () => {
     expect(mockStore.getActions()).toEqual([
       {
         type: FilesManagerEvent.ResetUploadingState,
+        payload: undefined,
+      },
+    ])
+  })
+})
+
+describe("Action: `resetUploadingStateAfterSuccess`", () => {
+  test("dispatch action with provided payload", () => {
+    mockStore.dispatch(resetUploadingStateAfterSuccess())
+    expect(mockStore.getActions()).toEqual([
+      {
+        type: FilesManagerEvent.ResetUploadingStateAfterSuccess,
         payload: undefined,
       },
     ])

--- a/packages/app/src/files-manager/actions/base.action.ts
+++ b/packages/app/src/files-manager/actions/base.action.ts
@@ -19,6 +19,10 @@ export const resetUploadingState = createAction(
   FilesManagerEvent.ResetUploadingState
 )
 
+export const resetUploadingStateAfterSuccess = createAction(
+  FilesManagerEvent.ResetUploadingStateAfterSuccess
+)
+
 export const setUploadingFileCount = createAction<number>(
   FilesManagerEvent.SetUploadingFileCount
 )

--- a/packages/app/src/files-manager/components/files-manager/files-manager.component.tsx
+++ b/packages/app/src/files-manager/components/files-manager/files-manager.component.tsx
@@ -48,6 +48,7 @@ const FilesManager: FunctionComponent<FilesManagerProps> = ({
   deleteFiles,
   resetDeletingState,
   resetUploadingState,
+  resetUploadingStateAfterSuccess,
   uploadingFileCount,
   deletingFileCount,
   uploadBlocked,
@@ -159,7 +160,7 @@ const FilesManager: FunctionComponent<FilesManagerProps> = ({
 
     const hideInfoPopupsTimeout = setTimeout(() => {
       updateFieldState("uploadingInfo", false)
-      resetUploadingState()
+      resetUploadingStateAfterSuccess()
     }, 5000)
 
     return () => {

--- a/packages/app/src/files-manager/components/files-manager/files-manager.interface.tsx
+++ b/packages/app/src/files-manager/components/files-manager/files-manager.interface.tsx
@@ -29,6 +29,7 @@ export interface FilesManagerProps {
   deleteFiles: (ids: string[]) => void
   resetDeletingState: () => void
   resetUploadingState: () => void
+  resetUploadingStateAfterSuccess: () => void
   uploadFile: () => void
   uploadBlocked: boolean
   error: AppError | null

--- a/packages/app/src/files-manager/components/files-manager/files-manager.test.tsx
+++ b/packages/app/src/files-manager/components/files-manager/files-manager.test.tsx
@@ -41,6 +41,7 @@ const defaultProps: Props = {
   deleteFiles: jest.fn(),
   resetDeletingState: jest.fn(),
   resetUploadingState: jest.fn(),
+  resetUploadingStateAfterSuccess: jest.fn(),
   uploadBlocked: false,
   setDeletingFileCount: jest.fn(),
   abortPendingUpload: jest.fn(),

--- a/packages/app/src/files-manager/constants/event.enum.ts
+++ b/packages/app/src/files-manager/constants/event.enum.ts
@@ -14,6 +14,7 @@ export enum FilesManagerEvent {
   SetUploadingState = "FILES_MANAGER_SET_UPLOADING_STATE",
   ResetDeletingState = "FILES_MANAGER_RESET_DELETING_STATE",
   ResetUploadingState = "FILES_MANAGER_RESET_UPLOADING_STATE",
+  ResetUploadingStateAfterSuccess = "FILES_MANAGER_RESET_UPLOADING_STATE_AFTER_SUCCESS",
   SetUploadingFileCount = "FILES_MANAGER_SET_UPLOADING_FILE_COUNT",
   SetUploadBlocked = "FILES_MANAGER_SET_UPLOAD_BLOCKED",
   SetDeletingFileCount = "FILES_MANAGER_SET_DELETING_FILE_COUNT",

--- a/packages/app/src/files-manager/files-manager.container.tsx
+++ b/packages/app/src/files-manager/files-manager.container.tsx
@@ -15,6 +15,7 @@ import {
   resetDeletingState,
   resetUploadingState,
   setDeletingFileCount,
+  resetUploadingStateAfterSuccess,
 } from "App/files-manager/actions"
 import { deleteFiles } from "App/files-manager/actions/delete-files.action"
 import { abortPendingUpload } from "./actions/abort-pending-upload.action"
@@ -47,6 +48,7 @@ const mapDispatchToProps = {
   deleteFiles,
   resetDeletingState,
   resetUploadingState,
+  resetUploadingStateAfterSuccess,
   setDeletingFileCount,
   abortPendingUpload,
   continuePendingUpload,

--- a/packages/app/src/files-manager/reducers/files-manager.reducer.ts
+++ b/packages/app/src/files-manager/reducers/files-manager.reducer.ts
@@ -152,7 +152,6 @@ export const filesManagerReducer = createReducer<FilesManagerState>(
           uploading: State.Initial,
           error: null,
           uploadingFileCount: 0,
-          uploadBlocked: false,
         }
       })
       .addCase(setUploadingFileCount, (state, action) => {

--- a/packages/app/src/files-manager/reducers/files-manager.reducer.ts
+++ b/packages/app/src/files-manager/reducers/files-manager.reducer.ts
@@ -19,6 +19,7 @@ import {
   setUploadBlocked,
   setDeletingFileCount,
   setPendingFilesToUpload,
+  resetUploadingStateAfterSuccess,
 } from "App/files-manager/actions"
 import { changeLocation } from "App/core/actions"
 import { FilesManagerState } from "App/files-manager/reducers/files-manager.interface"
@@ -147,6 +148,15 @@ export const filesManagerReducer = createReducer<FilesManagerState>(
         }
       })
       .addCase(resetUploadingState, (state) => {
+        return {
+          ...state,
+          uploading: State.Initial,
+          error: null,
+          uploadingFileCount: 0,
+          uploadBlocked: false,
+        }
+      })
+      .addCase(resetUploadingStateAfterSuccess, (state) => {
         return {
           ...state,
           uploading: State.Initial,


### PR DESCRIPTION
Jira: [CP-1933]

Action resetUploadingStateAfterSuccess has been added. 

<details>
<summary><b>Screenshots</b></summary>
// put images here
</details>
