### PR TITLE
[CP-2285] File Manager - duplicate files modal for a second shows different modal: uploading failed

### DIFF
--- a/packages/app/src/files-manager/components/files-manager/files-manager.component.tsx
+++ b/packages/app/src/files-manager/components/files-manager/files-manager.component.tsx
@@ -73,7 +73,6 @@ const FilesManager: FunctionComponent<FilesManagerProps> = ({
     deletingInfo: false,
     uploading: false,
     uploadingInfo: false,
-    uploadingFailed: false,
   })
   const [toDeleteFileIds, setToDeleteFileIds] = useState<string[]>([])
   const {
@@ -136,7 +135,6 @@ const FilesManager: FunctionComponent<FilesManagerProps> = ({
   useEffect(() => {
     if (uploading === State.Initial) {
       updateFieldState("uploadingInfo", false)
-      updateFieldState("uploadingFailed", false)
     } else if (uploading === State.Loading) {
       updateFieldState("uploading", true)
     } else if (uploading === State.Loaded) {
@@ -150,7 +148,6 @@ const FilesManager: FunctionComponent<FilesManagerProps> = ({
       clearTimeout(uploadTimeoutRef.current || undefined)
     } else if (uploading === State.Failed) {
       updateFieldState("uploading", false)
-      updateFieldState("uploadingFailed", true)
     }
     // AUTO DISABLED - fix me if you like :)
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -255,7 +252,6 @@ const FilesManager: FunctionComponent<FilesManagerProps> = ({
     openDeleteModal(selectedItems)
   }
   const handleCloseUploadingErrorModal = () => {
-    updateFieldState("uploadingFailed", false)
     resetUploadingState()
   }
   const handleCloseDeletingConfirmationModal = () => {
@@ -284,7 +280,6 @@ const FilesManager: FunctionComponent<FilesManagerProps> = ({
         filesLength={uploadingFileCount}
         uploading={states.uploading}
         uploadingInfo={states.uploadingInfo}
-        uploadingFailed={states.uploadingFailed}
         onCloseUploadingErrorModal={handleCloseUploadingErrorModal}
         pendingFilesCount={pendingFilesCount}
         pendingUpload={uploading === State.Pending}

--- a/packages/app/src/files-manager/components/files-manager/files-manager.interface.tsx
+++ b/packages/app/src/files-manager/components/files-manager/files-manager.interface.tsx
@@ -60,5 +60,4 @@ export interface FileServiceState {
   deletingFailed: boolean
   uploading: boolean
   uploadingInfo: boolean
-  uploadingFailed: boolean
 }

--- a/packages/app/src/files-manager/components/upload-files-modals/upload-files-modals.component.tsx
+++ b/packages/app/src/files-manager/components/upload-files-modals/upload-files-modals.component.tsx
@@ -43,7 +43,6 @@ export const UploadFilesModals: FunctionComponent<UploadFilesModalProps> = ({
   filesLength,
   uploading,
   uploadingInfo,
-  uploadingFailed,
   onCloseUploadingErrorModal,
   pendingUpload,
   pendingFilesCount,
@@ -86,13 +85,13 @@ export const UploadFilesModals: FunctionComponent<UploadFilesModalProps> = ({
           testId={UploadFilesModalsTestIds.UploadedPopUp}
         />
       )}
-      {uploadingFailed &&
-        error?.type !== FilesManagerError.UploadDuplicates &&
-        error?.type !== FilesManagerError.UnsupportedFileFormat &&
-        error?.type !== FilesManagerError.UnsupportedFileSize && (
+      {error &&
+        error.type !== FilesManagerError.UploadDuplicates &&
+        error.type !== FilesManagerError.UnsupportedFileFormat &&
+        error.type !== FilesManagerError.UnsupportedFileSize && (
           <ErrorModal
             testId={UploadFilesModalsTestIds.ErrorModal}
-            open={uploadingFailed}
+            open
             title={intl.formatMessage(errorTitle)}
             subtitle={intl.formatMessage(errorSubtitle)}
             closeModal={onCloseUploadingErrorModal}

--- a/packages/app/src/files-manager/components/upload-files-modals/upload-files-modals.interface.ts
+++ b/packages/app/src/files-manager/components/upload-files-modals/upload-files-modals.interface.ts
@@ -10,7 +10,6 @@ export interface UploadFilesModalProps {
   filesLength: number
   uploading: boolean
   uploadingInfo: boolean
-  uploadingFailed: boolean
   onCloseUploadingErrorModal: () => void
   pendingUpload: boolean
   pendingFilesCount: number

--- a/packages/app/src/files-manager/components/upload-files-modals/upload-files-modals.test.tsx
+++ b/packages/app/src/files-manager/components/upload-files-modals/upload-files-modals.test.tsx
@@ -21,7 +21,6 @@ const defaultProps: UploadFilesModalProps = {
   filesLength: 0,
   uploading: false,
   uploadingInfo: false,
-  uploadingFailed: false,
   error: null,
   onCloseUploadingErrorModal: jest.fn(),
   pendingUpload: false,
@@ -107,10 +106,10 @@ describe("Component: `UploadFilesModals`", () => {
     ).not.toBeInTheDocument()
   })
 
-  test("displays error modal if `uploadingFailed` is equal to `true`", () => {
+  test("displays error modal if there is an error defined", () => {
     const { queryByTestId } = render({
       ...defaultProps,
-      uploadingFailed: true,
+      error: new AppError(FilesManagerError.NotEnoughSpace, "test error"),
     })
 
     expect(
@@ -125,10 +124,9 @@ describe("Component: `UploadFilesModals`", () => {
     ).not.toBeInTheDocument()
   })
 
-  test("displays error modal with `NoSpaceLeft` error if `uploadingFailed` is equal to `true` and error type is equal to `FilesManagerError.NotEnoughSpace`", () => {
+  test("displays error modal with `NoSpaceLeft` error if error type is equal to `FilesManagerError.NotEnoughSpace`", () => {
     const { queryByTestId, queryByText } = render({
       ...defaultProps,
-      uploadingFailed: true,
       error: new AppError(
         FilesManagerError.NotEnoughSpace,
         "Not enough space on your device"
@@ -158,7 +156,10 @@ describe("Component: `UploadFilesModals`", () => {
   test("triggers `onCloseUploadingErrorModal` action when clicks on `close` button", () => {
     const { getByTestId } = render({
       ...defaultProps,
-      uploadingFailed: true,
+      error: new AppError(
+        FilesManagerError.NotEnoughSpace,
+        "Not enough space on your device"
+      ),
     })
 
     const closeModalButton = getByTestId(ModalTestIds.CloseButton)


### PR DESCRIPTION
JIRA Reference: [CP-2285]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated
