### PR TITLE
[CP-2132] It is possible to open multiple File Explorer windows during adding files to Harmony from the center

### DIFF
--- a/packages/app/src/files-manager/actions/get-files.action.ts
+++ b/packages/app/src/files-manager/actions/get-files.action.ts
@@ -17,7 +17,7 @@ export const getFiles = createAsyncThunk<File[], DeviceDirectory>(
   async (payload, { rejectWithValue }) => {
     const result = await getFilesRequest({
       directory: payload,
-      filter: { extensions: Object.values(EligibleFormat) },
+      filter: { extensions: EligibleFormat },
     })
 
     if (!result.ok || !result.data) {

--- a/packages/app/src/files-manager/actions/get-files.action.ts
+++ b/packages/app/src/files-manager/actions/get-files.action.ts
@@ -7,7 +7,7 @@ import { createAsyncThunk } from "@reduxjs/toolkit"
 import {
   FilesManagerEvent,
   DeviceDirectory,
-  EligibleFormat,
+  eligibleFormat,
 } from "App/files-manager/constants"
 import { getFilesRequest } from "App/files-manager/requests/get-files.request"
 import { File } from "App/files-manager/dto"
@@ -17,7 +17,7 @@ export const getFiles = createAsyncThunk<File[], DeviceDirectory>(
   async (payload, { rejectWithValue }) => {
     const result = await getFilesRequest({
       directory: payload,
-      filter: { extensions: EligibleFormat },
+      filter: { extensions: eligibleFormat },
     })
 
     if (!result.ok || !result.data) {

--- a/packages/app/src/files-manager/actions/upload-file.action.test.ts
+++ b/packages/app/src/files-manager/actions/upload-file.action.test.ts
@@ -12,11 +12,8 @@ import { Result, SuccessResult } from "App/core/builder"
 import { AppError } from "App/core/errors"
 import { pendingAction } from "App/__deprecated__/renderer/store/helpers"
 import { testError } from "App/__deprecated__/renderer/store/constants"
-import { getPathsRequest } from "App/file-system/requests"
 import { uploadFilesRequest } from "App/files-manager/requests"
-import { EligibleFormat } from "App/files-manager/constants/eligible-format.constant"
 import { DeviceDirectory } from "App/files-manager/constants/device-directory.constant"
-import { GetPathsInput } from "App/file-system/dto"
 import { uploadFile } from "App/files-manager/actions/upload-file.action"
 import {
   setUploadBlocked,
@@ -44,8 +41,6 @@ jest.mock("App/device/actions/load-storage-info.action", () => ({
 
 const pathsMock = ["/path/file-1.mp3", "/path/file-2.wav"]
 const errorMock = new AppError("SOME_ERROR_TYPE", "Luke, I'm your error")
-const successGetPathResponse = new SuccessResult<string[]>(pathsMock)
-const failedGetPathResponse = Result.failed(errorMock)
 const successUploadResponse = new SuccessResult<string[]>(pathsMock)
 const failedUploadResponse = Result.failed(errorMock)
 const initialStore = {
@@ -57,98 +52,74 @@ const initialStore = {
   },
 }
 
-const getFilesPathsResponseMock: GetPathsInput = {
-  filters: [
-    {
-      name: "Audio",
-      extensions: Object.values(EligibleFormat),
-    },
-  ],
-  properties: ["openFile", "multiSelections"],
-}
+describe("when `uploadFileRequest` request return Result.success with uploaded files list", () => {
+  beforeAll(() => {
+    ;(uploadFilesRequest as jest.Mock).mockReturnValue(successUploadResponse)
+    ;(getFiles as unknown as jest.Mock).mockReturnValue(GET_FILES_MOCK_RESULT)
+  })
 
-describe("when `getPathRequest` request return Result.success with files list", () => {
-  describe("when `uploadFileRequest` request return Result.success with uploaded files list", () => {
-    beforeAll(() => {
-      ;(getPathsRequest as jest.Mock).mockResolvedValue(successGetPathResponse)
-      ;(uploadFilesRequest as jest.Mock).mockReturnValue(successUploadResponse)
-      ;(getFiles as unknown as jest.Mock).mockReturnValue(GET_FILES_MOCK_RESULT)
-    })
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
 
-    afterEach(() => {
-      jest.resetAllMocks()
-    })
+  test("dispatch `setUploadingState` with `State.Loaded` and `getFiles` with provided directory", async () => {
+    const mockStore = createMockStore([thunk])(initialStore)
 
-    test("dispatch `setUploadingState` with `State.Loaded` and `getFiles` with provided directory", async () => {
-      const mockStore = createMockStore([thunk])(initialStore)
+    const {
+      meta: { requestId },
+      // AUTO DISABLED - fix me if you like :)
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+    } = await mockStore.dispatch(uploadFile(pathsMock) as unknown as AnyAction)
 
-      const {
-        meta: { requestId },
-        // AUTO DISABLED - fix me if you like :)
-        // eslint-disable-next-line @typescript-eslint/await-thenable
-      } = await mockStore.dispatch(uploadFile() as unknown as AnyAction)
+    expect(mockStore.getActions()).toEqual([
+      uploadFile.pending(requestId, pathsMock),
+      setUploadBlocked(true),
+      setUploadingFileCount(2),
+      setUploadingState(State.Loading),
+      setUploadBlocked(false),
+      GET_FILES_MOCK_RESULT,
+      {
+        type: pendingAction("DEVICE_LOAD_STORAGE_INFO"),
+        payload: undefined,
+      },
 
-      expect(mockStore.getActions()).toEqual([
-        uploadFile.pending(requestId),
-        setUploadBlocked(true),
-        setUploadingFileCount(2),
-        setUploadingState(State.Loading),
-        setUploadBlocked(false),
-        GET_FILES_MOCK_RESULT,
-        {
-          type: pendingAction("DEVICE_LOAD_STORAGE_INFO"),
-          payload: undefined,
-        },
+      setUploadingState(State.Loaded),
+      uploadFile.fulfilled(undefined, requestId, pathsMock),
+    ])
 
-        setUploadingState(State.Loaded),
-        uploadFile.fulfilled(undefined, requestId),
-      ])
-
-      expect(getPathsRequest).toHaveBeenLastCalledWith(
-        getFilesPathsResponseMock
-      )
-      expect(uploadFilesRequest).toHaveBeenLastCalledWith({
-        directory: DeviceDirectory.Music,
-        filePaths: pathsMock,
-      })
+    expect(uploadFilesRequest).toHaveBeenLastCalledWith({
+      directory: DeviceDirectory.Music,
+      filePaths: pathsMock,
     })
   })
 
   describe("when `uploadFileRequest` request return Result.success with empty files list", () => {
-    beforeAll(() => {
-      ;(getPathsRequest as jest.Mock).mockResolvedValue(Result.success([]))
-    })
-
     afterEach(() => {
       jest.resetAllMocks()
     })
 
-    test("any action is dispatch", async () => {
+    test("Action is dispatched with empty array as a argument", async () => {
       const mockStore = createMockStore([thunk])(initialStore)
 
       const {
         meta: { requestId },
         // AUTO DISABLED - fix me if you like :)
         // eslint-disable-next-line @typescript-eslint/await-thenable
-      } = await mockStore.dispatch(uploadFile() as unknown as AnyAction)
+      } = await mockStore.dispatch(uploadFile([]) as unknown as AnyAction)
 
       expect(mockStore.getActions()).toEqual([
-        uploadFile.pending(requestId),
+        uploadFile.pending(requestId, []),
         setUploadBlocked(true),
         setUploadBlocked(false),
-        uploadFile.fulfilled(undefined, requestId),
+        uploadFile.rejected(null, requestId, [], "no files to upload"),
       ])
 
-      expect(getPathsRequest).toHaveBeenLastCalledWith(
-        getFilesPathsResponseMock
-      )
       expect(uploadFilesRequest).not.toHaveBeenCalled()
     })
   })
 
   describe("when `uploadFileRequest` request return Result.failed", () => {
-    beforeAll(() => {
-      ;(getPathsRequest as jest.Mock).mockResolvedValue(successGetPathResponse)
+    beforeEach(() => {
       ;(uploadFilesRequest as jest.Mock).mockReturnValue(failedUploadResponse)
       ;(getFiles as unknown as jest.Mock).mockReturnValue(GET_FILES_MOCK_RESULT)
     })
@@ -164,54 +135,25 @@ describe("when `getPathRequest` request return Result.success with files list", 
         meta: { requestId },
         // AUTO DISABLED - fix me if you like :)
         // eslint-disable-next-line @typescript-eslint/await-thenable
-      } = await mockStore.dispatch(uploadFile() as unknown as AnyAction)
+      } = await mockStore.dispatch(
+        uploadFile(pathsMock) as unknown as AnyAction
+      )
 
       expect(mockStore.getActions()).toEqual([
-        uploadFile.pending(requestId),
+        uploadFile.pending(requestId, pathsMock),
         setUploadBlocked(true),
         setUploadingFileCount(2),
         setUploadingState(State.Loading),
         setUploadBlocked(false),
         GET_FILES_MOCK_RESULT,
-        uploadFile.rejected(testError, requestId, undefined, { ...errorMock }),
+
+        uploadFile.rejected(testError, requestId, pathsMock, { ...errorMock }),
       ])
 
-      expect(getPathsRequest).toHaveBeenLastCalledWith(
-        getFilesPathsResponseMock
-      )
       expect(uploadFilesRequest).toHaveBeenLastCalledWith({
         directory: DeviceDirectory.Music,
         filePaths: pathsMock,
       })
     })
-  })
-})
-
-describe("when `getPathRequest` request return Result.failed", () => {
-  beforeAll(() => {
-    ;(getPathsRequest as jest.Mock).mockResolvedValue(failedGetPathResponse)
-  })
-
-  afterEach(() => {
-    jest.resetAllMocks()
-  })
-
-  test("failed with receive from `uploadFileRequest` error", async () => {
-    const mockStore = createMockStore([thunk])(initialStore)
-
-    const {
-      meta: { requestId },
-      // AUTO DISABLED - fix me if you like :)
-      // eslint-disable-next-line @typescript-eslint/await-thenable
-    } = await mockStore.dispatch(uploadFile() as unknown as AnyAction)
-
-    expect(mockStore.getActions()).toEqual([
-      uploadFile.pending(requestId),
-      setUploadBlocked(true),
-      uploadFile.rejected(testError, requestId, undefined, { ...errorMock }),
-    ])
-
-    expect(getPathsRequest).toHaveBeenLastCalledWith(getFilesPathsResponseMock)
-    expect(uploadFilesRequest).not.toHaveBeenCalled()
   })
 })

--- a/packages/app/src/files-manager/actions/upload-file.action.test.ts
+++ b/packages/app/src/files-manager/actions/upload-file.action.test.ts
@@ -76,14 +76,13 @@ describe("when `uploadFileRequest` request return Result.success with uploaded f
       setUploadBlocked(true),
       setUploadingFileCount(2),
       setUploadingState(State.Loading),
-      setUploadBlocked(false),
       GET_FILES_MOCK_RESULT,
       {
         type: pendingAction("DEVICE_LOAD_STORAGE_INFO"),
         payload: undefined,
       },
-
       setUploadingState(State.Loaded),
+      setUploadBlocked(false),
       uploadFile.fulfilled(undefined, requestId, pathsMock),
     ])
 
@@ -144,7 +143,6 @@ describe("when `uploadFileRequest` request return Result.success with uploaded f
         setUploadBlocked(true),
         setUploadingFileCount(2),
         setUploadingState(State.Loading),
-        setUploadBlocked(false),
         GET_FILES_MOCK_RESULT,
 
         uploadFile.rejected(testError, requestId, pathsMock, { ...errorMock }),

--- a/packages/app/src/files-manager/actions/upload-file.action.ts
+++ b/packages/app/src/files-manager/actions/upload-file.action.ts
@@ -35,9 +35,7 @@ export const uploadFile = createAsyncThunk<
 >(
   FilesManagerEvent.UploadFiles,
   async (filePaths, { getState, dispatch, rejectWithValue }) => {
-    console.log("upload file action")
     dispatch(setUploadBlocked(true))
-    console.log("upload file action 2")
 
     const state = getState()
 

--- a/packages/app/src/files-manager/components/files-manager/files-manager.component.tsx
+++ b/packages/app/src/files-manager/components/files-manager/files-manager.component.tsx
@@ -18,7 +18,7 @@ import { FilesManagerTestIds } from "App/files-manager/components/files-manager/
 import {
   DeviceDirectory,
   DiskSpaceCategoryType,
-  EligibleFormat,
+  eligibleFormat,
   filesSummaryElements,
 } from "App/files-manager/constants"
 import FilesStorage from "App/files-manager/components/files-storage/files-storage.component"
@@ -323,7 +323,7 @@ const FilesManager: FunctionComponent<FilesManagerProps> = ({
       <input
         ref={fileInputRef}
         type="file"
-        accept={EligibleFormat.map((format) => `audio/${format}`).join(",")}
+        accept={eligibleFormat.map((format) => `audio/${format}`).join(",")}
         hidden
         multiple
         onChange={onFileInputChange}

--- a/packages/app/src/files-manager/components/files-manager/files-manager.component.tsx
+++ b/packages/app/src/files-manager/components/files-manager/files-manager.component.tsx
@@ -4,7 +4,7 @@
  */
 
 import { DeviceType } from "App/device/constants"
-import React, { ChangeEvent, useEffect, useRef, useState } from "react"
+import React, { useEffect, useRef, useState } from "react"
 import { State } from "App/core/constants"
 import { FunctionComponent } from "App/__deprecated__/renderer/types/function-component.interface"
 import { FilesManagerContainer } from "App/files-manager/components/files-manager/files-manager.styled"

--- a/packages/app/src/files-manager/components/files-manager/files-manager.component.tsx
+++ b/packages/app/src/files-manager/components/files-manager/files-manager.component.tsx
@@ -4,7 +4,7 @@
  */
 
 import { DeviceType } from "App/device/constants"
-import React, { useEffect, useState } from "react"
+import React, { ChangeEvent, useEffect, useRef, useState } from "react"
 import { State } from "App/core/constants"
 import { FunctionComponent } from "App/__deprecated__/renderer/types/function-component.interface"
 import { FilesManagerContainer } from "App/files-manager/components/files-manager/files-manager.styled"
@@ -18,6 +18,7 @@ import { FilesManagerTestIds } from "App/files-manager/components/files-manager/
 import {
   DeviceDirectory,
   DiskSpaceCategoryType,
+  EligibleFormat,
   filesSummaryElements,
 } from "App/files-manager/constants"
 import FilesStorage from "App/files-manager/components/files-storage/files-storage.component"
@@ -30,7 +31,6 @@ import { useDispatch } from "react-redux"
 import { resetFiles } from "App/files-manager/actions/base.action"
 import { uploadFile } from "App/files-manager/actions"
 import { Dispatch } from "App/__deprecated__/renderer/store"
-import { noop } from "App/__deprecated__/renderer/utils/noop"
 
 const FilesManager: FunctionComponent<FilesManagerProps> = ({
   memorySpace = {
@@ -62,6 +62,7 @@ const FilesManager: FunctionComponent<FilesManagerProps> = ({
   abortPendingUpload,
   continuePendingUpload,
 }) => {
+  const fileInputRef = useRef<HTMLInputElement>(null)
   const { noFoundFiles, searchValue, filteredFiles, handleSearchValueChange } =
     useFilesFilter({ files: files ?? [] })
   const { states, updateFieldState } = useLoadingState<FileServiceState>({
@@ -85,10 +86,7 @@ const FilesManager: FunctionComponent<FilesManagerProps> = ({
   const dispatch = useDispatch()
   const dispatchThunk = useDispatch<Dispatch>()
 
-  const [uploadActionTrigger, setUploadActionTrigger] = useState<number>()
-
   const disableUpload = uploadBlocked ? uploadBlocked : freeSpace === 0
-
   const downloadFiles = () => {
     // AUTO DISABLED - fix me if you like :)
     // eslint-disable-next-line @typescript-eslint/await-thenable
@@ -196,21 +194,15 @@ const FilesManager: FunctionComponent<FilesManagerProps> = ({
     }
   }, [resetUploadingState])
 
-  useEffect(() => {
-    if (uploadActionTrigger) {
-      const uploadActionPromise = dispatchThunk(uploadFile())
-
-      //abort on dismount or when a new upload has been triggered
-      return () => {
-        if ("abort" in uploadActionPromise) {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any
-          ;(uploadActionPromise as any).abort()
-        }
-      }
+  const onFileInputChange = () => {
+    if (fileInputRef.current?.files?.length) {
+      void dispatchThunk(
+        uploadFile(
+          Array.from(fileInputRef.current?.files).map((file) => file.path)
+        )
+      )
     }
-    return noop
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [uploadActionTrigger])
+  }
 
   const getDiskSpaceCategories = (element: DiskSpaceCategory) => {
     const elements = {
@@ -275,7 +267,7 @@ const FilesManager: FunctionComponent<FilesManagerProps> = ({
   }
 
   const handleUploadFiles = () => {
-    setUploadActionTrigger(new Date().getTime())
+    fileInputRef.current?.click()
   }
 
   return (
@@ -328,6 +320,14 @@ const FilesManager: FunctionComponent<FilesManagerProps> = ({
           deviceType={deviceType}
         />
       )}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={EligibleFormat.map((format) => `audio/${format}`).join(",")}
+        hidden
+        multiple
+        onChange={onFileInputChange}
+      />
     </FilesManagerContainer>
   )
 }

--- a/packages/app/src/files-manager/constants/eligible-format.constant.ts
+++ b/packages/app/src/files-manager/constants/eligible-format.constant.ts
@@ -2,4 +2,5 @@
  * Copyright (c) Mudita sp. z o.o. All rights reserved.
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
+
 export const EligibleFormat = ["mp3", "wav", "flac"]

--- a/packages/app/src/files-manager/constants/eligible-format.constant.ts
+++ b/packages/app/src/files-manager/constants/eligible-format.constant.ts
@@ -3,4 +3,4 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-export const EligibleFormat = ["mp3", "wav", "flac"]
+export const eligibleFormat = ["mp3", "wav", "flac"]

--- a/packages/app/src/files-manager/constants/eligible-format.constant.ts
+++ b/packages/app/src/files-manager/constants/eligible-format.constant.ts
@@ -2,9 +2,4 @@
  * Copyright (c) Mudita sp. z o.o. All rights reserved.
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
-
-export enum EligibleFormat {
-  MP3 = "mp3",
-  WAV = "wav",
-  FLAC = "flac",
-}
+export const EligibleFormat = ["mp3", "wav", "flac"]

--- a/packages/app/src/files-manager/helpers/check-files-extensions.helper.test.ts
+++ b/packages/app/src/files-manager/helpers/check-files-extensions.helper.test.ts
@@ -6,9 +6,7 @@
 import { checkFilesExtensions } from "App/files-manager/helpers/check-files-extensions.helper"
 import { EligibleFormat } from "App/files-manager/constants/eligible-format.constant"
 
-const supportedFiles = (Object.values(EligibleFormat) as string[]).map(
-  (extension) => `file.${extension}`
-)
+const supportedFiles = EligibleFormat.map((extension) => `file.${extension}`)
 
 describe("`checkFilesExtensions` helper", () => {
   test("all correct extensions", () => {

--- a/packages/app/src/files-manager/helpers/check-files-extensions.helper.test.ts
+++ b/packages/app/src/files-manager/helpers/check-files-extensions.helper.test.ts
@@ -4,9 +4,9 @@
  */
 
 import { checkFilesExtensions } from "App/files-manager/helpers/check-files-extensions.helper"
-import { EligibleFormat } from "App/files-manager/constants/eligible-format.constant"
+import { eligibleFormat } from "App/files-manager/constants/eligible-format.constant"
 
-const supportedFiles = EligibleFormat.map((extension) => `file.${extension}`)
+const supportedFiles = eligibleFormat.map((extension) => `file.${extension}`)
 
 describe("`checkFilesExtensions` helper", () => {
   test("all correct extensions", () => {

--- a/packages/app/src/files-manager/helpers/check-files-extensions.helper.ts
+++ b/packages/app/src/files-manager/helpers/check-files-extensions.helper.ts
@@ -7,7 +7,7 @@ import { EligibleFormat } from "App/files-manager/constants/eligible-format.cons
 
 export const checkFilesExtensions = (filesPaths: string[]): boolean => {
   return filesPaths.every((filePath) => {
-    return (Object.values(EligibleFormat) as string[]).includes(
+    return EligibleFormat.includes(
       (filePath.split(".").pop() ?? "").toLocaleLowerCase()
     )
   })

--- a/packages/app/src/files-manager/helpers/check-files-extensions.helper.ts
+++ b/packages/app/src/files-manager/helpers/check-files-extensions.helper.ts
@@ -3,11 +3,11 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { EligibleFormat } from "App/files-manager/constants/eligible-format.constant"
+import { eligibleFormat } from "App/files-manager/constants/eligible-format.constant"
 
 export const checkFilesExtensions = (filesPaths: string[]): boolean => {
   return filesPaths.every((filePath) => {
-    return EligibleFormat.includes(
+    return eligibleFormat.includes(
       (filePath.split(".").pop() ?? "").toLocaleLowerCase()
     )
   })


### PR DESCRIPTION
Jira: [CP-2132]

**Description**

- [ ] getState function in async thunk actions is correctly typed
- [ ] redux selectors are used in components / prop drilling is reduce

<details>
<summary><b>Screenshots</b></summary>
// put images here
</details>


[CP-2132]: https://appnroll.atlassian.net/browse/CP-2132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ