### PR TITLE
[CP-2419][Multidevice] Locking Pure does not seem to interupt the ongoing operation - v2

### DIFF
--- a/libs/core/contacts/actions/import-contact.action.ts
+++ b/libs/core/contacts/actions/import-contact.action.ts
@@ -30,6 +30,12 @@ export const importContact = createAsyncThunk<Error | Contact, NewContact>(
       return response.data ?? contact
     }
 
+    if (status === RequestResponseStatus.InternalServerError) {
+      return rejectWithValue(
+        new AppError(RequestResponseStatus.InternalServerError, "")
+      )
+    }
+
     if (error || !data) {
       return rejectWithValue(
         new AppError(


### PR DESCRIPTION
JIRA Reference: [CP-2419]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2419]: https://appnroll.atlassian.net/browse/CP-2419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ