### PR TITLE
[CP-2430][Multidevice] File manager memory usage is incorrectly calculated / no update

### DIFF
--- a/libs/core/files-manager/actions/delete-files.action.ts
+++ b/libs/core/files-manager/actions/delete-files.action.ts
@@ -8,6 +8,7 @@ import { FilesManagerEvent } from "Core/files-manager/constants"
 import { deleteFilesRequest } from "Core/files-manager/requests/delete-files.request"
 import { loadStorageInfoAction } from "Core/device/actions/load-storage-info.action"
 import { ReduxRootState } from "Core/__deprecated__/renderer/store"
+import { loadDeviceData } from "Core/device"
 
 export const deleteFiles = createAsyncThunk<
   string[],
@@ -21,6 +22,8 @@ export const deleteFiles = createAsyncThunk<
   }
 
   void dispatch(loadStorageInfoAction())
+
+  await dispatch(loadDeviceData())
 
   return result.data
 })

--- a/libs/core/files-manager/actions/get-files.action.test.ts
+++ b/libs/core/files-manager/actions/get-files.action.test.ts
@@ -14,8 +14,20 @@ import { File } from "Core/files-manager/dto"
 import { getFiles } from "Core/files-manager/actions"
 import { DeviceDirectory } from "Core/files-manager/constants"
 import { testError } from "Core/__deprecated__/renderer/store/constants"
+import * as loadDeviceDataActionModule from "Core/device/actions/load-device-data.action"
+import { fulfilledAction } from "Core/__deprecated__/renderer/store"
+import { DeviceEvent } from "Core/device"
 
 jest.mock("Core/files-manager/requests/get-files.request")
+
+jest
+  .spyOn(loadDeviceDataActionModule, "loadDeviceData")
+  .mockImplementation(
+    () =>
+      ({
+        type: fulfilledAction(DeviceEvent.LoadDeviceData),
+      } as unknown as jest.Mock)
+  )
 
 const successObjectResult: ResultObject<File[]> = Result.success([
   {
@@ -56,6 +68,9 @@ describe("when `getFiles` request return success result", () => {
 
     expect(mockStore.getActions()).toEqual([
       getFiles.pending(requestId, DeviceDirectory.Music),
+      {
+        type: fulfilledAction(DeviceEvent.LoadDeviceData),
+      },
       getFiles.fulfilled(
         successObjectResult.data,
         requestId,

--- a/libs/core/files-manager/actions/get-files.action.ts
+++ b/libs/core/files-manager/actions/get-files.action.ts
@@ -11,10 +11,12 @@ import {
 } from "Core/files-manager/constants"
 import { getFilesRequest } from "Core/files-manager/requests/get-files.request"
 import { File } from "Core/files-manager/dto"
+import { loadDeviceData } from "Core/device"
+import { ReduxRootState } from "Core/__deprecated__/renderer/store"
 
-export const getFiles = createAsyncThunk<File[], DeviceDirectory>(
+export const getFiles = createAsyncThunk<File[], DeviceDirectory, { state: ReduxRootState }>(
   FilesManagerEvent.GetFiles,
-  async (payload, { rejectWithValue }) => {
+  async (payload, { rejectWithValue, dispatch }) => {
     const result = await getFilesRequest({
       directory: payload,
       filter: { extensions: eligibleFormat },
@@ -23,6 +25,8 @@ export const getFiles = createAsyncThunk<File[], DeviceDirectory>(
     if (!result.ok || !result.data) {
       return rejectWithValue(result.error)
     }
+
+    await dispatch(loadDeviceData())
 
     return result.data
   }

--- a/libs/core/files-manager/actions/upload-file.action.test.ts
+++ b/libs/core/files-manager/actions/upload-file.action.test.ts
@@ -3,7 +3,7 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { DeviceType } from "Core/device/constants"
+import { DeviceEvent, DeviceType } from "Core/device/constants"
 import createMockStore from "redux-mock-store"
 import thunk from "redux-thunk"
 import { AnyAction } from "@reduxjs/toolkit"
@@ -22,6 +22,7 @@ import {
 } from "Core/files-manager/actions/base.action"
 import { getFiles } from "Core/files-manager/actions/get-files.action"
 import { getPathsRequest } from "Core/file-system/requests"
+import * as loadStorageInfoActionModule from "Core/device/actions/load-storage-info.action"
 
 jest.mock("Core/file-system/requests/get-paths.request")
 jest.mock("Core/files-manager/requests")
@@ -32,13 +33,14 @@ const GET_FILES_MOCK_RESULT = {
 }
 
 jest.mock("Core/files-manager/actions/get-files.action")
-
-jest.mock("Core/device/actions/load-storage-info.action", () => ({
-  loadStorageInfoAction: jest.fn().mockReturnValue({
-    type: pendingAction("DEVICE_LOAD_STORAGE_INFO"),
-    payload: undefined,
-  }),
-}))
+jest
+  .spyOn(loadStorageInfoActionModule, "loadStorageInfoAction")
+  .mockImplementation(
+    () =>
+      ({
+        type: pendingAction(DeviceEvent.LoadStorageInfo),
+      } as unknown as jest.Mock)
+  )
 
 const pathsMock = ["/path/file-1.mp3", "/path/file-2.wav"]
 const errorMock = new AppError("SOME_ERROR_TYPE", "Luke, I'm your error")
@@ -81,8 +83,7 @@ describe("when `uploadFileRequest` request return Result.success with uploaded f
       setUploadingState(State.Loading),
       GET_FILES_MOCK_RESULT,
       {
-        type: pendingAction("DEVICE_LOAD_STORAGE_INFO"),
-        payload: undefined,
+        type: pendingAction(DeviceEvent.LoadStorageInfo),
       },
       setUploadingState(State.Loaded),
       setUploadBlocked(false),

--- a/libs/core/files-manager/components/files-manager/get-spaces.helper.test.ts
+++ b/libs/core/files-manager/components/files-manager/get-spaces.helper.test.ts
@@ -3,7 +3,7 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { getSpaces } from "Core/files-manager/components/files-manager/get-spaces.helper"
+import { getSpaces } from "Core/files-manager/components/files-manager/use-spaces/get-spaces.helper"
 import { File } from "Core/files-manager/dto"
 
 describe("`getSpaces` helper", () => {

--- a/libs/core/files-manager/components/files-manager/use-disk-space-categories.hook.ts
+++ b/libs/core/files-manager/components/files-manager/use-disk-space-categories.hook.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Mudita sp. z o.o. All rights reserved.
+ * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
+ */
+
+import { useEffect, useState } from "react"
+import { DiskSpaceCategory } from "Core/files-manager/components/files-manager/files-manager.interface"
+import {
+  DiskSpaceCategoryType,
+  filesSummaryElements,
+} from "Core/files-manager/constants"
+import { Spaces } from "Core/files-manager/components/files-manager/use-spaces/spaces.interface"
+import { File } from "Core/files-manager/dto"
+
+const useDiskSpaceCategories = (
+  files: File[] | null,
+  { freeSpace, musicSpace, otherSpace, reservedSpace }: Spaces
+): DiskSpaceCategory[] | null => {
+  const [diskSpaceCategories, setDiskSpaceCategories] = useState<
+    DiskSpaceCategory[] | null
+  >(null)
+
+  useEffect(() => {
+    const getDiskSpaceCategories = (
+      element: DiskSpaceCategory
+    ): DiskSpaceCategory => {
+      const elements = {
+        [DiskSpaceCategoryType.Free]: { ...element, size: freeSpace },
+        [DiskSpaceCategoryType.System]: { ...element, size: reservedSpace },
+        [DiskSpaceCategoryType.Music]: {
+          ...element,
+          size: musicSpace,
+          filesAmount: files?.length ?? 0,
+        },
+        [DiskSpaceCategoryType.OtherSpace]: { ...element, size: otherSpace },
+      }
+
+      return elements[element.type] as DiskSpaceCategory
+    }
+
+    if (files && typeof otherSpace !== "undefined") {
+      const spaceCategories = filesSummaryElements.map(getDiskSpaceCategories)
+      setDiskSpaceCategories(spaceCategories)
+    }
+  }, [files, freeSpace, musicSpace, otherSpace, reservedSpace])
+
+
+  return diskSpaceCategories
+}
+
+export default useDiskSpaceCategories

--- a/libs/core/files-manager/components/files-manager/use-spaces/get-spaces.helper.ts
+++ b/libs/core/files-manager/components/files-manager/use-spaces/get-spaces.helper.ts
@@ -5,15 +5,7 @@
 
 import { MemorySpace } from "Core/files-manager/components/files-manager/files-manager.interface"
 import { File } from "Core/files-manager/dto"
-
-export interface Spaces {
-  reservedSpace: number
-  freeSpace: number
-  usedMemorySpace: number
-  totalMemorySpace: number
-  otherSpace: number
-  musicSpace: number
-}
+import { Spaces } from "Core/files-manager/components/files-manager/use-spaces/spaces.interface"
 
 /***
  * logic with the `isSizeCorrupt` property should be simplified after fix a issue in os side

--- a/libs/core/files-manager/components/files-manager/use-spaces/spaces.interface.ts
+++ b/libs/core/files-manager/components/files-manager/use-spaces/spaces.interface.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Mudita sp. z o.o. All rights reserved.
+ * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
+ */
+
+export interface Spaces {
+  reservedSpace: number
+  freeSpace: number
+  usedMemorySpace: number
+  totalMemorySpace: number
+  otherSpace: number
+  musicSpace: number
+}

--- a/libs/core/files-manager/components/files-manager/use-spaces/use-spaces.hook.ts
+++ b/libs/core/files-manager/components/files-manager/use-spaces/use-spaces.hook.ts
@@ -18,16 +18,16 @@ const useSpaces = (files: File[] | null, memorySpace: MemorySpace, loading: Stat
     freeSpace,
     totalMemorySpace,
     usedMemorySpace,
-    otherSpace: noFixOtherSpace,
+    otherSpace: notFixedOtherSpace,
     musicSpace,
   } = getSpaces(files, memorySpace);
 
   useEffect(() => {
     if (!rendered.current && loading === State.Loaded) {
       rendered.current = true;
-      setOtherSpace(noFixOtherSpace);
+      setOtherSpace(notFixedOtherSpace);
     }
-  }, [noFixOtherSpace, loading, rendered]);
+  }, [notFixedOtherSpace, loading, rendered]);
 
   return {
     reservedSpace,

--- a/libs/core/files-manager/components/files-manager/use-spaces/use-spaces.hook.ts
+++ b/libs/core/files-manager/components/files-manager/use-spaces/use-spaces.hook.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Mudita sp. z o.o. All rights reserved.
+ * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
+ */
+
+import { useEffect, useRef, useState } from "react"
+import { MemorySpace } from "Core/files-manager/components/files-manager/files-manager.interface"
+import { getSpaces} from "Core/files-manager/components/files-manager/use-spaces/get-spaces.helper"
+import { State } from "Core/core/constants"
+import { File } from "Core/files-manager/dto"
+import { Spaces } from "Core/files-manager/components/files-manager/use-spaces/spaces.interface"
+
+const useSpaces = (files: File[] | null, memorySpace: MemorySpace, loading: State): Spaces => {
+  const rendered = useRef<boolean>(false);
+  const [otherSpace, setOtherSpace] = useState<number>(0);
+  const {
+    reservedSpace,
+    freeSpace,
+    totalMemorySpace,
+    usedMemorySpace,
+    otherSpace: noFixOtherSpace,
+    musicSpace,
+  } = getSpaces(files, memorySpace);
+
+  useEffect(() => {
+    if (!rendered.current && loading === State.Loaded) {
+      rendered.current = true;
+      setOtherSpace(noFixOtherSpace);
+    }
+  }, [noFixOtherSpace, loading, rendered]);
+
+  return {
+    reservedSpace,
+    freeSpace,
+    usedMemorySpace,
+    otherSpace,
+    musicSpace,
+    totalMemorySpace,
+  }
+}
+
+export default useSpaces

--- a/libs/core/files-manager/components/files-manager/use-spaces/use-spaces.hook.ts
+++ b/libs/core/files-manager/components/files-manager/use-spaces/use-spaces.hook.ts
@@ -5,37 +5,33 @@
 
 import { useEffect, useRef, useState } from "react"
 import { MemorySpace } from "Core/files-manager/components/files-manager/files-manager.interface"
-import { getSpaces} from "Core/files-manager/components/files-manager/use-spaces/get-spaces.helper"
+import { getSpaces } from "Core/files-manager/components/files-manager/use-spaces/get-spaces.helper"
 import { State } from "Core/core/constants"
 import { File } from "Core/files-manager/dto"
 import { Spaces } from "Core/files-manager/components/files-manager/use-spaces/spaces.interface"
 
-const useSpaces = (files: File[] | null, memorySpace: MemorySpace, loading: State): Spaces => {
-  const rendered = useRef<boolean>(false);
-  const [otherSpace, setOtherSpace] = useState<number>(0);
-  const {
-    reservedSpace,
-    freeSpace,
-    totalMemorySpace,
-    usedMemorySpace,
-    otherSpace: notFixedOtherSpace,
-    musicSpace,
-  } = getSpaces(files, memorySpace);
+const useSpaces = (
+  files: File[] | null,
+  memorySpace: MemorySpace,
+  loading: State
+): Spaces => {
+  const rendered = useRef<boolean>(false)
+  const [otherSpace, setOtherSpace] = useState<number>(0)
+  const { otherSpace: notFixedOtherSpace, ...spaces } = getSpaces(
+    files,
+    memorySpace
+  )
 
   useEffect(() => {
     if (!rendered.current && loading === State.Loaded) {
-      rendered.current = true;
-      setOtherSpace(notFixedOtherSpace);
+      rendered.current = true
+      setOtherSpace(notFixedOtherSpace)
     }
-  }, [notFixedOtherSpace, loading, rendered]);
+  }, [notFixedOtherSpace, loading, rendered])
 
   return {
-    reservedSpace,
-    freeSpace,
-    usedMemorySpace,
     otherSpace,
-    musicSpace,
-    totalMemorySpace,
+    ...spaces,
   }
 }
 

--- a/libs/core/files-manager/components/files-summary/files-summary.component.tsx
+++ b/libs/core/files-manager/components/files-summary/files-summary.component.tsx
@@ -23,9 +23,6 @@ import StackedBarChart, {
 } from "Core/__deprecated__/renderer/components/core/stacked-bar-chart/stacked-bar-chart.component"
 import { defineMessages } from "react-intl"
 import { convertBytes } from "Core/core/helpers/convert-bytes/convert-bytes"
-import { DiskSpaceCategoryType } from "Core/files-manager/constants/files-manager.enum"
-
-const otherCategoryLabel = DiskSpaceCategoryType.OtherSpace
 
 const FilesSummaryWrapper = styled.div`
   display: flex;
@@ -64,19 +61,6 @@ const FilesSummary: FunctionComponent<Props> = ({
 }) => {
   const usedMemoryPercent = Math.floor((usedMemory / totalMemorySpace) * 100)
 
-  const otherCategory = React.useMemo(() => {
-    const otherCategory = diskSpaceCategories.find(
-      (category) => category.type === otherCategoryLabel
-    )
-    return otherCategory
-    // AUTO DISABLED - fix me if you like :)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  const diskSpaceCategoriesToDisplay = diskSpaceCategories.map((category) =>
-    category.type === otherCategory?.type ? otherCategory : category
-  )
-
   return (
     <FilesSummaryContainer>
       <FilesSummaryHeading
@@ -85,7 +69,7 @@ const FilesSummary: FunctionComponent<Props> = ({
         message={messages.summaryTitle}
       />
       <FilesSummaryWrapper data-testid={FilesSummaryTestIds.Wrapper}>
-        {diskSpaceCategoriesToDisplay.map(
+        {diskSpaceCategories.map(
           (diskSpaceCategory, index: number) => (
             <FilesSummaryItem {...diskSpaceCategory} key={index} />
           )

--- a/libs/core/files-manager/reducers/files-manager.reducer.ts
+++ b/libs/core/files-manager/reducers/files-manager.reducer.ts
@@ -136,7 +136,7 @@ export const filesManagerReducer = createReducer<FilesManagerState>(
         }
       })
       .addCase(changeLocation, (state) => {
-        return { ...state, selectedItems: { rows: [] } }
+        return { ...initialState }
       })
       .addCase(deleteFiles.pending, (state) => {
         return {


### PR DESCRIPTION
JIRA Reference: [CP-2430]

### :memo: Description ️



### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated



[CP-2430]: https://appnroll.atlassian.net/browse/CP-2430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ