### PR TITLE
[CP-2392][Multidevice] After reopening the app it does not see existing backups 

### DIFF
--- a/libs/core/device-initialization/actions/start-initializing-device/initialize-mudita-pure.ts
+++ b/libs/core/device-initialization/actions/start-initializing-device/initialize-mudita-pure.ts
@@ -35,6 +35,7 @@ import { isActiveDeviceProcessingSelector } from "Core/device-manager/selectors/
 import { shouldSkipDataSync } from "Core/device-initialization/actions/start-initializing-device/should-skip-data-sync.helper"
 import { configureDevice } from "Core/device-manager/actions/configure-device.action"
 import { activeDeviceIdSelector } from "Core/device-manager/selectors/active-device-id.selector"
+import { loadBackupData } from "Core/backup"
 
 export const initializeMuditaPure = async (
   history: History,
@@ -103,6 +104,9 @@ export const initializeMuditaPure = async (
       }
     }
   }
+
+
+  await dispatch(loadBackupData())
 
   dispatch(
     setDeviceInitializationStatus(DeviceInitializationStatus.Initialized)

--- a/libs/core/settings/actions/load-settings.action.ts
+++ b/libs/core/settings/actions/load-settings.action.ts
@@ -11,7 +11,6 @@ import { setSettings } from "Core/settings/actions/set-settings.action"
 import logger from "Core/__deprecated__/main/utils/logger"
 import { getConfiguration } from "Core/settings/requests"
 import packageInfo from "../../../../apps/mudita-center/package.json"
-import { loadBackupData } from "Core/backup/actions"
 import { ReduxRootState } from "Core/__deprecated__/renderer/store"
 
 export const loadSettings = createAsyncThunk<
@@ -53,7 +52,6 @@ export const loadSettings = createAsyncThunk<
       },
     })
   )
-  await dispatch(loadBackupData())
 
   return
 })


### PR DESCRIPTION
JIRA Reference: [CP-2392]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2392]: https://appnroll.atlassian.net/browse/CP-2392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ