### PR TITLE
[CP-2085] Uploading file larger than 2GB displays an error - instead of message "The file is too large for upload - max size is 2gb"

### DIFF
--- a/packages/app/src/files-manager/actions/upload-file.action.ts
+++ b/packages/app/src/files-manager/actions/upload-file.action.ts
@@ -137,11 +137,11 @@ export const uploadFile = createAsyncThunk<
       filePaths,
     })
 
-    void dispatch(getFiles(directory))
-
     if (!result.ok) {
       return rejectWithValue(result.error)
     }
+
+    void dispatch(getFiles(directory))
 
     void dispatch(loadStorageInfoAction())
     dispatch(setUploadingState(State.Loaded))

--- a/packages/app/src/files-manager/actions/upload-file.action.ts
+++ b/packages/app/src/files-manager/actions/upload-file.action.ts
@@ -137,11 +137,11 @@ export const uploadFile = createAsyncThunk<
       filePaths,
     })
 
+    void dispatch(getFiles(directory))
+
     if (!result.ok) {
       return rejectWithValue(result.error)
     }
-
-    void dispatch(getFiles(directory))
 
     void dispatch(loadStorageInfoAction())
     dispatch(setUploadingState(State.Loaded))

--- a/packages/app/src/files-manager/reducers/files-manager.reducer.ts
+++ b/packages/app/src/files-manager/reducers/files-manager.reducer.ts
@@ -52,6 +52,7 @@ export const filesManagerReducer = createReducer<FilesManagerState>(
         return {
           ...state,
           loading: State.Loading,
+          error: null,
         }
       })
       .addCase(getFiles.fulfilled, (state, action) => {
@@ -59,7 +60,6 @@ export const filesManagerReducer = createReducer<FilesManagerState>(
           ...state,
           loading: State.Loaded,
           files: action.payload,
-          error: null,
         }
       })
       .addCase(getFiles.rejected, (state, action) => {


### PR DESCRIPTION
Jira: [CP-2085]

**Description**

- [ ] getState function in async thunk actions is correctly typed
- [ ] redux selectors are used in components / prop drilling is reduce

<details>
<summary><b>Screenshots</b></summary>
// put images here
</details>


[CP-2085]: https://appnroll.atlassian.net/browse/CP-2085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ