### PR TITLE
[CP-2419][Multidevice] Locking Pure does not seem to interupt the ongoing operation

### DIFF
--- a/libs/core/contacts/services/contact.service.ts
+++ b/libs/core/contacts/services/contact.service.ts
@@ -22,6 +22,7 @@ import {
   RequestResponse,
   RequestResponseStatus,
 } from "Core/core/types/request-response.interface"
+import logger from "Core/__deprecated__/main/utils/logger"
 
 export class ContactService {
   constructor(
@@ -194,6 +195,17 @@ export class ContactService {
           status: RequestResponseStatus.Error,
           error: {
             message: "deleteContacts is break",
+          },
+        }
+      }
+
+      logger.info(`ContactService deleteContacts: ${JSON.stringify(result)}`)
+
+      if (error?.type === DeviceCommunicationError.DeviceLocked) {
+        return {
+          status: RequestResponseStatus.Error,
+          error: {
+            message: "deleteContacts is break by locked device",
           },
         }
       }

--- a/libs/core/device-initialization/components/passcode-modal/passcode-modal.container.tsx
+++ b/libs/core/device-initialization/components/passcode-modal/passcode-modal.container.tsx
@@ -3,7 +3,7 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import React from "react"
+import React, { useEffect } from "react"
 import { FunctionComponent } from "Core/core/types/function-component.interface"
 import PasscodeModal, {
   UnlockDeviceReturnType,
@@ -24,6 +24,7 @@ import { useWatchLockTimeEffect } from "Core/device-initialization/components/pa
 import { useWatchUnlockStatus } from "Core/device-initialization/components/passcode-modal/use-watch-unlock-status-effect"
 import { setDataSyncInitState } from "Core/data-sync/actions"
 import { getDevicesSelector } from "Core/device-manager/selectors/get-devices.selector"
+import modalService from "Core/__deprecated__/renderer/components/core/modal/modal.service"
 
 const PasscodeModalContainer: FunctionComponent = () => {
   useWatchLockTimeEffect()
@@ -47,6 +48,11 @@ const PasscodeModalContainer: FunctionComponent = () => {
   const handleUnlockDevice = (code: number[]): UnlockDeviceReturnType => {
     return dispatch(unlockDevice(code)) as unknown as UnlockDeviceReturnType
   }
+
+  useEffect(()=> {
+    // handle closing contact import failure modal
+    void modalService.closeModal(true)
+  }, [])
 
   return (
     <PasscodeModal


### PR DESCRIPTION
JIRA Reference: [CP-2419]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2419]: https://appnroll.atlassian.net/browse/CP-2419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ