### PR TITLE
[CP-2383][Multidevice] Incorect serial number display for Harmony with OS below 1.8.0

### DIFF
--- a/libs/core/__deprecated__/renderer/locales/default/en-US.json
+++ b/libs/core/__deprecated__/renderer/locales/default/en-US.json
@@ -671,7 +671,6 @@
   "module.overview.networkTitle": "Pure Status",
   "module.overview.networkTooltipDescription": "You can activate this SIM card by going to the network settings on your phone",
   "module.overview.networkTooltipTitle": "Activate card",
-  "module.overview.noSerialNumberMessage": "-",
   "module.overview.phoneBattery": "Battery",
   "module.overview.phoneDescription": "Mudita Pure",
   "module.overview.phoneDisconnectAction": "Disconnect",

--- a/libs/core/discovery-device/components/device-list-item.component.tsx
+++ b/libs/core/discovery-device/components/device-list-item.component.tsx
@@ -21,6 +21,7 @@ import Text, {
 } from "Core/__deprecated__/renderer/components/core/text/text.component"
 import { intl } from "Core/__deprecated__/renderer/utils/intl"
 import { CaseColor, DeviceType } from "Core/device"
+import { getSerialNumberValue } from "Core/utils/get-serial-number-value"
 
 const messages = defineMessages({
   headerTitle: { id: "module.availableDeviceList.headerTitle" },
@@ -131,11 +132,10 @@ const DeviceListItem: FunctionComponent<DeviceListItemProps> = ({
   deviceType,
   caseColour = CaseColor.Black,
 }) => {
-  const serialNumberValue = serialNumber ?? ""
+  const serialNumberValue = getSerialNumberValue(serialNumber)
 
-  const serialNumberHeader = serialNumber
-    ? intl.formatMessage(messages.serialNumber)
-    : ""
+  const serialNumberHeader =
+    serialNumberValue !== "" ? intl.formatMessage(messages.serialNumber) : ""
 
   return (
     <Container className={className} onClick={() => onDeviceClick(id)}>

--- a/libs/core/overview/components/device-preview/device-preview.component.tsx
+++ b/libs/core/overview/components/device-preview/device-preview.component.tsx
@@ -35,12 +35,12 @@ import Text, {
 } from "Core/__deprecated__/renderer/components/core/text/text.component"
 import { IconSize } from "Core/__deprecated__/renderer/components/core/icon/icon.component"
 import { IconType } from "Core/__deprecated__/renderer/components/core/icon/icon-type"
+import { getSerialNumberValue } from "Core/utils/get-serial-number-value"
 
 const messages = defineMessages({
   serialNumber: { id: "module.overview.serialNumber" },
   phoneDisconnectAction: { id: "module.overview.phoneDisconnectAction" },
   pureSystem: { id: "module.overview.pureSystem" },
-  noSerialNumberMessage: { id: "module.overview.noSerialNumberMessage" },
 })
 
 const DeviceSystemButton = styled(Button)`
@@ -55,6 +55,9 @@ export const DevicePreview: FunctionComponent<DevicePreviewProps> = ({
   deviceType,
   serialNumber,
 }) => {
+  const serialNumberValue = getSerialNumberValue(serialNumber)
+  const serialNumberHeader =
+    serialNumberValue !== "" ? intl.formatMessage(messages.serialNumber) : ""
   const history = useHistory()
   const handleDisconnect = () => {
     onDisconnect()
@@ -77,18 +80,14 @@ export const DevicePreview: FunctionComponent<DevicePreviewProps> = ({
         </DeviceInfo>
 
         <SerialNumberWrapper>
-          <Text
-            displayStyle={TextDisplayStyle.Paragraph4}
-            color="secondary"
-            message={messages.serialNumber}
-          />
+          <Text displayStyle={TextDisplayStyle.Paragraph4} color="secondary">
+            {serialNumberHeader}
+          </Text>
           <Text
             displayStyle={TextDisplayStyle.Paragraph1}
             testId={DeviceTestIds.SerialNumber}
           >
-            {serialNumber
-              ? serialNumber
-              : intl.formatMessage(messages.noSerialNumberMessage)}
+            {serialNumberValue}
           </Text>
         </SerialNumberWrapper>
       </DeviceCardContentWrapper>

--- a/libs/core/utils/get-serial-number-value.ts
+++ b/libs/core/utils/get-serial-number-value.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Mudita sp. z o.o. All rights reserved.
+ * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
+ */
+
+export const getSerialNumberValue = (
+  serialNumber: string | undefined
+): string => {
+  if (serialNumber === undefined) {
+    return ""
+  }
+  if (serialNumber === "00000000000000") {
+    return ""
+  }
+
+  return serialNumber
+}


### PR DESCRIPTION
JIRA Reference: [CP-2383]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2383]: https://appnroll.atlassian.net/browse/CP-2383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ