### PR TITLE
[CP-2110] Window toolbar is displayed when left ALT key is pressed 

### DIFF
--- a/packages/app/src/__deprecated__/main/main.ts
+++ b/packages/app/src/__deprecated__/main/main.ts
@@ -132,7 +132,6 @@ const commonWindowOptions: BrowserWindowConstructorOptions = {
     webSecurity: false,
     devTools: !productionEnvironment,
   },
-  autoHideMenuBar: true,
 }
 const getWindowOptions = (
   extendedWindowOptions?: BrowserWindowConstructorOptions
@@ -163,6 +162,7 @@ const createWindow = async () => {
       title,
     })
   )
+  win.setMenuBarVisibility(false)
 
   win.webContents.on("before-input-event", (event, input) => {
     if ((input.control || input.meta) && input.key.toLowerCase() === "r") {


### PR DESCRIPTION
Jira: [CP-2110]

**Description**

- [ ] getState function in async thunk actions is correctly typed
- [ ] redux selectors are used in components / prop drilling is reduce

<details>
<summary><b>Screenshots</b></summary>
// put images here
</details>


[CP-2110]: https://appnroll.atlassian.net/browse/CP-2110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ