### PR TITLE
[CP-1921] [Messages] lack of empty messages screen when deleting empty thread

### DIFF
--- a/packages/app/src/messages/components/messages/messages.component.tsx
+++ b/packages/app/src/messages/components/messages/messages.component.tsx
@@ -160,6 +160,15 @@ const Messages: FunctionComponent<MessagesProps> = ({
   }, [searchPreviewValue, messagesState])
 
   useEffect(() => {
+    const noThreadsToDisplay =
+      threads.length === 0 && !activeThread && !tmpActiveThread
+
+    if (messagesState === MessagesState.ThreadDetails && noThreadsToDisplay) {
+      setMessagesState(MessagesState.List)
+    }
+  }, [messagesState, threads.length, activeThread, tmpActiveThread])
+
+  useEffect(() => {
     messageLayoutNotifications
       .filter(
         (item) => (item.content as Message)?.messageType === MessageType.OUTBOX
@@ -688,6 +697,7 @@ const Messages: FunctionComponent<MessagesProps> = ({
       query: searchPreviewValue,
     })
   }
+
   return (
     <>
       <ContactSelectModal


### PR DESCRIPTION
Jira: [CP-1921]

Covered in e2e test "New thread creation scenarios - no contacts & no threads"

<details>
<summary><b>Screenshots</b></summary>
// put images here
</details>


[CP-1921]: https://appnroll.atlassian.net/browse/CP-1921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ