### PR TITLE
[CP-2400][Multidevice] Disconnected device during OS update - after failed modal, Center acts like device was connected

### DIFF
--- a/libs/core/device-manager/actions/handle-device-detached.action.ts
+++ b/libs/core/device-manager/actions/handle-device-detached.action.ts
@@ -10,6 +10,7 @@ import { DeviceManagerEvent } from "Core/device-manager/constants"
 import {
   URL_DISCOVERY_DEVICE,
   URL_MAIN,
+  URL_ONBOARDING,
 } from "Core/__deprecated__/renderer/constants/urls"
 import { removeDevice } from "Core/device-manager/actions/base.action"
 import { DeviceBaseProperties } from "Core/device/constants/device-base-properties"
@@ -17,6 +18,7 @@ import { getActiveDevice } from "Core/device-manager/selectors/get-active-device
 import { getDevicesSelector } from "Core/device-manager/selectors/get-devices.selector"
 import { isActiveDeviceProcessingSelector } from "Core/device-manager/selectors/is-active-device-processing.selector"
 import { deactivateDevice } from "Core/device-manager/actions/deactivate-device.action"
+import { DownloadState } from "Core/update/constants"
 
 export const handleDeviceDetached = createAsyncThunk<
   void,
@@ -38,6 +40,11 @@ export const handleDeviceDetached = createAsyncThunk<
     const activeDeviceProcessing = isActiveDeviceProcessingSelector(getState())
 
     if (activeDeviceProcessing) {
+      return
+    }
+
+    if (getState().update.downloadState === DownloadState.Loading) {
+      history.push(URL_ONBOARDING.welcome)
       return
     }
 

--- a/libs/core/device-manager/selectors/is-active-device-attached.selector.ts
+++ b/libs/core/device-manager/selectors/is-active-device-attached.selector.ts
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Mudita sp. z o.o. All rights reserved.
+ * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
+ */
+
+import { createSelector } from "@reduxjs/toolkit"
+import { getActiveDevice } from "Core/device-manager/selectors/get-active-device.selector"
+
+export const isActiveDeviceAttachedSelector = createSelector(
+  getActiveDevice,
+  (device): boolean => {
+    return device !== undefined
+  }
+)

--- a/libs/core/update/actions/base.action.ts
+++ b/libs/core/update/actions/base.action.ts
@@ -24,6 +24,3 @@ export const setStateForInstalledRelease = createAction<{
   version: string
   state: ReleaseProcessState
 }>(UpdateOsEvent.SetStateForInstalledRelease)
-export const setDeviceHasBeenDetachedDuringDownload = createAction<boolean>(
-  UpdateOsEvent.DeviceHasBeenDetachedDuringDownload
-)

--- a/libs/core/update/actions/download-updates/download-updates.action.test.ts
+++ b/libs/core/update/actions/download-updates/download-updates.action.test.ts
@@ -25,6 +25,7 @@ import * as osUpdateAlreadyDownloadedCheckModule from "Core/update/requests/os-u
 import createMockStore from "redux-mock-store"
 import thunk from "redux-thunk"
 import { trackOsDownload } from "Core/analytic-data-tracker/helpers/track-os-download"
+import { DeviceManagerState } from "Core/device-manager/reducers/device-manager.interface"
 
 jest.mock("Core/analytic-data-tracker/helpers/track-os-download")
 
@@ -62,6 +63,11 @@ const mockedRelease2: OsRelease = {
   mandatoryVersions: [],
 }
 
+const mockedDeviceManagerState = {
+  devices: [{ id: "1" }],
+  activeDeviceId: "1",
+} as unknown as DeviceManagerState
+
 const params = { releases: [mockedRelease, mockedRelease2] }
 
 const getParamsForDownloadingIntallingRelaseStateAction = (
@@ -84,9 +90,6 @@ describe("when battery is lower than 40%", () => {
         data: {
           batteryLevel: 0.39,
         },
-      },
-      update: {
-        deviceHasBeenDetachedDuringDownload: false,
       },
     })
 
@@ -125,9 +128,7 @@ describe("when some of the updates have been downloaded before", () => {
           batteryLevel: 0.55,
         },
       },
-      update: {
-        deviceHasBeenDetachedDuringDownload: false,
-      },
+      deviceManager: mockedDeviceManagerState,
     })
 
     const {
@@ -186,9 +187,7 @@ describe("when update downloads successfully", () => {
           batteryLevel: 0.55,
         },
       },
-      update: {
-        deviceHasBeenDetachedDuringDownload: false,
-      },
+      deviceManager: mockedDeviceManagerState,
     })
 
     const {
@@ -243,9 +242,7 @@ describe("when download is cancelled by user", () => {
           batteryLevel: 0.55,
         },
       },
-      update: {
-        deviceHasBeenDetachedDuringDownload: false,
-      },
+      deviceManager: mockedDeviceManagerState,
     })
 
     const {
@@ -293,9 +290,7 @@ describe("when download failed", () => {
           batteryLevel: 0.55,
         },
       },
-      update: {
-        deviceHasBeenDetachedDuringDownload: false,
-      },
+      deviceManager: mockedDeviceManagerState,
     })
 
     const {

--- a/libs/core/update/components/update-os-interrupted-flow/update-os-interrupted-flow.component.tsx
+++ b/libs/core/update/components/update-os-interrupted-flow/update-os-interrupted-flow.component.tsx
@@ -28,6 +28,8 @@ export const UpdateOsInterruptedFlow: FunctionComponent<
       return
     }
 
+    console.log("history: ", history)
+
     history.push(URL_ONBOARDING.welcome)
   }, [history, downloadInterruptedModalOpened, updateInterruptedModalOpened])
 

--- a/libs/core/update/components/update-os-interrupted-flow/update-os-interrupted-flow.component.tsx
+++ b/libs/core/update/components/update-os-interrupted-flow/update-os-interrupted-flow.component.tsx
@@ -3,33 +3,51 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
+import React, { FunctionComponent, useEffect } from "react"
+import { useHistory } from "react-router-dom"
+import { URL_ONBOARDING } from "Core/__deprecated__/renderer/constants/urls"
 import { DownloadingUpdateInterruptedModal } from "Core/overview/components/update-os-modals/downloading-update-interrupted-modal"
 import { UpdateInterruptedModal } from "Core/overview/components/update-os-modals/update-interrupted-modal"
 import { UpdateOsInterruptedFlowTestIds } from "Core/update/components/update-os-interrupted-flow/update-os-interrupted-flow-test-ids"
 import { UpdateOsInterruptedFlowProps } from "Core/update/components/update-os-interrupted-flow/update-os-interrupted-flow.interface"
-import React, { FunctionComponent } from "react"
 
 export const UpdateOsInterruptedFlow: FunctionComponent<
   UpdateOsInterruptedFlowProps
 > = ({
   onClose,
+  deactivateDevice,
   alreadyDownloadedReleases,
   alreadyInstalledReleases,
   downloadInterruptedModalOpened,
   updateInterruptedModalOpened,
 }) => {
+  const history = useHistory()
+
+  useEffect(() => {
+    if (!downloadInterruptedModalOpened && !updateInterruptedModalOpened) {
+      return
+    }
+
+    history.push(URL_ONBOARDING.welcome)
+  }, [history, downloadInterruptedModalOpened, updateInterruptedModalOpened])
+
+  const handleClose = async () => {
+    await deactivateDevice()
+    onClose()
+  }
+
   return (
     <>
       <DownloadingUpdateInterruptedModal
         testId={UpdateOsInterruptedFlowTestIds.DownloadingInterruptedModal}
         open={downloadInterruptedModalOpened}
-        onClose={onClose}
+        onClose={handleClose}
         alreadyDownloadedReleases={alreadyDownloadedReleases}
       />
       <UpdateInterruptedModal
         testId={UpdateOsInterruptedFlowTestIds.UpdatingInterruptedModal}
         open={updateInterruptedModalOpened}
-        onClose={onClose}
+        onClose={handleClose}
         alreadyInstalledReleases={alreadyInstalledReleases}
       />
     </>

--- a/libs/core/update/components/update-os-interrupted-flow/update-os-interrupted-flow.container.tsx
+++ b/libs/core/update/components/update-os-interrupted-flow/update-os-interrupted-flow.container.tsx
@@ -16,16 +16,17 @@ import {
   RootState,
   TmpDispatch,
 } from "Core/__deprecated__/renderer/store"
-import { isActiveDeviceProcessingSelector } from "Core/device-manager/selectors/is-active-device-processing.selector"
+import { isActiveDeviceAttachedSelector } from "Core/device-manager/selectors/is-active-device-attached.selector"
+import { deactivateDevice } from "Core/device-manager/actions/deactivate-device.action"
 
 const mapStateToProps = (state: RootState & ReduxRootState) => {
   return {
     downloadInterruptedModalOpened:
       state.update.downloadState === DownloadState.Failed &&
-      isActiveDeviceProcessingSelector(state),
+      !isActiveDeviceAttachedSelector(state),
     updateInterruptedModalOpened:
       state.update.updateOsState === State.Failed &&
-      isActiveDeviceProcessingSelector(state),
+      !isActiveDeviceAttachedSelector(state),
     alreadyDownloadedReleases: alreadyProcessedReleasesSelector(
       Mode.DownloadedReleases
     )(state),
@@ -36,13 +37,14 @@ const mapStateToProps = (state: RootState & ReduxRootState) => {
 }
 
 const mapDispatchToProps = (dispatch: TmpDispatch) => ({
-  // AUTO DISABLED - fix me if you like :)
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   onClose: () => dispatch(closeUpdateFlow()),
   openContactSupportFlow: () =>
-    // AUTO DISABLED - fix me if you like :)
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     dispatch(showModal(ModalStateKey.ContactSupportFlow)),
+  deactivateDevice: () =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    dispatch(deactivateDevice()),
 })
 
 export const UpdateOsInterruptedFlowContainer = connect(

--- a/libs/core/update/components/update-os-interrupted-flow/update-os-interrupted-flow.interface.ts
+++ b/libs/core/update/components/update-os-interrupted-flow/update-os-interrupted-flow.interface.ts
@@ -7,6 +7,7 @@ import { OsRelease } from "Core/update/dto"
 
 export interface UpdateOsInterruptedFlowProps {
   onClose: () => void
+  deactivateDevice: () => Promise<void>
   alreadyDownloadedReleases: OsRelease[]
   alreadyInstalledReleases: OsRelease[]
   downloadInterruptedModalOpened: boolean

--- a/libs/core/update/components/update-os-interrupted-flow/update-os-interrupted-flow.test.tsx
+++ b/libs/core/update/components/update-os-interrupted-flow/update-os-interrupted-flow.test.tsx
@@ -3,11 +3,19 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
+import React from "react"
 import { UpdateOsInterruptedFlowTestIds } from "Core/update/components/update-os-interrupted-flow/update-os-interrupted-flow-test-ids"
 import { UpdateOsInterruptedFlow } from "Core/update/components/update-os-interrupted-flow/update-os-interrupted-flow.component"
 import { UpdateOsInterruptedFlowProps } from "Core/update/components/update-os-interrupted-flow/update-os-interrupted-flow.interface"
 import { renderWithThemeAndIntl } from "Core/__deprecated__/renderer/utils/render-with-theme-and-intl"
-import React from "react"
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: () => ({
+    push: jest.fn(),
+  }),
+}));
 
 const defaultProps: UpdateOsInterruptedFlowProps = {
   alreadyDownloadedReleases: [],
@@ -17,7 +25,6 @@ const defaultProps: UpdateOsInterruptedFlowProps = {
   onClose: jest.fn(),
   deactivateDevice: jest.fn(),
 }
-
 const render = (extraProps?: Partial<UpdateOsInterruptedFlowProps>) => {
   const props = {
     ...defaultProps,

--- a/libs/core/update/components/update-os-interrupted-flow/update-os-interrupted-flow.test.tsx
+++ b/libs/core/update/components/update-os-interrupted-flow/update-os-interrupted-flow.test.tsx
@@ -15,6 +15,7 @@ const defaultProps: UpdateOsInterruptedFlowProps = {
   downloadInterruptedModalOpened: false,
   updateInterruptedModalOpened: false,
   onClose: jest.fn(),
+  deactivateDevice: jest.fn(),
 }
 
 const render = (extraProps?: Partial<UpdateOsInterruptedFlowProps>) => {

--- a/libs/core/update/constants/event.constant.ts
+++ b/libs/core/update/constants/event.constant.ts
@@ -18,5 +18,4 @@ export enum UpdateOsEvent {
   CheckForForceUpdate = "CHECK_FOR_FORCE_UPDATE",
   StartOsForceUpdateProcess = "START_OS_FORCE_UPDATE_PROCESS",
   CloseForceUpdateFlow = "CLOSE_FORCE_UPDATE_FLOW",
-  DeviceHasBeenDetachedDuringDownload = "DEVICE_HAS_BEEN_DETACHED_DURING_DOWNLOAD",
 }

--- a/libs/core/update/reducers/update-os.interface.ts
+++ b/libs/core/update/reducers/update-os.interface.ts
@@ -22,7 +22,6 @@ export interface UpdateOsState {
   error: AppError<UpdateError> | null
   needsForceUpdate: boolean
   checkedForForceUpdateNeed: boolean
-  deviceHasBeenDetachedDuringDownload: boolean
   data: {
     allReleases: OsRelease[] | null
     availableReleasesForUpdate: OsRelease[] | null

--- a/libs/core/update/reducers/update-os.reducer.test.ts
+++ b/libs/core/update/reducers/update-os.reducer.test.ts
@@ -31,11 +31,11 @@ const mockHistory = {
   block: jest.fn(),
   listen: jest.fn(),
   location: { pathname: "", search: "", hash: "", state: null },
-};
+}
 
 jest.mock("history", () => ({
   createHashHistory: jest.fn(() => mockHistory),
-}));
+}))
 
 const exampleError = new AppError(
   UpdateError.UpdateOsProcess,
@@ -68,7 +68,6 @@ test("empty event returns initial state", () => {
         "downloadedProcessedReleases": null,
         "updateProcessedReleases": null,
       },
-      "deviceHasBeenDetachedDuringDownload": false,
       "downloadState": 0,
       "error": null,
       "forceUpdateState": 0,

--- a/libs/core/update/reducers/update-os.reducer.ts
+++ b/libs/core/update/reducers/update-os.reducer.ts
@@ -20,7 +20,6 @@ import {
   startUpdateOs,
   forceUpdate,
   checkForForceUpdateNeed,
-  setDeviceHasBeenDetachedDuringDownload,
 } from "Core/update/actions"
 
 import {
@@ -41,7 +40,6 @@ export const initialState: UpdateOsState = {
   error: null,
   needsForceUpdate: false,
   checkedForForceUpdateNeed: false,
-  deviceHasBeenDetachedDuringDownload: false,
   data: {
     allReleases: null,
     availableReleasesForUpdate: null,
@@ -53,12 +51,6 @@ export const initialState: UpdateOsState = {
 export const updateOsReducer = createReducer<UpdateOsState>(
   initialState,
   (builder) => {
-    builder.addCase(setDeviceHasBeenDetachedDuringDownload, (state, action) => {
-      return {
-        ...state,
-        deviceHasBeenDetachedDuringDownload: action.payload,
-      }
-    })
     builder.addCase(closeForceUpdateFlow, (state) => {
       return {
         ...state,
@@ -97,13 +89,9 @@ export const updateOsReducer = createReducer<UpdateOsState>(
         downloadState: DownloadState.Initial,
       }
     })
-    builder.addCase(clearStateAndData, (state) => {
+    builder.addCase(clearStateAndData, () => {
       return {
         ...initialState,
-        deviceHasBeenDetachedDuringDownload:
-          state.downloadState === DownloadState.Loading
-            ? state.deviceHasBeenDetachedDuringDownload
-            : initialState.deviceHasBeenDetachedDuringDownload,
       }
     })
     builder.addCase(setStateForDownloadedRelease, (state, action) => {
@@ -216,19 +204,19 @@ export const updateOsReducer = createReducer<UpdateOsState>(
         return {
           ...state,
           error: null,
-          silentCheckForUpdate: SilentCheckForUpdateState.Initial
+          silentCheckForUpdate: SilentCheckForUpdateState.Initial,
         }
       } else if (action.meta.arg.mode === CheckForUpdateMode.SilentCheck) {
         return {
           ...state,
           error: error ?? null,
-          silentCheckForUpdate: SilentCheckForUpdateState.Failed
+          silentCheckForUpdate: SilentCheckForUpdateState.Failed,
         }
       } else {
         return {
           ...state,
           error: error ?? null,
-          checkForUpdateState: CheckForUpdateState.Failed
+          checkForUpdateState: CheckForUpdateState.Failed,
         }
       }
     })
@@ -257,7 +245,6 @@ export const updateOsReducer = createReducer<UpdateOsState>(
         state.downloadState = DownloadState.Failed
         state.error = error
       }
-      state.deviceHasBeenDetachedDuringDownload = false
     })
     builder.addCase(cancelDownload, (state) => {
       state.downloadState = DownloadState.Cancelled


### PR DESCRIPTION
JIRA Reference: [CP-2400]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2400]: https://appnroll.atlassian.net/browse/CP-2400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ