### PR TITLE
[CP-2374][Multidevice] battery is flat modal is displayed having another modal in the background (regression) 

### DIFF
--- a/libs/core/update/components/update-os-interrupted-flow/update-os-interrupted-flow.container.tsx
+++ b/libs/core/update/components/update-os-interrupted-flow/update-os-interrupted-flow.container.tsx
@@ -3,6 +3,7 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
+import { connect } from "react-redux"
 import { State } from "Core/core/constants"
 import { showModal } from "Core/modals-manager/actions"
 import { ModalStateKey } from "Core/modals-manager/reducers"
@@ -15,15 +16,16 @@ import {
   RootState,
   TmpDispatch,
 } from "Core/__deprecated__/renderer/store"
-import { connect } from "react-redux"
+import { isActiveDeviceProcessingSelector } from "Core/device-manager/selectors/is-active-device-processing.selector"
 
 const mapStateToProps = (state: RootState & ReduxRootState) => {
   return {
     downloadInterruptedModalOpened:
-      state.update.downloadState === DownloadState.Failed,
-    // && !state.device.status.connected,
-    updateInterruptedModalOpened: state.update.updateOsState === State.Failed,
-    // && !state.device.status.connected,
+      state.update.downloadState === DownloadState.Failed &&
+      isActiveDeviceProcessingSelector(state),
+    updateInterruptedModalOpened:
+      state.update.updateOsState === State.Failed &&
+      isActiveDeviceProcessingSelector(state),
     alreadyDownloadedReleases: alreadyProcessedReleasesSelector(
       Mode.DownloadedReleases
     )(state),


### PR DESCRIPTION
JIRA Reference: [CP-2374]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated
