### PR TITLE
[CP-2421][Multidevice] switching Pure during restore operation - Center keeps displaying first one

### DIFF
--- a/libs/core/device-manager/actions/handle-device-detached.action.ts
+++ b/libs/core/device-manager/actions/handle-device-detached.action.ts
@@ -19,6 +19,7 @@ import { getDevicesSelector } from "Core/device-manager/selectors/get-devices.se
 import { isActiveDeviceProcessingSelector } from "Core/device-manager/selectors/is-active-device-processing.selector"
 import { deactivateDevice } from "Core/device-manager/actions/deactivate-device.action"
 import { DownloadState } from "Core/update/constants"
+import { cancelOsDownload } from "Core/update/requests"
 
 export const handleDeviceDetached = createAsyncThunk<
   void,
@@ -44,6 +45,8 @@ export const handleDeviceDetached = createAsyncThunk<
     }
 
     if (getState().update.downloadState === DownloadState.Loading) {
+      await dispatch(deactivateDevice())
+      cancelOsDownload()
       history.push(URL_ONBOARDING.welcome)
       return
     }

--- a/libs/core/device/actions/get-onboarding-status.action.ts
+++ b/libs/core/device/actions/get-onboarding-status.action.ts
@@ -29,7 +29,7 @@ export const getOnboardingStatus = createAsyncThunk<
       const { ok, error } = await unlockDeviceStatusRequest()
       return (
         ok ||
-        error?.type === DeviceCommunicationError.DeviceOnboardingNotFinished
+        error?.type !== DeviceCommunicationError.DeviceOnboardingNotFinished
       )
     } else if (deviceType === DeviceType.MuditaHarmony) {
       const { ok, data } = await getDeviceInfoRequest()

--- a/libs/core/overview/components/overview-screens/pure-overview/pure-overview.component.tsx
+++ b/libs/core/overview/components/overview-screens/pure-overview/pure-overview.component.tsx
@@ -28,6 +28,7 @@ import { ipcRenderer } from "electron-better-ipc"
 import React, { useEffect, useState } from "react"
 import { CheckForUpdateState } from "Core/update/constants/check-for-update-state.constant"
 import { useWatchDeviceDataEffect } from "Core/overview/components/overview-screens/helpers/use-watch-device-data-effect"
+import { useHandleDeviceDetached } from "Core/overview/components/overview-screens/pure-overview/use-handle-device-detached.hook"
 
 export const PureOverview: FunctionComponent<PureOverviewProps> = ({
   batteryLevel = 0,
@@ -78,6 +79,8 @@ export const PureOverview: FunctionComponent<PureOverviewProps> = ({
   backupActionDisabled,
 }) => {
   useWatchDeviceDataEffect()
+  const handleDeviceDetached = useHandleDeviceDetached()
+
   const [openModal, setOpenModal] = useState({
     backupStartModal: false,
     loadingModal: false,
@@ -126,6 +129,7 @@ export const PureOverview: FunctionComponent<PureOverviewProps> = ({
   const closeBackupDeviceFlowState = () => {
     setBackupDeviceFlowState(undefined)
     readBackupDeviceDataState()
+    handleDeviceDetached()
   }
 
   useEffect(() => {
@@ -150,6 +154,7 @@ export const PureOverview: FunctionComponent<PureOverviewProps> = ({
   const closeRestoreDeviceFlowState = () => {
     setRestoreDeviceFlowState(undefined)
     readRestoreDeviceDataState()
+    handleDeviceDetached()
   }
 
   useEffect(() => {

--- a/libs/core/overview/components/overview-screens/pure-overview/use-handle-device-detached.hook.ts
+++ b/libs/core/overview/components/overview-screens/pure-overview/use-handle-device-detached.hook.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Mudita sp. z o.o. All rights reserved.
+ * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
+ */
+
+import { useHistory } from "react-router-dom"
+import { useDispatch, useSelector } from "react-redux"
+import { useCallback } from "react"
+import { Dispatch } from "Core/__deprecated__/renderer/store"
+import { isActiveDeviceAttachedSelector } from "Core/device-manager/selectors/is-active-device-attached.selector"
+import { getDevicesSelector } from "Core/device-manager/selectors/get-devices.selector"
+import { deactivateDevice } from "Core/device-manager/actions/deactivate-device.action"
+import { URL_DISCOVERY_DEVICE, URL_MAIN } from "Core/__deprecated__/renderer/constants/urls"
+
+export const useHandleDeviceDetached = () => {
+  const history = useHistory()
+  const dispatch = useDispatch<Dispatch>()
+  const activeDeviceAttached = useSelector(isActiveDeviceAttachedSelector)
+  const devices = useSelector(getDevicesSelector)
+
+  return useCallback( () => {
+    if (!activeDeviceAttached) {
+      void dispatch(deactivateDevice())
+      if (devices.length > 1) {
+        history.push(URL_DISCOVERY_DEVICE.availableDeviceListModal)
+      } else if (devices.length === 1) {
+        history.push(URL_DISCOVERY_DEVICE.root)
+      } else {
+        history.push(URL_MAIN.news)
+      }
+    }
+  }, [devices, history, dispatch, activeDeviceAttached])
+}

--- a/libs/core/update/components/update-os-interrupted-flow/update-os-interrupted-flow.component.tsx
+++ b/libs/core/update/components/update-os-interrupted-flow/update-os-interrupted-flow.component.tsx
@@ -24,11 +24,9 @@ export const UpdateOsInterruptedFlow: FunctionComponent<
   const history = useHistory()
 
   useEffect(() => {
-    if (!downloadInterruptedModalOpened && !updateInterruptedModalOpened) {
+    if (!updateInterruptedModalOpened) {
       return
     }
-
-    console.log("history: ", history)
 
     history.push(URL_ONBOARDING.welcome)
   }, [history, downloadInterruptedModalOpened, updateInterruptedModalOpened])
@@ -42,8 +40,8 @@ export const UpdateOsInterruptedFlow: FunctionComponent<
     <>
       <DownloadingUpdateInterruptedModal
         testId={UpdateOsInterruptedFlowTestIds.DownloadingInterruptedModal}
-        open={downloadInterruptedModalOpened}
-        onClose={handleClose}
+        open={downloadInterruptedModalOpened && history.location.pathname === URL_ONBOARDING.welcome}
+        onClose={onClose}
         alreadyDownloadedReleases={alreadyDownloadedReleases}
       />
       <UpdateInterruptedModal

--- a/libs/core/update/components/update-os-interrupted-flow/update-os-interrupted-flow.container.tsx
+++ b/libs/core/update/components/update-os-interrupted-flow/update-os-interrupted-flow.container.tsx
@@ -22,8 +22,8 @@ import { deactivateDevice } from "Core/device-manager/actions/deactivate-device.
 const mapStateToProps = (state: RootState & ReduxRootState) => {
   return {
     downloadInterruptedModalOpened:
-      state.update.downloadState === DownloadState.Failed &&
-      !isActiveDeviceAttachedSelector(state),
+      state.update.downloadState === DownloadState.Failed ||
+      state.update.downloadState === DownloadState.Cancelled,
     updateInterruptedModalOpened:
       state.update.updateOsState === State.Failed &&
       !isActiveDeviceAttachedSelector(state),

--- a/libs/core/update/components/update-os-interrupted-flow/update-os-interrupted-flow.test.tsx
+++ b/libs/core/update/components/update-os-interrupted-flow/update-os-interrupted-flow.test.tsx
@@ -8,12 +8,14 @@ import { UpdateOsInterruptedFlowTestIds } from "Core/update/components/update-os
 import { UpdateOsInterruptedFlow } from "Core/update/components/update-os-interrupted-flow/update-os-interrupted-flow.component"
 import { UpdateOsInterruptedFlowProps } from "Core/update/components/update-os-interrupted-flow/update-os-interrupted-flow.interface"
 import { renderWithThemeAndIntl } from "Core/__deprecated__/renderer/utils/render-with-theme-and-intl"
+import { URL_ONBOARDING } from "Core/__deprecated__/renderer/constants/urls"
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-return
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useHistory: () => ({
     push: jest.fn(),
+    location: { pathname: URL_ONBOARDING.welcome },
   }),
 }));
 


### PR DESCRIPTION
JIRA Reference: [CP-2421]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2421]: https://appnroll.atlassian.net/browse/CP-2421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ