### PR TITLE
[CP-2016] [SOSU] Sequential update for Harmony displays download progress while for Pure doesn't

### DIFF
--- a/packages/app/src/overview/components/overview-screens/pure-overview/pure-overview.component.tsx
+++ b/packages/app/src/overview/components/overview-screens/pure-overview/pure-overview.component.tsx
@@ -224,27 +224,29 @@ export const PureOverview: FunctionComponent<PureOverviewProps> = ({
 
   return (
     <>
-      <UpdateOsFlow
-        deviceType={DeviceType.MuditaPure}
-        currentOsVersion={osVersion}
-        silentCheckForUpdateState={silentCheckForUpdateState}
-        checkForUpdateState={checkingForUpdateState}
-        availableReleasesForUpdate={availableReleasesForUpdate}
-        areAllReleasesDownloaded={areAllReleasesDownloaded}
-        downloadState={downloadingState}
-        tryAgainCheckForUpdate={tryAgainPureUpdate}
-        clearUpdateOsFlow={clearUpdateState}
-        downloadUpdates={downloadReleases}
-        abortDownloading={abortDownload}
-        updateState={updatingState}
-        updateOs={updateReleases}
-        openContactSupportFlow={openContactSupportFlow}
-        allReleases={allReleases}
-        openHelpView={goToHelp}
-        error={updateOsError}
-        downloadingReleasesProcessStates={downloadingReleasesProcessStates}
-        updatingReleasesProcessStates={updatingReleasesProcessStates}
-      />
+      {!forceUpdateNeeded && (
+        <UpdateOsFlow
+          deviceType={DeviceType.MuditaPure}
+          currentOsVersion={osVersion}
+          silentCheckForUpdateState={silentCheckForUpdateState}
+          checkForUpdateState={checkingForUpdateState}
+          availableReleasesForUpdate={availableReleasesForUpdate}
+          areAllReleasesDownloaded={areAllReleasesDownloaded}
+          downloadState={downloadingState}
+          tryAgainCheckForUpdate={tryAgainPureUpdate}
+          clearUpdateOsFlow={clearUpdateState}
+          downloadUpdates={downloadReleases}
+          abortDownloading={abortDownload}
+          updateState={updatingState}
+          updateOs={updateReleases}
+          openContactSupportFlow={openContactSupportFlow}
+          allReleases={allReleases}
+          openHelpView={goToHelp}
+          error={updateOsError}
+          downloadingReleasesProcessStates={downloadingReleasesProcessStates}
+          updatingReleasesProcessStates={updatingReleasesProcessStates}
+        />
+      )}
 
       {flags.get(Feature.ForceUpdate) && (
         <UpdatingForceModalFlow


### PR DESCRIPTION
Jira: [CP-2016]

**Description**

- [ ] getState function in async thunk actions is correctly typed
- [ ] redux selectors are used in components / prop drilling is reduce

<details>
<summary><b>Screenshots</b></summary>
// put images here
</details>


[CP-2016]: https://appnroll.atlassian.net/browse/CP-2016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ