### PR TITLE
[CP-2186] [Messages][Templates] Templates order is reversed on attach template window in conversation

### DIFF
--- a/packages/app/src/__deprecated__/renderer/locales/default/en-US.json
+++ b/packages/app/src/__deprecated__/renderer/locales/default/en-US.json
@@ -855,7 +855,6 @@
   "module.templates.emptyTemplate": "Empty template",
   "module.templates.modalTitle": "Use Template",
   "module.templates.newButton": "New template",
-  "module.templates.newLine": "The template contains new line character",
   "module.templates.newTemplate": "new",
   "module.templates.newTitle": "New template",
   "module.templates.orderError": "Reordering was not successful",

--- a/packages/app/src/messages/messages.container.tsx
+++ b/packages/app/src/messages/messages.container.tsx
@@ -49,6 +49,7 @@ import { CreateMessageDataResponse } from "App/messages/services"
 import { PayloadAction } from "@reduxjs/toolkit"
 import { search, searchPreview } from "App/search/actions"
 import { SearchParams } from "App/search/dto"
+import { templatesListSelector } from "App/templates/selectors"
 
 const mapStateToProps = (state: RootState & ReduxRootState) => ({
   error: state.messages.error,
@@ -70,7 +71,7 @@ const mapStateToProps = (state: RootState & ReduxRootState) => ({
     NotificationResourceType.Message,
     NotificationMethod.Layout
   )(state),
-  templates: state.templates.data,
+  templates: templatesListSelector(state),
   selectedItems: state.messages.selectedItems,
   searchResult: state.messages.data.searchResult,
   searchPreviewResult: state.messages.data.searchPreviewResult,


### PR DESCRIPTION
Jira: [CP-2186]

**Description**

- [ ] getState function in async thunk actions is correctly typed
- [ ] redux selectors are used in components / prop drilling is reduce

<details>
<summary><b>Screenshots</b></summary>
// put images here
</details>


[CP-2186]: https://appnroll.atlassian.net/browse/CP-2186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ