### PR TITLE
[CP-2188] [Messages][Templates] change order success status popup appears even without changing template order

### DIFF
--- a/packages/app/src/templates/components/templates/templates.component.tsx
+++ b/packages/app/src/templates/components/templates/templates.component.tsx
@@ -189,18 +189,20 @@ export const Templates: FunctionComponent<TemplatesProps> = ({
     updateFieldState("creating", false)
   }
 
-  const onDragEnd = (result: DropResult) => {
-    updateFieldState("updatingOrder", true)
-    if (!result.destination) {
-      return
-    }
+  const onDragEnd = ({ source, destination }: DropResult) => {
+    if (source.index !== destination?.index) {
+      updateFieldState("updatingOrder", true)
+      if (!destination) {
+        return
+      }
 
-    const list = Array.from(templatesList)
-    const [removed] = list.splice(result.source.index, 1)
-    list.splice(result.destination.index, 0, removed)
-    setTemplatesList(list)
-    const updatedTemplates = reorder(list)
-    void updateTemplateOrder(updatedTemplates)
+      const list = Array.from(templatesList)
+      const [removed] = list.splice(source.index, 1)
+      list.splice(destination.index, 0, removed)
+      setTemplatesList(list)
+      const updatedTemplates = reorder(list)
+      void updateTemplateOrder(updatedTemplates)
+    }
   }
 
   return (


### PR DESCRIPTION
Jira: [CP-2188]

**Description**

- [ ] getState function in async thunk actions is correctly typed
- [ ] redux selectors are used in components / prop drilling is reduce

<details>
<summary><b>Screenshots</b></summary>
// put images here
</details>


[CP-2188]: https://appnroll.atlassian.net/browse/CP-2188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ