### PR TITLE
[CP-2372][Multidevice] OS update information is globally set - v3

### DIFF
--- a/libs/core/update/actions/check-for-force-update-need/check-for-force-update-need.action.ts
+++ b/libs/core/update/actions/check-for-force-update-need/check-for-force-update-need.action.ts
@@ -9,16 +9,16 @@ import isVersionGreaterOrEqual from "Core/utils/is-version-greater-or-equal"
 import { checkForUpdate } from "Core/update/actions/check-for-update/check-for-update.action"
 import { CheckForUpdateMode, UpdateOsEvent } from "Core/update/constants"
 import { versionFormatter } from "Core/update/helpers"
-import { ReduxRootState, RootState } from "Core/__deprecated__/renderer/store"
+import { ReduxRootState } from "Core/__deprecated__/renderer/store"
 
-export const checkForForceUpdateNeed = createAsyncThunk<boolean, void>(
+export const checkForForceUpdateNeed = createAsyncThunk<boolean, void, { state: ReduxRootState }>(
   UpdateOsEvent.CheckForForceUpdate,
   (_, { getState, dispatch }) => {
     if (!flags.get(Feature.ForceUpdate)) {
       return false
     }
 
-    const { device, settings } = getState() as RootState & ReduxRootState
+    const { device, settings } = getState()
 
     const osVersion = versionFormatter(device.data?.osVersion ?? "")
     const lowestSupportedProductVersion =

--- a/libs/core/update/actions/check-for-update/check-for-update.action.test.ts
+++ b/libs/core/update/actions/check-for-update/check-for-update.action.test.ts
@@ -93,6 +93,9 @@ describe("when fetching all releases fails", () => {
           osVersion: "1.2.0",
         },
       },
+      deviceManager:{
+        activeDeviceId: ""
+      }
     })
 
     const {
@@ -131,6 +134,9 @@ describe("when latest release os version is not greater than current os version"
           osVersion: "1.1.0",
         },
       },
+      deviceManager:{
+        activeDeviceId: ""
+      }
     })
 
     const {
@@ -179,6 +185,9 @@ describe("when latest release os version is greater than current os version", ()
           osVersion: "1.2.0",
         },
       },
+      deviceManager:{
+        activeDeviceId: ""
+      }
     })
 
     const {
@@ -252,6 +261,9 @@ describe("when latest release contains information about mandatory releases", ()
           osVersion: "1.2.0",
         },
       },
+      deviceManager:{
+        activeDeviceId: ""
+      }
     })
 
     const {
@@ -305,6 +317,9 @@ describe("when fetching mandatory releases fails", () => {
           osVersion: "1.2.0",
         },
       },
+      deviceManager:{
+        activeDeviceId: ""
+      }
     })
 
     const {

--- a/libs/core/update/actions/download-updates/download-updates.action.ts
+++ b/libs/core/update/actions/download-updates/download-updates.action.ts
@@ -33,7 +33,6 @@ export const downloadUpdates = createAsyncThunk<
   Params,
   {
     state: ReduxRootState
-    rejectValue: AppError<UpdateError>
   }
 >(
   UpdateOsEvent.DownloadUpdate,

--- a/libs/core/update/actions/start-update-os/start-update-os.action.ts
+++ b/libs/core/update/actions/start-update-os/start-update-os.action.ts
@@ -48,7 +48,6 @@ export const startUpdateOs = createAsyncThunk<
   Params,
   {
     state: ReduxRootState
-    rejectValue: AppError<UpdateError>
   }
 >(
   UpdateOsEvent.StartOsUpdateProcess,

--- a/libs/core/update/constants/errors.constant.ts
+++ b/libs/core/update/constants/errors.constant.ts
@@ -26,4 +26,5 @@ export enum UpdateError {
   TooLowBattery = "TOO_LOW_BATTERY",
   UnexpectedDownloadError = "UNEXPECTED_DOWNLOAD_ERROR",
   ForceUpdateError = "FORCE_UPDATE_ERROR",
+  NoActiveDevice = "UPDATE_NO_ACTIVE_DEVICE",
 }


### PR DESCRIPTION
JIRA Reference: [CP-2372]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2372]: https://appnroll.atlassian.net/browse/CP-2372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ