### PR TITLE
[CP-2434][Multidevice] Icon on the EULA prompt is inconsistent with the design

### DIFF
--- a/libs/core/eula-agreement/components/agreement-modal/agreement-modal.component.tsx
+++ b/libs/core/eula-agreement/components/agreement-modal/agreement-modal.component.tsx
@@ -41,7 +41,7 @@ export const DescriptionText = styled(Text)`
 export const AgreementModal: FunctionComponent<AgreementModalProps> = ({
   open,
   onActionButtonClick,
-                                                                         closeModal
+  closeModal,
 }) => {
   return (
     <ModalDialog
@@ -57,7 +57,7 @@ export const AgreementModal: FunctionComponent<AgreementModalProps> = ({
     >
       <ModalContent>
         <RoundIconWrapper>
-          <Icon type={IconType.MuditaLogo} width={4.8} />
+          <Icon type={IconType.Exclamation} width={4.8} />
         </RoundIconWrapper>
         <DescriptionText
           testId={AgreementModalIds.Text}


### PR DESCRIPTION
JIRA Reference: [CP-2434]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2434]: https://appnroll.atlassian.net/browse/CP-2434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ