### PR TITLE
[CP-XXX] Enhancements for Mudita Center Release Process

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,9 @@ ROLLBAR_TOKEN=
 # [Optional] Access token for dummy-account that has an access to Mudita private repositories. This variable is needed only in development and build production app.
 GITHUB_ACCESS_TOKEN=
 
+# [Optional] Name of the repository from which the application retrieves update packages. It is crucial for the application update process, enabling the determination of the update source.
+RELEASES_REPOSITORY_NAME=
+
 # [Optional] client id of the Microsoft Outlook application used for calendars and contacts
 LOGIN_MICROSOFT_ONLINE_CLIENT_ID=
 

--- a/.env.example
+++ b/.env.example
@@ -49,5 +49,3 @@ DEV_DEVICE_LOGGER_ENABLED=
 
 FEATURE_TOGGLE_RELEASE_ENVIRONMENT=
 
-# [Optional] enable Mudita Center prerelease feature. Disabled by default, set "1" to enable
-MUDITA_CENTER_PRERELEASE_ENABLED=

--- a/packages/app/src/__deprecated__/main/autoupdate.ts
+++ b/packages/app/src/__deprecated__/main/autoupdate.ts
@@ -30,13 +30,16 @@ export const mockAutoupdate = (win: BrowserWindow): void => {
   })
 }
 
+const token = process.env.GITHUB_ACCESS_TOKEN
+const repo = process.env.RELEASES_REPOSITORY_NAME
+
 export default (win: BrowserWindow): void => {
   autoUpdater.setFeedURL({
+    token,
+    repo,
     private: true,
     provider: "github",
-    token: process.env.GITHUB_ACCESS_TOKEN,
     owner: "Mudita",
-    repo: "mudita-center",
   })
   autoUpdater.logger = logger
   autoUpdater.autoDownload = false

--- a/packages/app/src/__deprecated__/main/autoupdate.ts
+++ b/packages/app/src/__deprecated__/main/autoupdate.ts
@@ -7,7 +7,6 @@ import { autoUpdater } from "electron-updater"
 import { ipcMain } from "electron-better-ipc"
 import { BrowserWindow } from "electron"
 import logger from "App/__deprecated__/main/utils/logger"
-import { Feature, flags } from "App/feature-flags"
 
 export enum AppUpdateEvent {
   Available = "app-update-available",
@@ -41,7 +40,6 @@ export default (win: BrowserWindow): void => {
   })
   autoUpdater.logger = logger
   autoUpdater.autoDownload = false
-  autoUpdater.allowPrerelease = flags.get(Feature.MuditaCenterPrereleaseEnabled)
   autoUpdater.autoInstallOnAppQuit = false
 
   autoUpdater.on("update-available", ({ version }) => {

--- a/packages/app/src/feature-flags/constants/feature.enum.ts
+++ b/packages/app/src/feature-flags/constants/feature.enum.ts
@@ -11,7 +11,6 @@ export enum Feature {
   MessagesThreadCallsEnabled = "messages-thread-calls-enabled",
   MessagesCallFromThreadEnabled = "messages-call-from-thread-enabled",
   MessagesDraftStatus = "messages-draft-status",
-  MuditaCenterPrereleaseEnabled = "mudita-center-prerelease-enabled",
   ContactForwardEnabled = "contact-forward-enabled",
   ContactBlockingEnabled = "contact-blocking-enabled",
   ContactPhoneFieldIconsEnabled = "contact-phone-field-icons-enabled",

--- a/packages/app/src/feature-flags/features/index.ts
+++ b/packages/app/src/feature-flags/features/index.ts
@@ -6,8 +6,6 @@
 import { EnvironmentConfig } from "App/feature-flags/types"
 import { Feature, Environment } from "App/feature-flags/constants"
 
-const muditaCenterPrereleaseEnabled =
-  process.env.MUDITA_CENTER_PRERELEASE_ENABLED === "1"
 const loggerEnabled = process.env.DEV_DEVICE_LOGGER_ENABLED !== "0"
 
 export const features: EnvironmentConfig = {
@@ -29,11 +27,6 @@ export const features: EnvironmentConfig = {
   [Feature.DeveloperModeEnabled]: {
     [Environment.Development]: true,
     [Environment.Production]: false,
-    [Environment.AlphaProduction]: true,
-  },
-  [Feature.MuditaCenterPrereleaseEnabled]: {
-    [Environment.Development]: true,
-    [Environment.Production]: muditaCenterPrereleaseEnabled,
     [Environment.AlphaProduction]: true,
   },
   [Feature.MessagesThreadCallsEnabled]: {


### PR DESCRIPTION
Jira: [CP-XXX]

**Description**

In this pull request, the following changes have been made:

1. Removed the feature flag associated with `MuditaCenterPrereleaseEnabled`.
2. Eliminated the pre-release logic from the application update process.
3. Added a new environment variable named `RELEASES_REPOSITORY_NAME` to handle both production and stage environments, including release candidates.

Additionally,
-  a team has been added to the [mudita-center-internal-releases](https://github.com/mudita/mudita-center-internal-releases), to manage and store necessary updates for pre-release testing.
- changes have been tested with the new repository by self.

After merging this pull request, the following actions are planned:

1. Update environment variables in [Bitwarden](https://bitwarden.com/).
2. Update the Confluence space for the 
  - "[Project tools](https://appnroll.atlassian.net/wiki/spaces/CP/pages/1799192895/Project+tools)" 
  - "[Environmental variables - Mudita Center](https://appnroll.atlassian.net/wiki/spaces/CP/pages/1021673727/Environmental+variables+-+Mudita+Center)"
  - "[Mudita Center Environments](https://appnroll.atlassian.net/wiki/spaces/CP/pages/1545928747/Mudita+Center+Environments)"



<details>
</details>
