### PR TITLE
[CP-2185] [Messages][Templates] Center displays a newly added template on 2nd position (after deleting other template) 

### DIFF
--- a/packages/app/src/templates/components/templates/templates.component.tsx
+++ b/packages/app/src/templates/components/templates/templates.component.tsx
@@ -202,8 +202,6 @@ export const Templates: FunctionComponent<TemplatesProps> = ({
     const updatedTemplates = reorder(list)
     void updateTemplateOrder(updatedTemplates)
   }
-  console.log("templatesList", templatesList)
-  console.log("templates", templates)
 
   return (
     <>

--- a/packages/app/src/templates/components/templates/templates.component.tsx
+++ b/packages/app/src/templates/components/templates/templates.component.tsx
@@ -181,8 +181,7 @@ export const Templates: FunctionComponent<TemplatesProps> = ({
   const handleCreateTemplate = async (template: NewTemplate) => {
     updateFieldState("creating", true)
     setTemplateFormOpenState(false)
-    const lastTemplateOrder = templates[templates.length - 1]?.order
-    const newTemplateOrder = lastTemplateOrder ? lastTemplateOrder + 1 : 1
+    const newTemplateOrder = templates.length > 0 ? templates[0].order : 1
     await createTemplate({ ...template, order: newTemplateOrder })
   }
 
@@ -203,6 +202,9 @@ export const Templates: FunctionComponent<TemplatesProps> = ({
     const updatedTemplates = reorder(list)
     void updateTemplateOrder(updatedTemplates)
   }
+  console.log("templatesList", templatesList)
+  console.log("templates", templates)
+
   return (
     <>
       <TemplatesPanel


### PR DESCRIPTION
Jira: [CP-2185]

**Description**

- [ ] getState function in async thunk actions is correctly typed
- [ ] redux selectors are used in components / prop drilling is reduce

<details>
<summary><b>Screenshots</b></summary>
// put images here
</details>


[CP-2185]: https://appnroll.atlassian.net/browse/CP-2185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ