### PR TITLE
[CP-2131] [Settings] [About] Switching to online causes out-of-date modals and wrong badges statuses

### DIFF
--- a/packages/app/src/settings/components/about/about-ui.component.tsx
+++ b/packages/app/src/settings/components/about/about-ui.component.tsx
@@ -28,6 +28,7 @@ import { AppUpdateNotAvailable } from "App/__deprecated__/renderer/wrappers/app-
 import { UpdateFailedModal } from "App/settings/components/about/update-failed-modal.component"
 import { AboutLoaderModal } from "App/settings/components/about/about-loader.component"
 import { ModalLayers } from "App/modals-manager/constants/modal-layers.enum"
+import { useOnlineChecker } from "App/settings/hooks/use-online-checker"
 
 const AvailableUpdate = styled(Text)`
   margin-top: 0.8rem;
@@ -85,6 +86,8 @@ const AboutUI: FunctionComponent<Props> = ({
   appUpdateFailedShow,
   hideAppUpdateFailed,
 }) => {
+  const online = useOnlineChecker()
+
   return (
     <>
       <UpdateFailedModal
@@ -98,7 +101,7 @@ const AboutUI: FunctionComponent<Props> = ({
       />
       <AppUpdateNotAvailable
         appCurrentVersion={appCurrentVersion}
-        open={appUpdateNotAvailableShow && window.navigator.onLine}
+        open={appUpdateNotAvailableShow && online}
         closeModal={hideAppUpdateNotAvailable}
         layer={ModalLayers.UpdateApp}
       />
@@ -112,7 +115,7 @@ const AboutUI: FunctionComponent<Props> = ({
               />
             </SettingsLabel>
           </Data>
-          {!window.navigator.onLine && (
+          {!online && (
             <ActionContainer>
               <AvailableUpdate
                 displayStyle={TextDisplayStyle.Label}
@@ -129,7 +132,7 @@ const AboutUI: FunctionComponent<Props> = ({
               />
             </ActionContainer>
           )}
-          {appUpdateAvailable && window.navigator.onLine && (
+          {appUpdateAvailable && online && (
             <ActionContainer>
               <AvailableUpdate
                 displayStyle={TextDisplayStyle.Label}
@@ -149,7 +152,7 @@ const AboutUI: FunctionComponent<Props> = ({
               />
             </ActionContainer>
           )}
-          {!appUpdateAvailable && window.navigator.onLine && (
+          {!appUpdateAvailable && online && (
             <ActionContainer>
               <AvailableUpdate
                 displayStyle={TextDisplayStyle.Label}

--- a/packages/app/src/settings/components/about/about.component.tsx
+++ b/packages/app/src/settings/components/about/about.component.tsx
@@ -13,7 +13,6 @@ interface Props {
   latestVersion?: string
   currentVersion?: string
   updateAvailable?: boolean
-  toggleApplicationUpdateAvailable: (appUpdateAvailable: boolean) => void
   checkingForUpdate: boolean
   checkUpdateAvailable: () => void
 }
@@ -23,7 +22,6 @@ export const About: FunctionComponent<Props> = ({
   currentVersion,
   updateAvailable,
   checkingForUpdate,
-  toggleApplicationUpdateAvailable,
   checkUpdateAvailable,
 }) => {
   const [appUpdateNotAvailableShow, setAppUpdateNotAvailableShow] =
@@ -51,7 +49,6 @@ export const About: FunctionComponent<Props> = ({
 
   const handleAppUpdateAvailableCheck = (): void => {
     if (!window.navigator.onLine) {
-      toggleApplicationUpdateAvailable(false)
       setAppUpdateFailedShow(true)
     } else {
       checkUpdateAvailable()

--- a/packages/app/src/settings/components/about/about.container.tsx
+++ b/packages/app/src/settings/components/about/about.container.tsx
@@ -6,10 +6,7 @@
 import { connect } from "react-redux"
 import { About } from "App/settings/components/about/about.component"
 import { ReduxRootState, RootState } from "App/__deprecated__/renderer/store"
-import {
-  toggleApplicationUpdateAvailable,
-  checkUpdateAvailable,
-} from "App/settings/actions"
+import { checkUpdateAvailable } from "App/settings/actions"
 
 const mapStateToProps = (state: RootState & ReduxRootState) => {
   return {
@@ -21,7 +18,6 @@ const mapStateToProps = (state: RootState & ReduxRootState) => {
 }
 
 const mapDispatchToProps = {
-  toggleApplicationUpdateAvailable,
   checkUpdateAvailable,
 }
 

--- a/packages/app/src/settings/hooks/use-online-checker.ts
+++ b/packages/app/src/settings/hooks/use-online-checker.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Mudita sp. z o.o. All rights reserved.
+ * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
+ */
+
+import { useState, useEffect } from "react"
+
+export const useOnlineChecker = (): boolean => {
+  const [online, setOnline] = useState(window.navigator.onLine)
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      if (window.navigator.onLine !== online) {
+        setOnline(window.navigator.onLine)
+      }
+    }, 500)
+    return () => clearInterval(intervalId)
+  }, [online, setOnline])
+
+  return online
+}


### PR DESCRIPTION
Jira: [CP-2131]

**Description**

- [ ] getState function in async thunk actions is correctly typed
- [ ] redux selectors are used in components / prop drilling is reduce

<details>
<summary><b>Screenshots</b></summary>
// put images here
</details>


[CP-2131]: https://appnroll.atlassian.net/browse/CP-2131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ