### PR TITLE
[CP-2094] No Events about Harmony 1.5.1, 1.8.2, 1.9.0 and 2.0.0 are sent to Matomo.

### DIFF
--- a/packages/app/src/device-manager/actions/get-current-device.action.ts
+++ b/packages/app/src/device-manager/actions/get-current-device.action.ts
@@ -8,18 +8,20 @@ import { connectDevice } from "App/device/actions"
 import { DeviceManagerEvent } from "App/device-manager/constants"
 import { readAllIndexes, setDataSyncInitialized } from "App/data-sync/actions"
 import { getCurrentDeviceRequest } from "App/device-manager/requests"
+import { ReduxRootState } from "App/__deprecated__/renderer/store"
 
-export const getCurrentDevice = createAsyncThunk(
-  DeviceManagerEvent.GetCurrentDevice,
-  async (_, { dispatch }) => {
-    const { ok, data } = await getCurrentDeviceRequest()
+export const getCurrentDevice = createAsyncThunk<
+  void,
+  void,
+  { state: ReduxRootState }
+>(DeviceManagerEvent.GetCurrentDevice, async (_, { dispatch }) => {
+  const { ok, data } = await getCurrentDeviceRequest()
 
-    if (!ok || !data) {
-      return
-    }
-
-    void dispatch(connectDevice(data.deviceType))
-    void dispatch(readAllIndexes())
-    dispatch(setDataSyncInitialized())
+  if (!ok || !data) {
+    return
   }
-)
+
+  void dispatch(connectDevice(data.deviceType))
+  void dispatch(readAllIndexes())
+  dispatch(setDataSyncInitialized())
+})

--- a/packages/app/src/device/actions/base.action.ts
+++ b/packages/app/src/device/actions/base.action.ts
@@ -33,3 +33,7 @@ export const unlockedDevice = createAction<boolean | undefined>(
 export const setCriticalBatteryLevel = createAction<boolean>(
   DeviceEvent.CriticalBatteryLevel
 )
+
+export const setExternalUsageDevice = createAction<boolean>(
+  DeviceEvent.ExternalUsageDevice
+)

--- a/packages/app/src/device/actions/connect-device.action.ts
+++ b/packages/app/src/device/actions/connect-device.action.ts
@@ -16,10 +16,12 @@ import {
   DeviceEvent,
 } from "App/device/constants"
 import { connectDeviceRequest } from "App/device/requests"
+import { ReduxRootState } from "App/__deprecated__/renderer/store"
 
 export const connectDevice = createAsyncThunk<
   DeviceType | undefined,
-  DeviceType
+  DeviceType,
+  { state: ReduxRootState }
 >(DeviceEvent.Connected, async (payload, { dispatch, rejectWithValue }) => {
   const data = await connectDeviceRequest()
 

--- a/packages/app/src/device/actions/load-device-data.action.test.ts
+++ b/packages/app/src/device/actions/load-device-data.action.test.ts
@@ -8,7 +8,7 @@ import thunk from "redux-thunk"
 import { Result } from "App/core/builder"
 import { AnyAction } from "@reduxjs/toolkit"
 import { ConnectionState, DeviceError } from "App/device/constants"
-import { loadDeviceData } from "App/device/actions"
+import { loadDeviceData, setExternalUsageDevice } from "App/device/actions"
 import { PureDeviceData, HarmonyDeviceData } from "App/device/reducers"
 import { testError } from "App/__deprecated__/renderer/store/constants"
 import { AppError } from "App/core/errors"
@@ -95,6 +95,7 @@ describe("Device type: MuditaPure", () => {
 
       expect(mockStore.getActions()).toEqual([
         loadDeviceData.pending(requestId),
+        setExternalUsageDevice(true),
         {
           type: "DEVICE_SET_DATA",
           payload: {
@@ -190,6 +191,7 @@ describe("Device type: MuditaHarmony", () => {
 
       expect(mockStore.getActions()).toEqual([
         loadDeviceData.pending(requestId),
+        setExternalUsageDevice(true),
         {
           type: "DEVICE_SET_DATA",
           payload: {

--- a/packages/app/src/device/actions/load-device-data.action.ts
+++ b/packages/app/src/device/actions/load-device-data.action.ts
@@ -21,60 +21,61 @@ import { trackOsVersion } from "App/analytic-data-tracker/helpers"
 import { externalUsageDevice } from "App/device/requests/external-usage-device.request"
 import { setExternalUsageDeviceRequest } from "App/analytic-data-tracker/requests/set-external-usage-device.request"
 
-export const loadDeviceData = createAsyncThunk(
-  DeviceEvent.Loading,
-  async (_, { getState, dispatch, rejectWithValue }) => {
-    const state = getState() as ReduxRootState
+export const loadDeviceData = createAsyncThunk<
+  undefined,
+  void,
+  { state: ReduxRootState }
+>(DeviceEvent.Loading, async (_, { getState, dispatch, rejectWithValue }) => {
+  const state = getState()
 
-    if (state.device.state === ConnectionState.Loaded) {
+  if (state.device.state === ConnectionState.Loaded) {
+    return
+  }
+
+  try {
+    const { ok, data, error } = await getDeviceInfoRequest()
+
+    if (!ok || !data) {
+      if (error?.type === DeviceCommunicationError.DeviceLocked) {
+        void dispatch(lockedDevice())
+      }
+
       return
     }
 
-    try {
-      const { ok, data, error } = await getDeviceInfoRequest()
-
-      if (!ok || !data) {
-        if (error?.type === DeviceCommunicationError.DeviceLocked) {
-          void dispatch(lockedDevice())
-        }
-
-        return
-      }
-
-      if (state.device.deviceType !== null) {
-        void trackOsVersion({
-          serialNumber: data.serialNumber,
-          osVersion: data.osVersion,
-          deviceType: state.device.deviceType,
-        })
-      }
-      void setValue({
-        key: MetadataKey.DeviceOsVersion,
-        value: data.osVersion ?? null,
+    if (state.device.deviceType !== null) {
+      void trackOsVersion({
+        serialNumber: data.serialNumber,
+        osVersion: data.osVersion,
+        deviceType: state.device.deviceType,
       })
-      void setValue({
-        key: MetadataKey.DeviceType,
-        value: state.device.deviceType,
-      })
-
-      if (
-        data.serialNumber !== state.device.data?.serialNumber ||
-        state.device.externalUsageDevice === null
-      ) {
-        const resultExternalUsageDevice = state.settings.privacyPolicyAccepted
-          ? await externalUsageDevice(data.serialNumber)
-          : false
-
-        await setExternalUsageDeviceRequest(resultExternalUsageDevice)
-        if (state.settings.privacyPolicyAccepted !== undefined) {
-          dispatch(setExternalUsageDevice(resultExternalUsageDevice))
-        }
-      }
-      dispatch(setDeviceData(data))
-    } catch (error) {
-      return rejectWithValue(error)
     }
+    void setValue({
+      key: MetadataKey.DeviceOsVersion,
+      value: data.osVersion ?? null,
+    })
+    void setValue({
+      key: MetadataKey.DeviceType,
+      value: state.device.deviceType,
+    })
 
-    return
+    if (
+      data.serialNumber !== state.device.data?.serialNumber ||
+      state.device.externalUsageDevice === null
+    ) {
+      const resultExternalUsageDevice = state.settings.privacyPolicyAccepted
+        ? await externalUsageDevice(data.serialNumber)
+        : false
+
+      await setExternalUsageDeviceRequest(resultExternalUsageDevice)
+      if (state.settings.privacyPolicyAccepted !== undefined) {
+        dispatch(setExternalUsageDevice(resultExternalUsageDevice))
+      }
+    }
+    dispatch(setDeviceData(data))
+  } catch (error) {
+    return rejectWithValue(error)
   }
-)
+
+  return
+})

--- a/packages/app/src/device/actions/load-device-data.action.ts
+++ b/packages/app/src/device/actions/load-device-data.action.ts
@@ -10,7 +10,10 @@ import {
   DeviceCommunicationError,
 } from "App/device/constants"
 import { ReduxRootState } from "App/__deprecated__/renderer/store"
-import { setDeviceData } from "App/device/actions/base.action"
+import {
+  setDeviceData,
+  setExternalUsageDevice,
+} from "App/device/actions/base.action"
 import { lockedDevice } from "App/device/actions/locked-device.action"
 import { getDeviceInfoRequest } from "App/device-info/requests"
 import { setValue, MetadataKey } from "App/metadata"
@@ -54,12 +57,18 @@ export const loadDeviceData = createAsyncThunk(
         value: state.device.deviceType,
       })
 
-      if (data.serialNumber !== state.device.data?.serialNumber) {
+      if (
+        data.serialNumber !== state.device.data?.serialNumber ||
+        state.device.externalUsageDevice === null
+      ) {
         const resultExternalUsageDevice = state.settings.privacyPolicyAccepted
           ? await externalUsageDevice(data.serialNumber)
           : false
 
         await setExternalUsageDeviceRequest(resultExternalUsageDevice)
+        if (state.settings.privacyPolicyAccepted !== undefined) {
+          dispatch(setExternalUsageDevice(resultExternalUsageDevice))
+        }
       }
       dispatch(setDeviceData(data))
     } catch (error) {

--- a/packages/app/src/device/actions/unlock-device.action.ts
+++ b/packages/app/src/device/actions/unlock-device.action.ts
@@ -12,27 +12,28 @@ import { AppError } from "App/core/errors"
 // DEPRECATED
 import { ReduxRootState } from "App/__deprecated__/renderer/store"
 
-export const unlockDevice = createAsyncThunk<boolean, number[]>(
-  DeviceEvent.Unlock,
-  async (code, { rejectWithValue, dispatch, getState }) => {
-    const data = await unlockDeviceRequest(code)
+export const unlockDevice = createAsyncThunk<
+  boolean,
+  number[],
+  { state: ReduxRootState }
+>(DeviceEvent.Unlock, async (code, { rejectWithValue, dispatch, getState }) => {
+  const data = await unlockDeviceRequest(code)
 
-    const state = getState() as ReduxRootState
+  const state = getState()
 
-    if (!data.ok) {
-      return rejectWithValue(
-        new AppError(
-          DeviceError.Unlocking,
-          "Something went wrong during unlocking",
-          data
-        )
+  if (!data.ok) {
+    return rejectWithValue(
+      new AppError(
+        DeviceError.Unlocking,
+        "Something went wrong during unlocking",
+        data
       )
-    }
-
-    // AUTO DISABLED - fix me if you like :)
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    void dispatch(connectDevice(state.device.deviceType!))
-
-    return Boolean(data.data)
+    )
   }
-)
+
+  // AUTO DISABLED - fix me if you like :)
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  void dispatch(connectDevice(state.device.deviceType!))
+
+  return Boolean(data.data)
+})

--- a/packages/app/src/device/reducers/device.interface.ts
+++ b/packages/app/src/device/reducers/device.interface.ts
@@ -54,6 +54,7 @@ export interface DeviceState {
     criticalBatteryLevel: boolean
   }
   error: Error | string | null
+  externalUsageDevice: boolean | null
 }
 
 export interface OsVersionPayload {

--- a/packages/app/src/device/reducers/device.reducer.test.ts
+++ b/packages/app/src/device/reducers/device.reducer.test.ts
@@ -487,6 +487,7 @@ describe("`LoadStorageInfo` functionality", () => {
         },
         "deviceType": null,
         "error": null,
+        "externalUsageDevice": null,
         "state": 2,
         "status": Object {
           "agreementAccepted": true,

--- a/packages/app/src/device/reducers/device.reducer.ts
+++ b/packages/app/src/device/reducers/device.reducer.ts
@@ -29,6 +29,7 @@ import {
 import {
   setAgreementStatus,
   setCriticalBatteryLevel,
+  setExternalUsageDevice,
   unlockedDevice,
 } from "App/device/actions/base.action"
 
@@ -45,6 +46,7 @@ export const initialState: DeviceState = {
   },
   state: ConnectionState.Empty,
   error: null,
+  externalUsageDevice: null,
 }
 
 export const deviceReducer = createReducer<DeviceState>(
@@ -70,6 +72,7 @@ export const deviceReducer = createReducer<DeviceState>(
             loaded: false,
           },
           error: null,
+          externalUsageDevice: null,
         }
       })
       .addCase(
@@ -107,6 +110,7 @@ export const deviceReducer = createReducer<DeviceState>(
           ...state,
           state: ConnectionState.Loading,
           error: null,
+          externalUsageDevice: null,
         }
       })
       .addCase(fulfilledAction(DeviceEvent.Disconnected), (state) => {
@@ -304,6 +308,9 @@ export const deviceReducer = createReducer<DeviceState>(
 
       .addCase(setCriticalBatteryLevel, (state, action) => {
         state.status.criticalBatteryLevel = action.payload
+      })
+      .addCase(setExternalUsageDevice, (state, action) => {
+        state.externalUsageDevice = action.payload
       })
   }
 )


### PR DESCRIPTION
Jira: [CP-2094]

**Description**

- [ ] getState function in async thunk actions is correctly typed
- [x] redux selectors are used in components / prop drilling is reduce

<details>
<summary><b>Screenshots</b></summary>
// put images here
</details>


[CP-2094]: https://appnroll.atlassian.net/browse/CP-2094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ