### PR TITLE
[CP-2399][Multidevice] Selection manager once triggered remains set after switching app sections

### DIFF
--- a/libs/core/contacts/actions/delete-contacts.action.test.ts
+++ b/libs/core/contacts/actions/delete-contacts.action.test.ts
@@ -66,6 +66,9 @@ describe("async `deleteContacts` ", () => {
       )
       const mockStore = createMockStore([thunk])({
         contacts: initialState,
+        deviceManager: {
+          activeDeviceId: ""
+        }
       })
       const {
         meta: { requestId },
@@ -97,6 +100,9 @@ describe("async `deleteContacts` ", () => {
       )
       const mockStore = createMockStore([thunk])({
         contacts: initialState,
+        deviceManager: {
+          activeDeviceId: ""
+        }
       })
       const {
         meta: { requestId },
@@ -122,6 +128,9 @@ describe("async `deleteContacts` ", () => {
       )
       const mockStore = createMockStore([thunk])({
         contacts: initialState,
+        deviceManager: {
+          activeDeviceId: ""
+        }
       })
       const {
         meta: { requestId },

--- a/libs/core/contacts/actions/delete-contacts.action.ts
+++ b/libs/core/contacts/actions/delete-contacts.action.ts
@@ -9,11 +9,22 @@ import { ContactsEvent } from "Core/contacts/constants"
 import { ContactID } from "Core/contacts/reducers"
 import { deleteContactsRequest } from "Core/contacts/requests"
 import { AppError } from "Core/core/errors"
+import { isActiveDeviceSet } from "Core/device-manager/selectors/is-active-device-set.selector"
+import { ReduxRootState } from "Core/__deprecated__/renderer/store"
 
-export const deleteContacts = createAsyncThunk<Error | undefined, ContactID[]>(
+export const deleteContacts = createAsyncThunk<
+  Error | undefined,
+  ContactID[],
+  { state: ReduxRootState }
+>(
   ContactsEvent.DeleteContacts,
-  async (ids, { dispatch, rejectWithValue }) => {
+  async (ids, { dispatch, rejectWithValue, getState }) => {
     const { error } = await deleteContactsRequest(ids)
+    const activeDeviceSet = isActiveDeviceSet(getState())
+
+    if (!activeDeviceSet) {
+      return
+    }
 
     if (error && error.data === undefined) {
       return rejectWithValue(

--- a/libs/core/core/components/base-app.component.tsx
+++ b/libs/core/core/components/base-app.component.tsx
@@ -4,6 +4,7 @@
  */
 
 import React from "react"
+import { useHistory } from "react-router-dom"
 import { FunctionComponent } from "Core/core/types/function-component.interface"
 import AppInitialization from "Core/app-initialization/components/app-initialization.component"
 import { useDeviceConnectedEffect } from "Core/core/hooks/use-device-connected-effect"
@@ -17,8 +18,18 @@ import { useDeviceLockedEffect } from "Core/core/hooks/use-device-locked-effect"
 import { useDeviceDetachedEffect } from "Core/core/hooks/use-device-detached-effect"
 import { useAPISerialPortListeners } from "device/feature"
 import { useDeviceConnectFailedEffect } from "Core/core/hooks/use-device-connect-failed-effect"
+import { useRouterListener } from "Core/core/hooks"
+import { URL_MAIN, URL_OVERVIEW } from "Core/__deprecated__/renderer/constants/urls"
+
+const actions = {[URL_MAIN.contacts]: [],
+  [URL_MAIN.phone]: [],
+  [URL_OVERVIEW.root]: [],
+  [URL_MAIN.messages]: [],}
 
 const BaseApp: FunctionComponent = () => {
+  const history = useHistory()
+  useRouterListener(history, actions)
+
   useApplicationUpdateEffects()
   useDeviceConnectedEffect()
   useDeviceConnectFailedEffect()
@@ -26,7 +37,6 @@ const BaseApp: FunctionComponent = () => {
   useDeviceLockedEffect()
   useWatchOutboxEntriesEffect()
   useWatchUnlockStatus()
-
   // API
   useAPISerialPortListeners()
 


### PR DESCRIPTION
JIRA Reference: [CP-2399]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2399]: https://appnroll.atlassian.net/browse/CP-2399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ