### PR TITLE
[CP-2185][2] [Messages][Templates] Center displays a newly added template on 2nd position (after deleting other template) 

### DIFF
--- a/packages/app/src/device/types/mudita-os/serialport-request.type.ts
+++ b/packages/app/src/device/types/mudita-os/serialport-request.type.ts
@@ -329,7 +329,7 @@ export interface Thread {
   threadID: number
 }
 
-export interface Template {
+export interface PureTemplate {
   templateID: number
   lastUsedAt: number
   templateBody: string
@@ -380,7 +380,7 @@ export interface GetTemplatesRequestConfig
 }
 
 export interface GetTemplatesResponseBody {
-  entries: Template[]
+  entries: PureTemplate[]
   totalCount: number
   nextPage?: PaginationBody
 }

--- a/packages/app/src/templates/components/templates/templates.component.tsx
+++ b/packages/app/src/templates/components/templates/templates.component.tsx
@@ -181,8 +181,7 @@ export const Templates: FunctionComponent<TemplatesProps> = ({
   const handleCreateTemplate = async (template: NewTemplate) => {
     updateFieldState("creating", true)
     setTemplateFormOpenState(false)
-    const newTemplateOrder = templates.length > 0 ? templates[0].order : 1
-    await createTemplate({ ...template, order: newTemplateOrder })
+    await createTemplate(template)
   }
 
   const handleCloseCreatingErrorModal = () => {

--- a/packages/app/src/templates/presenters/template.presenter.test.ts
+++ b/packages/app/src/templates/presenters/template.presenter.test.ts
@@ -3,7 +3,7 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { Template as PureTemplate } from "App/device/types/mudita-os"
+import { PureTemplate } from "App/device/types/mudita-os"
 import { MessagesCategory as PureMessagesCategory } from "App/device/constants"
 import { NewTemplate, Template } from "App/templates/dto"
 import { TemplatePresenter } from "App/templates/presenters/template.presenter"

--- a/packages/app/src/templates/presenters/template.presenter.ts
+++ b/packages/app/src/templates/presenters/template.presenter.ts
@@ -4,7 +4,7 @@
  */
 
 import {
-  Template as PureTemplate,
+  PureTemplate,
   UpdateTemplateRequestConfig,
   CreateTemplateRequestConfig,
   UpdateTemplateOrderRequestConfig,

--- a/packages/app/src/templates/services/template.service.test.ts
+++ b/packages/app/src/templates/services/template.service.test.ts
@@ -12,7 +12,7 @@ import {
   ErrorRequestResponse,
   RequestResponseStatus,
 } from "App/core/types/request-response.interface"
-import { NewTemplate, Template } from "App/templates/dto"
+import { Template } from "App/templates/dto"
 
 const templateRepository = {
   create: jest.fn(),
@@ -32,9 +32,11 @@ const errorResponse: ErrorRequestResponse = {
   status: RequestResponseStatus.Error,
 }
 
-const newTemplate: NewTemplate = {
+const newTemplate: Template = {
   text: "Hello world",
   order: 1,
+  id: "1",
+  lastUsedAt: "1",
 }
 
 const template: Template = {
@@ -69,7 +71,7 @@ describe("`TemplateService`", () => {
       const response = await subject.createTemplate(newTemplate)
       // AUTO DISABLED - fix me if you like :)
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(deviceManager.device.request).toHaveBeenLastCalledWith({
+      expect(deviceManager.device.request).toHaveBeenNthCalledWith(1, {
         endpoint: Endpoint.Messages,
         method: Method.Post,
         body: {


### PR DESCRIPTION
Jira: [CP-2185]

**Description**

- [ ] getState function in async thunk actions is correctly typed
- [ ] redux selectors are used in components / prop drilling is reduce

<details>
<summary><b>Screenshots</b></summary>
// put images here
</details>


[CP-2185]: https://appnroll.atlassian.net/browse/CP-2185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ