### PR TITLE
[CP-1861][Sequential update] Disconnected device at 100% of first OS download does not interupt the force update process

### DIFF
--- a/packages/app/src/overview/components/overview-screens/helpers/use-update-flow-state.hook.tsx
+++ b/packages/app/src/overview/components/overview-screens/helpers/use-update-flow-state.hook.tsx
@@ -79,7 +79,6 @@ export const useUpdateFlowState = ({
       setCheckForUpdateLocalState(CheckForUpdateLocalState.Loaded)
     }
   }, [silentCheckForUpdateState, checkingForUpdateState, forceUpdateNeeded])
-  console.log(checkForUpdateLocalState)
   return {
     checkForUpdateLocalState,
   }

--- a/packages/app/src/update/actions/base.action.ts
+++ b/packages/app/src/update/actions/base.action.ts
@@ -24,3 +24,6 @@ export const setStateForInstalledRelease = createAction<{
   version: string
   state: ReleaseProcessState
 }>(UpdateOsEvent.SetStateForInstalledRelease)
+export const setDeviceHasBeenDetachedDuringDownload = createAction<boolean>(
+  UpdateOsEvent.DeviceHasBeenDetachedDuringDownload
+)

--- a/packages/app/src/update/actions/download-updates/download-updates.action.test.ts
+++ b/packages/app/src/update/actions/download-updates/download-updates.action.test.ts
@@ -74,6 +74,9 @@ describe("when battery is lower than 40%", () => {
           batteryLevel: 0.39,
         },
       },
+      update: {
+        deviceHasBeenDetachedDuringDownload: false,
+      },
     })
 
     const {
@@ -110,6 +113,9 @@ describe("when some of the updates have been downloaded before", () => {
         data: {
           batteryLevel: 0.55,
         },
+      },
+      update: {
+        deviceHasBeenDetachedDuringDownload: false,
       },
     })
 
@@ -168,6 +174,9 @@ describe("when update downloads successfully", () => {
         data: {
           batteryLevel: 0.55,
         },
+      },
+      update: {
+        deviceHasBeenDetachedDuringDownload: false,
       },
     })
 

--- a/packages/app/src/update/actions/download-updates/download-updates.action.ts
+++ b/packages/app/src/update/actions/download-updates/download-updates.action.ts
@@ -35,8 +35,8 @@ export const downloadUpdates = createAsyncThunk<
 >(
   UpdateOsEvent.DownloadUpdate,
   async ({ releases }, { getState, rejectWithValue, dispatch }) => {
-    const { device } = getState() as RootState & ReduxRootState
-    const batteryLevel = device.data?.batteryLevel ?? 0
+    let state = getState() as RootState & ReduxRootState
+    const batteryLevel = state.device.data?.batteryLevel ?? 0
 
     if (!isBatteryLevelEnoughForUpdate(batteryLevel)) {
       return rejectWithValue(
@@ -89,6 +89,16 @@ export const downloadUpdates = createAsyncThunk<
           state: ReleaseProcessState.Done,
           version: release.version,
         })
+      )
+    }
+    state = getState() as RootState & ReduxRootState
+
+    if (state.update.deviceHasBeenDetachedDuringDownload) {
+      return rejectWithValue(
+        new AppError(
+          UpdateError.UnexpectedDownloadError,
+          "Unexpected error while downloading update"
+        )
       )
     }
 

--- a/packages/app/src/update/actions/handle-device-detached/handle-device-detached.action.ts
+++ b/packages/app/src/update/actions/handle-device-detached/handle-device-detached.action.ts
@@ -7,13 +7,15 @@ import { createAsyncThunk } from "@reduxjs/toolkit"
 import { DownloadState, UpdateOsEvent } from "App/update/constants"
 import { cancelOsDownload } from "App/update/requests"
 import { ReduxRootState, RootState } from "App/__deprecated__/renderer/store"
+import { setDeviceHasBeenDetachedDuringDownload } from "../base.action"
 
 export const handleDeviceDetached = createAsyncThunk<void, void>(
   UpdateOsEvent.HandleDeviceDetached,
-  (_, { getState }) => {
+  (_, { getState, dispatch }) => {
     const { update } = getState() as RootState & ReduxRootState
 
     if (update.downloadState === DownloadState.Loading) {
+      dispatch(setDeviceHasBeenDetachedDuringDownload(true))
       cancelOsDownload(true)
     }
   }

--- a/packages/app/src/update/constants/event.constant.ts
+++ b/packages/app/src/update/constants/event.constant.ts
@@ -18,5 +18,5 @@ export enum UpdateOsEvent {
   CheckForForceUpdate = "CHECK_FOR_FORCE_UPDATE",
   StartOsForceUpdateProcess = "START_OS_FORCE_UPDATE_PROCESS",
   CloseForceUpdateFlow = "CLOSE_FORCE_UPDATE_FLOW",
-  DeviceHasBeenDetachedDuringDownload = "DOWNLOAD_DEVICE_DETACHED",
+  DeviceHasBeenDetachedDuringDownload = "DEVICE_HAS_BEEN_DETACHED_DURING_DOWNLOAD",
 }

--- a/packages/app/src/update/constants/event.constant.ts
+++ b/packages/app/src/update/constants/event.constant.ts
@@ -18,4 +18,5 @@ export enum UpdateOsEvent {
   CheckForForceUpdate = "CHECK_FOR_FORCE_UPDATE",
   StartOsForceUpdateProcess = "START_OS_FORCE_UPDATE_PROCESS",
   CloseForceUpdateFlow = "CLOSE_FORCE_UPDATE_FLOW",
+  DeviceHasBeenDetachedDuringDownload = "DOWNLOAD_DEVICE_DETACHED",
 }

--- a/packages/app/src/update/reducers/update-os.interface.ts
+++ b/packages/app/src/update/reducers/update-os.interface.ts
@@ -22,6 +22,7 @@ export interface UpdateOsState {
   error: AppError<UpdateError> | null
   needsForceUpdate: boolean
   checkedForForceUpdateNeed: boolean
+  deviceHasBeenDetachedDuringDownload: boolean
   data: {
     allReleases: OsRelease[] | null
     availableReleasesForUpdate: OsRelease[] | null

--- a/packages/app/src/update/reducers/update-os.reducer.test.ts
+++ b/packages/app/src/update/reducers/update-os.reducer.test.ts
@@ -55,6 +55,7 @@ test("empty event returns initial state", () => {
         "downloadedProcessedReleases": null,
         "updateProcessedReleases": null,
       },
+      "deviceHasBeenDetachedDuringDownload": false,
       "downloadState": 0,
       "error": null,
       "forceUpdateState": 0,


### PR DESCRIPTION
Jira: [CP-1861]

** Fix for update not aborting after device was unplugged during sequential update first completed os download **



[CP-1861]: https://appnroll.atlassian.net/browse/CP-1861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ