### PR TITLE
[CP-1877] [Messages] selected contact name isn't displayed above conversation window until message is sent

### DIFF
--- a/packages/app/src/messages/components/messages/messages.component.tsx
+++ b/packages/app/src/messages/components/messages/messages.component.tsx
@@ -525,14 +525,14 @@ const Messages: FunctionComponent<MessagesProps> = ({
   }
 
   const getViewReceiver = (activeThread: Thread): Receiver => {
+    const receiver = getReceiver(activeThread.phoneNumber)
+
     if (activeThread.id === mockThread.id) {
       return {
-        phoneNumber: activeThread.phoneNumber,
+        ...(receiver || { phoneNumber: activeThread.phoneNumber }),
         identification: ReceiverIdentification.unknown,
       }
     }
-
-    const receiver = getReceiver(activeThread.phoneNumber)
 
     if (receiver === undefined) {
       return {


### PR DESCRIPTION
Jira: [CP-1877]

**Description**

<details>
<summary><b>Screenshots</b></summary>

![image](https://user-images.githubusercontent.com/37898730/232757310-8d818227-6f12-4d2c-9b1d-7ab5cd9038cb.png)


</details>


[CP-1877]: https://appnroll.atlassian.net/browse/CP-1877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ