### PR TITLE
[CP-1932] [Tech] All unit tests should run with the development flag

### DIFF
--- a/packages/app/test-envs.js
+++ b/packages/app/test-envs.js
@@ -3,3 +3,5 @@ const path = require("path")
 require("dotenv").config({ path: path.join(__dirname, "../../.env") })
 
 global.__static = path.join(__dirname, "/static").replace(/\\/g, "\\\\")
+
+process.env.FEATURE_TOGGLE_ENVIRONMENT='development'


### PR DESCRIPTION
Jira: [CP-1932]

overwrite FEATURE_TOGGLE_ENVIRONMENT env variable for unit tests

<details>
<summary><b>Screenshots</b></summary>
// put images here
</details>


[CP-1932]: https://appnroll.atlassian.net/browse/CP-1932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ