### PR TITLE
[CP-2379] Handle Battery Critical Level as an initializing step

### DIFF
--- a/libs/core/device-initialization/actions/start-initializing-device/initialize-mudita-pure.ts
+++ b/libs/core/device-initialization/actions/start-initializing-device/initialize-mudita-pure.ts
@@ -12,6 +12,7 @@ import {
   DeviceCommunicationError,
   loadDeviceData,
   PureDeviceData,
+  setCriticalBatteryLevelStatus,
   setOnboardingStatus,
   setUnlockedStatus,
 } from "Core/device"
@@ -44,6 +45,12 @@ export const initializeMuditaPure = async (
 
   if (!unlockDeviceStatusResult.ok) {
     const errorType = unlockDeviceStatusResult.error.type
+
+    // Handle Battery Critical Level as an initializing step
+    if (errorType === DeviceCommunicationError.BatteryCriticalLevel) {
+      dispatch(setCriticalBatteryLevelStatus(true))
+      return
+    }
 
     // Handle EULA as an initializing step
     if (errorType === DeviceCommunicationError.DeviceOnboardingNotFinished) {


### PR DESCRIPTION
JIRA Reference: [CP-2379]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2379]: https://appnroll.atlassian.net/browse/CP-2379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ