### PR TITLE
[CP-2371][Multidevice] Overview UI is a bit missaligned due to device image change - v2

### DIFF
--- a/libs/core/overview/components/device-preview/device-preview.component.tsx
+++ b/libs/core/overview/components/device-preview/device-preview.component.tsx
@@ -9,10 +9,7 @@ import { defineMessages } from "react-intl"
 import { DeviceType } from "Core/device/constants"
 import { FunctionComponent } from "Core/core/types/function-component.interface"
 import { DevicePreviewProps } from "Core/overview/components/device-preview/device-preview.interface"
-import {
-  CardAction,
-  CardActionButton,
-} from "Core/overview/components/card.elements"
+import { CardActionButton } from "Core/overview/components/card.elements"
 import { intl } from "Core/__deprecated__/renderer/utils/intl"
 import { useHistory } from "react-router"
 import { DeviceTestIds } from "Core/overview/components/device-preview/device-preview-test-ids.enum"
@@ -22,6 +19,7 @@ import {
   PureSystemButtonContainer,
   SerialNumberWrapper,
   DeviceCardContentWrapper,
+  DisconnectActionCard,
 } from "Core/overview/components/device-preview/device-preview.styled"
 import {
   URL_MAIN,
@@ -92,14 +90,14 @@ export const DevicePreview: FunctionComponent<DevicePreviewProps> = ({
         </SerialNumberWrapper>
       </DeviceCardContentWrapper>
 
-      <CardAction>
+      <DisconnectActionCard>
         <CardActionButton
           active
           label={intl.formatMessage(messages.phoneDisconnectAction)}
           onClick={handleDisconnect}
           data-testid={DeviceTestIds.DisconnectButton}
         />
-      </CardAction>
+      </DisconnectActionCard>
       {deviceType === DeviceType.MuditaPure && (
         <PureSystemButtonContainer>
           <DeviceSystemButton

--- a/libs/core/overview/components/device-preview/device-preview.styled.tsx
+++ b/libs/core/overview/components/device-preview/device-preview.styled.tsx
@@ -4,7 +4,10 @@
  */
 
 import styled from "styled-components"
-import Card, { CardContent } from "Core/overview/components/card.elements"
+import Card, {
+  CardAction,
+  CardContent,
+} from "Core/overview/components/card.elements"
 import { borderColor } from "Core/core/styles/theming/theme-getters"
 
 export const PhoneCard = styled(Card)`
@@ -14,6 +17,11 @@ export const PhoneCard = styled(Card)`
   align-items: center;
   height: 100%;
   min-height: 60rem;
+  padding: 2.4rem 2.4rem 0 2.4rem;
+`
+
+export const DisconnectActionCard = styled(CardAction)`
+  margin-bottom: 2.4rem;
 `
 
 export const DeviceCardContentWrapper = styled.div`
@@ -42,7 +50,6 @@ export const PureSystemButtonContainer = styled.div`
   justify-content: center;
   border-top: 0.1rem solid ${borderColor("separator")};
   width: 100%;
-  margin-top: 2.4rem;
 `
 
 export const SerialNumberWrapper = styled.div`


### PR DESCRIPTION
JIRA Reference: [CP-2371]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2371]: https://appnroll.atlassian.net/browse/CP-2371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ