### PR TITLE
[CP-1957] [Center] [Tech] Add feature toggle to .env to set releases environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,4 +42,5 @@ DISABLE_DEV_REDUX_LOGGER=
 # [Optional] disable device logger during development. Enabled by default, set "1" to disable
 DISABLE_DEV_DEVICE_LOGGER=
 
-
+# [Optional] set desired latest release. Is based on enum OsEnvironment, so can be set to 'production', 'test-production' or 'daily'.
+FEATURE_TOGGLE_LATEST_RELEASE=

--- a/.env.example
+++ b/.env.example
@@ -43,4 +43,4 @@ DISABLE_DEV_REDUX_LOGGER=
 DISABLE_DEV_DEVICE_LOGGER=
 
 # [Optional] set desired latest release. Is based on enum OsEnvironment, so can be set to 'production', 'test-production' or 'daily'.
-FEATURE_TOGGLE_LATEST_RELEASE=
+FEATURE_TOGGLE_RELEASE_ENVIRONMENT=

--- a/packages/app/src/update/services/releases.service.ts
+++ b/packages/app/src/update/services/releases.service.ts
@@ -103,7 +103,7 @@ export class ReleaseService {
     try {
       const release = await this.getRelease(
         product,
-        (process.env.FEATURE_TOGGLE_LATEST_RELEASE as OsEnvironment) ||
+        (process.env.FEATURE_TOGGLE_RELEASE_ENVIRONMENT as OsEnvironment) ||
           OsEnvironment.Production,
         "latest"
       )

--- a/packages/app/src/update/services/releases.service.ts
+++ b/packages/app/src/update/services/releases.service.ts
@@ -103,7 +103,8 @@ export class ReleaseService {
     try {
       const release = await this.getRelease(
         product,
-        OsEnvironment.Production,
+        (process.env.FEATURE_TOGGLE_LATEST_RELEASE as OsEnvironment) ||
+          OsEnvironment.Production,
         "latest"
       )
 


### PR DESCRIPTION
Jira: [CP-1957]

- added toggle for latest release
- wondering about naming this feature toggle differently? Any ideas? Maybe 'FEATURE_TOGGLE_ENV_LATEST_RELEASE'?

[CP-1957]: https://appnroll.atlassian.net/browse/CP-1957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ