### PR TITLE
[CP-2016] [SOSU] Sequential update for Harmony displays download progress while for Pure doesn't

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -6,7 +6,6 @@ addAssignees: author
 
 # A list of reviewers to be added to pull requests (GitHub user name)
 reviewers:
-  - dkarski
   - lkowalczyk87
   - patryk-sierzega
   - OskarMichalkiewicz

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,9 @@ Jira: [CP-XXX]
 
 **Description**
 
+- [ ] getState function in async thunk actions is correctly typed
+- [ ] redux selectors are used in components / prop drilling is reduce
+
 <details>
 <summary><b>Screenshots</b></summary>
 // put images here

--- a/packages/app/src/__deprecated__/main/main.ts
+++ b/packages/app/src/__deprecated__/main/main.ts
@@ -164,6 +164,12 @@ const createWindow = async () => {
     })
   )
 
+  win.webContents.on("before-input-event", (event, input) => {
+    if ((input.control || input.meta) && input.key.toLowerCase() === "r") {
+      event.preventDefault()
+    }
+  })
+
   win.on("closed", () => {
     win = null
     app.exit()

--- a/packages/app/src/overview/components/overview-screens/pure-overview/pure-overview.component.tsx
+++ b/packages/app/src/overview/components/overview-screens/pure-overview/pure-overview.component.tsx
@@ -224,29 +224,27 @@ export const PureOverview: FunctionComponent<PureOverviewProps> = ({
 
   return (
     <>
-      {!forceUpdateNeeded && (
-        <UpdateOsFlow
-          deviceType={DeviceType.MuditaPure}
-          currentOsVersion={osVersion}
-          silentCheckForUpdateState={silentCheckForUpdateState}
-          checkForUpdateState={checkingForUpdateState}
-          availableReleasesForUpdate={availableReleasesForUpdate}
-          areAllReleasesDownloaded={areAllReleasesDownloaded}
-          downloadState={downloadingState}
-          tryAgainCheckForUpdate={tryAgainPureUpdate}
-          clearUpdateOsFlow={clearUpdateState}
-          downloadUpdates={downloadReleases}
-          abortDownloading={abortDownload}
-          updateState={updatingState}
-          updateOs={updateReleases}
-          openContactSupportFlow={openContactSupportFlow}
-          allReleases={allReleases}
-          openHelpView={goToHelp}
-          error={updateOsError}
-          downloadingReleasesProcessStates={downloadingReleasesProcessStates}
-          updatingReleasesProcessStates={updatingReleasesProcessStates}
-        />
-      )}
+      <UpdateOsFlow
+        deviceType={DeviceType.MuditaPure}
+        currentOsVersion={osVersion}
+        silentCheckForUpdateState={silentCheckForUpdateState}
+        checkForUpdateState={checkingForUpdateState}
+        availableReleasesForUpdate={availableReleasesForUpdate}
+        areAllReleasesDownloaded={areAllReleasesDownloaded}
+        downloadState={downloadingState}
+        tryAgainCheckForUpdate={tryAgainPureUpdate}
+        clearUpdateOsFlow={clearUpdateState}
+        downloadUpdates={downloadReleases}
+        abortDownloading={abortDownload}
+        updateState={updatingState}
+        updateOs={updateReleases}
+        openContactSupportFlow={openContactSupportFlow}
+        allReleases={allReleases}
+        openHelpView={goToHelp}
+        error={updateOsError}
+        downloadingReleasesProcessStates={downloadingReleasesProcessStates}
+        updatingReleasesProcessStates={updatingReleasesProcessStates}
+      />
 
       {flags.get(Feature.ForceUpdate) && (
         <UpdatingForceModalFlow

--- a/packages/app/src/update/actions/download-updates/download-updates.action.ts
+++ b/packages/app/src/update/actions/download-updates/download-updates.action.ts
@@ -21,7 +21,7 @@ import {
   downloadOsUpdateRequest,
   osUpdateAlreadyDownloadedCheck,
 } from "App/update/requests"
-import { ReduxRootState, RootState } from "App/__deprecated__/renderer/store"
+import { ReduxRootState } from "App/__deprecated__/renderer/store"
 import { RELEASE_SPACE } from "App/update/constants/release-space.constant"
 
 interface Params {

--- a/packages/app/src/update/actions/download-updates/download-updates.action.ts
+++ b/packages/app/src/update/actions/download-updates/download-updates.action.ts
@@ -32,12 +32,13 @@ export const downloadUpdates = createAsyncThunk<
   void,
   Params,
   {
+    state: ReduxRootState
     rejectValue: AppError<UpdateError>
   }
 >(
   UpdateOsEvent.DownloadUpdate,
   async ({ releases }, { getState, rejectWithValue, dispatch }) => {
-    let state = (await getState()) as RootState & ReduxRootState
+    let state = getState()
     const batteryLevel = state.device.data?.batteryLevel ?? 0
 
     if (!isBatteryLevelEnoughForUpdate(batteryLevel)) {
@@ -50,7 +51,7 @@ export const downloadUpdates = createAsyncThunk<
     }
 
     for (const release of releases) {
-      state = (await getState()) as RootState & ReduxRootState
+      state = getState()
 
       if (state.update.deviceHasBeenDetachedDuringDownload) {
         return rejectWithValue(
@@ -103,7 +104,7 @@ export const downloadUpdates = createAsyncThunk<
             )
           )
         }
-        state = (await getState()) as RootState & ReduxRootState
+        state = getState()
 
         if (state.update.deviceHasBeenDetachedDuringDownload) {
           return rejectWithValue(

--- a/packages/app/src/update/actions/force-update/force-update.action.ts
+++ b/packages/app/src/update/actions/force-update/force-update.action.ts
@@ -10,12 +10,17 @@ import { startUpdateOs } from "App/update/actions/start-update-os/start-update-o
 import { UpdateError, UpdateOsEvent } from "App/update/constants"
 import { OsRelease } from "App/update/dto"
 import { rejectedAction } from "App/__deprecated__/renderer/store/helpers/action.helper"
+import { ReduxRootState } from "App/__deprecated__/renderer/store"
 
 interface Params {
   releases: OsRelease[]
 }
 
-export const forceUpdate = createAsyncThunk<void, Params>(
+export const forceUpdate = createAsyncThunk<
+  void,
+  Params,
+  { state: ReduxRootState }
+>(
   UpdateOsEvent.StartOsForceUpdateProcess,
   async ({ releases }, { dispatch, rejectWithValue }) => {
     const downloadUpdate = await dispatch(downloadUpdates({ releases }))

--- a/packages/app/src/update/actions/start-update-os/start-update-os.action.ts
+++ b/packages/app/src/update/actions/start-update-os/start-update-os.action.ts
@@ -45,13 +45,14 @@ export const startUpdateOs = createAsyncThunk<
   void,
   Params,
   {
+    state: ReduxRootState
     rejectValue: AppError<UpdateError>
   }
 >(
   UpdateOsEvent.StartOsUpdateProcess,
   async ({ releases }, { dispatch, rejectWithValue, getState }) => {
     void setUpdatingRequest(true)
-    let state = (await getState()) as RootState & ReduxRootState
+    let state = getState()
     const batteryLevel = state.device.data?.batteryLevel ?? 0
     const deviceType = state.device.deviceType
 
@@ -73,7 +74,7 @@ export const startUpdateOs = createAsyncThunk<
     await dispatch(removeFile(DiagnosticsFilePath.UPDATER_LOG))
 
     for (const release of releases) {
-      state = (await getState()) as RootState & ReduxRootState
+      state = getState()
 
       const trackOsUpdateOptions: Omit<TrackOsUpdateOptions, "state"> = {
         deviceType,

--- a/packages/app/src/update/actions/start-update-os/start-update-os.action.ts
+++ b/packages/app/src/update/actions/start-update-os/start-update-os.action.ts
@@ -17,7 +17,7 @@ import {
 import { OsRelease } from "App/update/dto"
 import { isBatteryLevelEnoughForUpdate } from "App/update/helpers"
 import { removeDownloadedOsUpdates, startOsUpdate } from "App/update/requests"
-import { ReduxRootState, RootState } from "App/__deprecated__/renderer/store"
+import { ReduxRootState } from "App/__deprecated__/renderer/store"
 import { setUpdatingRequest } from "App/device/requests/set-updating.request"
 import {
   trackOsUpdate,


### PR DESCRIPTION
Jira: [CP-2016]

**Description**

- [x] getState function in async thunk actions is correctly typed
- [ ] redux selectors are used in components / prop drilling is reduce



[CP-2016]: https://appnroll.atlassian.net/browse/CP-2016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ