### PR TITLE
[CP-1810] [Update] Too long timeout for update availablility check when losing network connection

### DIFF
--- a/packages/app/src/__deprecated__/api/mudita-center-server/client.ts
+++ b/packages/app/src/__deprecated__/api/mudita-center-server/client.ts
@@ -25,12 +25,13 @@ export interface getLatestProductionReleaseParams {
 export class Client implements ClientInterface {
   private httpClient: AxiosInstance
 
-  constructor() {
+  constructor(timeout?: number) {
     this.httpClient = axios.create({
       baseURL: process.env.MUDITA_CENTER_SERVER_URL as string,
       httpsAgent: new https.Agent({
         rejectUnauthorized: false,
       }),
+      timeout,
     })
   }
 

--- a/packages/app/src/__deprecated__/api/mudita-center-server/create-client.ts
+++ b/packages/app/src/__deprecated__/api/mudita-center-server/create-client.ts
@@ -5,6 +5,4 @@
 
 import { Client } from "App/__deprecated__/api/mudita-center-server/client"
 
-// AUTO DISABLED - fix me if you like :)
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export const createClient = () => new Client()
+export const createClient = (timeout?: number): Client => new Client(timeout)

--- a/packages/app/src/update/actions/check-for-update/check-for-update.action.ts
+++ b/packages/app/src/update/actions/check-for-update/check-for-update.action.ts
@@ -62,8 +62,10 @@ export const checkForUpdate = createAsyncThunk<Result, Params>(
       )
     }
 
-    const latestReleaseResult = await getLatestReleaseRequest(product)
-    const allReleasesResult = await getAllReleasesRequest(product)
+    const [latestReleaseResult, allReleasesResult] = await Promise.all([
+      getLatestReleaseRequest(product),
+      getAllReleasesRequest(product),
+    ])
 
     if (!latestReleaseResult.ok || !latestReleaseResult.data) {
       return rejectWithValue(

--- a/packages/app/src/update/constants/get-release-timeout.constant.ts
+++ b/packages/app/src/update/constants/get-release-timeout.constant.ts
@@ -1,0 +1,7 @@
+/**
+ * Copyright (c) Mudita sp. z o.o. All rights reserved.
+ * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
+ */
+
+export const SECOND_IN_MILIS = 1000
+export const GET_RELEASE_TIMEOUT = 60 * SECOND_IN_MILIS

--- a/packages/app/src/update/services/releases.service.ts
+++ b/packages/app/src/update/services/releases.service.ts
@@ -18,8 +18,9 @@ import {
 } from "App/update/constants"
 import { GithubReleasePresenter } from "App/update/presenters"
 
-const releaseSpace = (process.env.FEATURE_TOGGLE_RELEASE_ENVIRONMENT as OsEnvironment) ||
-    OsEnvironment.Production
+const releaseSpace =
+  (process.env.FEATURE_TOGGLE_RELEASE_ENVIRONMENT as OsEnvironment) ||
+  OsEnvironment.Production
 
 export class ReleaseService {
   constructor(private client: ReturnType<typeof createClient>) {}
@@ -104,11 +105,7 @@ export class ReleaseService {
     product: Product
   ): Promise<ResultObject<OsRelease | undefined>> {
     try {
-      const release = await this.getRelease(
-        product,
-        releaseSpace,
-        "latest"
-      )
+      const release = await this.getRelease(product, releaseSpace, "latest")
 
       return Result.success(GithubReleasePresenter.toRelease(release))
     } catch (error) {

--- a/packages/app/src/update/update.module.ts
+++ b/packages/app/src/update/update.module.ts
@@ -24,6 +24,7 @@ import {
 } from "App/update/controllers"
 import { DeviceManager } from "App/device-manager/services"
 import { DeviceInfoService } from "App/device-info/services"
+import { GET_RELEASE_TIMEOUT } from "App/update/constants/get-release-timeout.constant"
 
 export class UpdateModule extends BaseModule {
   constructor(
@@ -58,7 +59,7 @@ export class UpdateModule extends BaseModule {
       new DeviceInfoService(this.deviceManager)
     )
     const deviceUpdateFilesService = new DeviceUpdateFilesService()
-    const releaseService = new ReleaseService(createClient())
+    const releaseService = new ReleaseService(createClient(GET_RELEASE_TIMEOUT))
     const releasesController = new ReleasesController(releaseService)
     const deviceUpdateController = new DeviceUpdateController(
       deviceUpdateService,


### PR DESCRIPTION
Jira: [CP-1810]

**Description**
- added timeout of 60 seconds for checking for updates
- changed sequential requests to parallel with Promise.all