### PR TITLE
[CP-2134] [backup] password validation fails to indicate password mismatch in certain scenario

### DIFF
--- a/packages/app/src/overview/components/backup-set-secret-key-modal-dialog/backup-set-secret-key-modal-dialog.component.tsx
+++ b/packages/app/src/overview/components/backup-set-secret-key-modal-dialog/backup-set-secret-key-modal-dialog.component.tsx
@@ -4,7 +4,7 @@
  */
 
 import { FunctionComponent } from "App/__deprecated__/renderer/types/function-component.interface"
-import React, { ComponentProps } from "react"
+import React, { ComponentProps, useEffect } from "react"
 import { ModalDialog } from "App/ui/components/modal-dialog"
 import { intl } from "App/__deprecated__/renderer/utils/intl"
 import { ModalText } from "App/contacts/components/sync-contacts-modal/sync-contacts.styled"
@@ -118,14 +118,21 @@ export const BackupSetSecretKeyModal: FunctionComponent<
     watch,
     handleSubmit,
     formState: { errors },
+    trigger,
   } = useForm<BackupSetSecretKeyFieldValues>({
     mode: "onChange",
   })
-  const fields = watch()
+  const password = watch(FieldKeys.SecretKey)
 
   const handleSubmitClick = handleSubmit((data) => {
     onSecretKeySet(data.secretKey)
   })
+
+  useEffect(() => {
+    if (password) {
+      trigger(FieldKeys.ConfirmationSecretKey)
+    }
+  }, [password, trigger])
 
   return (
     <Modal
@@ -156,7 +163,7 @@ export const BackupSetSecretKeyModal: FunctionComponent<
               message: intl.formatMessage(messages.backupSecretKeyRequired),
             },
             validate: (value): string | undefined => {
-              if (value === fields[FieldKeys.SecretKey]) {
+              if (value === password) {
                 return
               }
 

--- a/packages/app/src/overview/components/backup-set-secret-key-modal-dialog/backup-set-secret-key-modal-dialog.component.tsx
+++ b/packages/app/src/overview/components/backup-set-secret-key-modal-dialog/backup-set-secret-key-modal-dialog.component.tsx
@@ -130,7 +130,7 @@ export const BackupSetSecretKeyModal: FunctionComponent<
 
   useEffect(() => {
     if (password) {
-      trigger(FieldKeys.ConfirmationSecretKey)
+      void trigger(FieldKeys.ConfirmationSecretKey)
     }
   }, [password, trigger])
 


### PR DESCRIPTION
Jira: [CP-2134]

**Description**

- [ ] getState function in async thunk actions is correctly typed
- [ ] redux selectors are used in components / prop drilling is reduce

<details>
<summary><b>Screenshots</b></summary>
// put images here
</details>


[CP-2134]: https://appnroll.atlassian.net/browse/CP-2134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ