### PR TITLE
[CP-2098] We do not store downloaded builds for Harmony in a suitable folder; everything is stored in the Pure's folder.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8699,6 +8699,5 @@
       "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
       "dev": true
     }
-  },
-  "version": "2.0.2-rc.3"
+  }
 }

--- a/packages/app/src/settings/store/schemas/settings.schema.ts
+++ b/packages/app/src/settings/store/schemas/settings.schema.ts
@@ -84,7 +84,7 @@ export const settingsSchema: Schema<Settings> = {
   },
   osDownloadLocation: {
     type: "string",
-    default: path.join(getAppPath(), "pure", "os", "downloads"),
+    default: path.join(getAppPath(), "os", "downloads"),
   },
   language: {
     type: "string",


### PR DESCRIPTION
Jira: [CP-2098]

**Description**

- [ ] getState function in async thunk actions is correctly typed
- [ ] redux selectors are used in components / prop drilling is reduce

<details>
<summary><b>Screenshots</b></summary>
// put images here
</details>
