### PR TITLE
[CP-2389][Multidevice] User must press Try again on Sync failed modal in order to make a sync

### DIFF
--- a/libs/core/data-sync/actions/update-all-indexes.action.ts
+++ b/libs/core/data-sync/actions/update-all-indexes.action.ts
@@ -4,6 +4,7 @@
  */
 
 import { createAsyncThunk } from "@reduxjs/toolkit"
+import delayResponse from "@appnroll/delay-response"
 import { AppError } from "Core/core/errors"
 import { readAllIndexes } from "Core/data-sync/actions/read-all-indexes.action"
 import { DataSyncError, DataSyncEvent } from "Core/data-sync/constants"
@@ -13,13 +14,25 @@ import { ReduxRootState } from "Core/__deprecated__/renderer/store"
 import { isPureDeviceData } from "Core/device/helpers/is-pure-device-data"
 import { saveIndexRequest } from "Core/index-storage/requests"
 
+/***
+ * `shouldDelay` - Specifies whether to delay the process.
+ * @param {boolean} shouldDelay - Set to `true` to introduce a delay.
+ *
+ * Asynchronously updates all indexes. If `shouldDelay` is `true`,
+ * the process is delayed to ensure adequate time between attempts,
+ * critical for proper device handling.
+***/
+
 export const updateAllIndexes = createAsyncThunk<
   void,
-  void,
+  boolean | undefined,
   { state: ReduxRootState }
 >(
   DataSyncEvent.UpdateAllIndexes,
-  async (_, { dispatch, rejectWithValue, getState }) => {
+  async (shouldDelay = false, { dispatch, rejectWithValue, getState }) => {
+    if(shouldDelay){
+      await delayResponse(Promise.resolve(),30000)
+    }
     const data = deviceDataSelector(getState())
     if (!isPureDeviceData(data)) {
       return


### PR DESCRIPTION
JIRA Reference: [CP-2389]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2389]: https://appnroll.atlassian.net/browse/CP-2389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ