### PR TITLE
[CP-2377][Multidevice] Harmony 2 is visible on the list as Harmony 1 

### DIFF
--- a/libs/core/discovery-device/components/device-list-item.component.tsx
+++ b/libs/core/discovery-device/components/device-list-item.component.tsx
@@ -95,15 +95,32 @@ export interface DeviceListItemProps extends Device {
   onDeviceClick: (id: string) => void
 }
 
-const getDeviceTypeName = (deviceType: DeviceType): string => {
-  switch (deviceType) {
-    case DeviceType.MuditaPure:
-      return "Pure"
-    case DeviceType.MuditaHarmony:
-      return "Harmony 1"
-    case DeviceType.APIDevice:
-      return "Kompakt"
+const getDeviceTypeName = (
+  deviceType: DeviceType,
+  caseColour: CaseColor = CaseColor.Black
+): string => {
+  if (deviceType === DeviceType.MuditaPure) {
+    return "Pure"
   }
+
+  if (
+    deviceType === DeviceType.MuditaHarmony &&
+    caseColour === CaseColor.Gray
+  ) {
+    return "Harmony 1"
+  }
+
+  if (
+    deviceType === DeviceType.MuditaHarmony &&
+    caseColour === CaseColor.Black
+  ) {
+    return "Harmony 2"
+  }
+
+  if (deviceType === DeviceType.APIDevice) {
+    return "Kompakt"
+  }
+  return "Unknown Device"
 }
 
 const DeviceListItem: FunctionComponent<DeviceListItemProps> = ({
@@ -127,7 +144,7 @@ const DeviceListItem: FunctionComponent<DeviceListItemProps> = ({
       </DeviceImageWrapper>
       <DeviceInfoContainer>
         <DeviceInfoDeviceTypeName displayStyle={TextDisplayStyle.Headline4}>
-          {getDeviceTypeName(deviceType)}
+          {getDeviceTypeName(deviceType, caseColour)}
         </DeviceInfoDeviceTypeName>
         <Text displayStyle={TextDisplayStyle.Paragraph4} color="secondary">
           {serialNumberHeader}


### PR DESCRIPTION
JIRA Reference: [CP-2377]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2377]: https://appnroll.atlassian.net/browse/CP-2377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ