### PR TITLE
[CP-2163] Fix for Initialization Abort Process and Enhancement of Discovery Mode Logic

### DIFF
--- a/libs/core/__deprecated__/renderer/constants/urls.ts
+++ b/libs/core/__deprecated__/renderer/constants/urls.ts
@@ -46,7 +46,7 @@ export const URL_ONBOARDING = {
 
 export const URL_DISCOVERY_DEVICE = {
   root: "/discovery-device",
-  availableDeviceListModal: "/available-device-list-modal",
+  availableDeviceListModal: "/discovery-device/available-device-list-modal",
 }
 
 export const URL_DEVICE_INITIALIZATION = {

--- a/libs/core/__deprecated__/renderer/wrappers/layout-blank-wrapper.tsx
+++ b/libs/core/__deprecated__/renderer/wrappers/layout-blank-wrapper.tsx
@@ -23,6 +23,8 @@ import { IconType } from "Core/__deprecated__/renderer/components/core/icon/icon
 import { RootState, ReduxRootState } from "Core/__deprecated__/renderer/store"
 import { State } from "Core/core/constants"
 import { useHandleActiveDeviceAborted } from "Core/overview/components/overview-screens/pure-overview/use-handle-active-device-aborted.hook"
+import { DisplayStyle } from "Core/__deprecated__/renderer/components/core/button/button.config"
+import { Close } from "Core/__deprecated__/renderer/components/core/modal/modal.styled.elements"
 
 const Layout = styled.div`
   display: grid;
@@ -102,7 +104,7 @@ const LayoutBlankWrapper: FunctionComponent<Props> = ({
   const handleActiveDeviceAborted = useHandleActiveDeviceAborted()
 
   const handleClosePage = () => {
-    handleActiveDeviceAborted()
+    void handleActiveDeviceAborted()
     onClose && onClose()
   }
 
@@ -115,13 +117,12 @@ const LayoutBlankWrapper: FunctionComponent<Props> = ({
           message={{ id: "module.onboarding.mainTitle" }}
         />
         {!recoveryMode && closeable && (
-          <Link
-            to={URL_MAIN.news}
+          <Close
             onClick={handleClosePage}
             data-testid={LayoutBlankWrapperTestIds.Close}
-          >
-            <Icon type={IconType.Close} />
-          </Link>
+            displayStyle={DisplayStyle.IconOnly}
+            Icon={IconType.Close}
+          />
         )}
       </Header>
       {children}

--- a/libs/core/__deprecated__/renderer/wrappers/layout-blank-wrapper.tsx
+++ b/libs/core/__deprecated__/renderer/wrappers/layout-blank-wrapper.tsx
@@ -6,7 +6,6 @@
 import * as React from "react"
 import styled from "styled-components"
 import { connect } from "react-redux"
-import { Link } from "react-router-dom"
 import { FunctionComponent } from "Core/core/types/function-component.interface"
 import {
   textColor,
@@ -17,7 +16,6 @@ import Icon from "Core/__deprecated__/renderer/components/core/icon/icon.compone
 import Text, {
   TextDisplayStyle,
 } from "Core/__deprecated__/renderer/components/core/text/text.component"
-import { URL_MAIN } from "Core/__deprecated__/renderer/constants/urls"
 import { LayoutBlankWrapperTestIds } from "Core/__deprecated__/renderer/wrappers/wrappers-test-ids.enum"
 import { IconType } from "Core/__deprecated__/renderer/components/core/icon/icon-type"
 import { RootState, ReduxRootState } from "Core/__deprecated__/renderer/store"

--- a/libs/core/core/components/apps/base-app/base-app-routes.tsx
+++ b/libs/core/core/components/apps/base-app/base-app-routes.tsx
@@ -73,10 +73,12 @@ export default () => (
         <Route
           path={URL_DISCOVERY_DEVICE.root}
           component={ConfiguredDevicesDiscovery}
+          exact
         />
         <Route
           path={URL_DISCOVERY_DEVICE.availableDeviceListModal}
           component={AvailableDeviceListContainer}
+          exact
         />
       </LayoutBlankWrapper>
     </Route>

--- a/libs/core/core/hooks/use-device-detached-effect.ts
+++ b/libs/core/core/hooks/use-device-detached-effect.ts
@@ -16,7 +16,7 @@ import { isActiveDeviceProcessingSelector } from "Core/device-manager/selectors/
 import { deactivateDevice } from "Core/device-manager/actions/deactivate-device.action"
 import { cancelOsDownload } from "Core/update/requests"
 import { URL_ONBOARDING } from "Core/__deprecated__/renderer/constants/urls"
-import { useRedirectOnActiveDeviceDetached } from "Core/overview/components/overview-screens/pure-overview/use-redirect-on-active-device-detached.hook"
+import { useDeactivateDeviceAndRedirect } from "Core/overview/components/overview-screens/pure-overview/use-deactivate-device-and-redirect.hook"
 import { getDevicesSelector } from "Core/device-manager/selectors/get-devices.selector"
 import { setSelectDeviceDrawerOpen } from "Core/device-select/actions/set-select-device-drawer-open.action"
 
@@ -29,7 +29,7 @@ export const useDeviceDetachedEffect = () => {
     ({ update }: ReduxRootState) => update.downloadState
   )
   const devices = useSelector(getDevicesSelector)
-  const redirectOnActiveDeviceDetached = useRedirectOnActiveDeviceDetached()
+  const deactivateDeviceAndRedirect = useDeactivateDeviceAndRedirect()
 
   useEffect(() => {
     return registerDeviceDetachedListener(
@@ -57,7 +57,7 @@ export const useDeviceDetachedEffect = () => {
           history.push(URL_ONBOARDING.welcome)
           return
         }
-        redirectOnActiveDeviceDetached()
+        deactivateDeviceAndRedirect()
       }
     )
   }, [
@@ -67,6 +67,6 @@ export const useDeviceDetachedEffect = () => {
     downloadProcessing,
     dispatch,
     history,
-    redirectOnActiveDeviceDetached,
+    deactivateDeviceAndRedirect,
   ])
 }

--- a/libs/core/core/hooks/use-device-detached-effect.ts
+++ b/libs/core/core/hooks/use-device-detached-effect.ts
@@ -18,7 +18,6 @@ import { cancelOsDownload } from "Core/update/requests"
 import { URL_ONBOARDING } from "Core/__deprecated__/renderer/constants/urls"
 import { useDeactivateDeviceAndRedirect } from "Core/overview/components/overview-screens/pure-overview/use-deactivate-device-and-redirect.hook"
 import { getDevicesSelector } from "Core/device-manager/selectors/get-devices.selector"
-import { setSelectDeviceDrawerOpen } from "Core/device-select/actions/set-select-device-drawer-open.action"
 
 export const useDeviceDetachedEffect = () => {
   const history = useHistory()
@@ -35,10 +34,6 @@ export const useDeviceDetachedEffect = () => {
     return registerDeviceDetachedListener(
       async (properties: DeviceBaseProperties) => {
         dispatch(removeDevice(properties))
-
-        if (devices.length < 2) {
-          dispatch(setSelectDeviceDrawerOpen(false))
-        }
 
         if (activeDeviceId !== properties.id) {
           return

--- a/libs/core/core/hooks/use-device-detached-effect.ts
+++ b/libs/core/core/hooks/use-device-detached-effect.ts
@@ -16,7 +16,9 @@ import { isActiveDeviceProcessingSelector } from "Core/device-manager/selectors/
 import { deactivateDevice } from "Core/device-manager/actions/deactivate-device.action"
 import { cancelOsDownload } from "Core/update/requests"
 import { URL_ONBOARDING } from "Core/__deprecated__/renderer/constants/urls"
-import { useHandleActiveDeviceDetached } from "Core/overview/components/overview-screens/pure-overview/use-handle-active-device-detached.hook"
+import { useRedirectOnActiveDeviceDetached } from "Core/overview/components/overview-screens/pure-overview/use-redirect-on-active-device-detached.hook"
+import { getDevicesSelector } from "Core/device-manager/selectors/get-devices.selector"
+import { setSelectDeviceDrawerOpen } from "Core/device-select/actions/set-select-device-drawer-open.action"
 
 export const useDeviceDetachedEffect = () => {
   const history = useHistory()
@@ -26,12 +28,17 @@ export const useDeviceDetachedEffect = () => {
   const downloadProcessing = useSelector(
     ({ update }: ReduxRootState) => update.downloadState
   )
-  const handleActiveDeviceDetached = useHandleActiveDeviceDetached()
+  const devices = useSelector(getDevicesSelector)
+  const redirectOnActiveDeviceDetached = useRedirectOnActiveDeviceDetached()
 
   useEffect(() => {
     return registerDeviceDetachedListener(
       async (properties: DeviceBaseProperties) => {
         dispatch(removeDevice(properties))
+
+        if (devices.length < 2) {
+          dispatch(setSelectDeviceDrawerOpen(false))
+        }
 
         if (activeDeviceId !== properties.id) {
           return
@@ -50,16 +57,16 @@ export const useDeviceDetachedEffect = () => {
           history.push(URL_ONBOARDING.welcome)
           return
         }
-
-        handleActiveDeviceDetached()
+        redirectOnActiveDeviceDetached()
       }
     )
   }, [
+    devices,
     activeDeviceId,
     activeDeviceProcessing,
     downloadProcessing,
     dispatch,
     history,
-    handleActiveDeviceDetached,
+    redirectOnActiveDeviceDetached,
   ])
 }

--- a/libs/core/core/hooks/use-discovery-redirect-effect.ts
+++ b/libs/core/core/hooks/use-discovery-redirect-effect.ts
@@ -3,7 +3,7 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 import { useSelector } from "react-redux"
 import { useHistory } from "react-router-dom"
 import { isDeviceListEmpty } from "Core/device-manager/selectors/is-device-list-empty.selector"
@@ -23,8 +23,16 @@ export const useDiscoveryRedirectEffect = () => {
     isInitializationDeviceInProgress
   )
   const appInitializationStatus = useSelector(getAppInitializationStatus)
+  const previousAppInitializationStatus = useRef(appInitializationStatus)
 
   useEffect(() => {
+
+    if(previousAppInitializationStatus.current === AppInitializationStatus.Initialized){
+      return
+    }
+
+    previousAppInitializationStatus.current = appInitializationStatus
+
     if (appInitializationStatus !== AppInitializationStatus.Initialized) {
       return
     }
@@ -46,5 +54,6 @@ export const useDiscoveryRedirectEffect = () => {
     discoveryDeviceInProgress,
     history,
     initializationDeviceInProgress,
+    previousAppInitializationStatus,
   ])
 }

--- a/libs/core/device-initialization/actions/initialize-mudita-pure.action.ts
+++ b/libs/core/device-initialization/actions/initialize-mudita-pure.action.ts
@@ -44,6 +44,7 @@ export const initializeMuditaPure = createAsyncThunk<
         )
         throw new AppError(DeviceInitializationError.ActiveDeviceNotAttached)
       }
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return dispatch(action)
     }
 

--- a/libs/core/device-initialization/constants/errors.enum.ts
+++ b/libs/core/device-initialization/constants/errors.enum.ts
@@ -5,5 +5,4 @@
 
 export enum DeviceInitializationError {
   InitializingDeviceError = "device-initialization-initializing-device-error",
-  ActiveDeviceNotAttached = "device-initialization-active-device-not-attached",
 }

--- a/libs/core/device-initialization/constants/errors.enum.ts
+++ b/libs/core/device-initialization/constants/errors.enum.ts
@@ -5,4 +5,5 @@
 
 export enum DeviceInitializationError {
   InitializingDeviceError = "device-initialization-initializing-device-error",
+  ActiveDeviceNotAttached = "device-initialization-active-device-not-attached",
 }

--- a/libs/core/device-manager/actions/deactivate-device.action.ts
+++ b/libs/core/device-manager/actions/deactivate-device.action.ts
@@ -19,12 +19,14 @@ import { setInitialBackupState } from "Core/backup"
 import { setInitialContactsState } from "Core/contacts/actions"
 import { setInitialFilesManagerState } from "Core/files-manager/actions"
 import { setInitialMessagesState } from "Core/messages/actions/base.action"
+import { getDevicesSelector } from "Core/device-manager/selectors/get-devices.selector"
+import { Device } from "Core/device-manager/reducers/device-manager.interface"
 
 export const deactivateDevice = createAsyncThunk<
-  void,
+  Device[],
   void,
   { state: ReduxRootState }
->(DeviceManagerEvent.DeactivateDevice, async (_, { dispatch }) => {
+>(DeviceManagerEvent.DeactivateDevice, async (_, { dispatch, getState }) => {
   await setActiveDeviceRequest(undefined)
   dispatch(setDiscoveryStatus(DiscoveryStatus.Idle))
   dispatch(setDeviceInitializationStatus(DeviceInitializationStatus.Idle))
@@ -38,4 +40,6 @@ export const deactivateDevice = createAsyncThunk<
   dispatch(clearStateAndData())
   void setValue({ key: MetadataKey.DeviceOsVersion, value: null })
   void setValue({ key: MetadataKey.DeviceType, value: null })
+
+  return getDevicesSelector(getState())
 })

--- a/libs/core/device-manager/reducers/device-manager.reducer.ts
+++ b/libs/core/device-manager/reducers/device-manager.reducer.ts
@@ -88,23 +88,9 @@ export const deviceManagerReducer = createReducer<DeviceManagerState>(
         }
       })
       .addCase(deactivateDevice.fulfilled, (state) => {
-        const devices = state.devices.reduce((prev, device) => {
-          if (device.id === state.activeDeviceId) {
-            return [
-              ...prev,
-              {
-                ...device,
-                state: DeviceState.Connected,
-              },
-            ]
-          } else {
-            return [...prev, device]
-          }
-        }, [] as Device[])
 
         return {
           ...state,
-          devices,
           activeDeviceId: undefined,
         }
       })

--- a/libs/core/discovery-device/components/available-device-list.component.tsx
+++ b/libs/core/discovery-device/components/available-device-list.component.tsx
@@ -16,7 +16,7 @@ import Text, {
 import { fontWeight } from "Core/core/styles/theming/theme-getters"
 import DeviceList from "Core/discovery-device/components/device-list.component"
 import { Dispatch } from "Core/__deprecated__/renderer/store"
-import { getDevicesSelector } from "Core/device-manager/selectors/get-devices.selector"
+import { getAvailableDevicesSelector } from "Core/device-manager/selectors/get-available-devices.selector"
 import {
   URL_DEVICE_INITIALIZATION,
   URL_ONBOARDING,
@@ -51,7 +51,7 @@ const SubheaderTitle = styled(Text)`
 const AvailableDeviceList: FunctionComponent = () => {
   const history = useHistory()
   const dispatch = useDispatch<Dispatch>()
-  const devices = useSelector(getDevicesSelector)
+  const devices = useSelector(getAvailableDevicesSelector)
 
   const handleDeviceClick = async (id: string) => {
     const device = devices.find((device) => device.id === id)

--- a/libs/core/discovery-device/components/available-device-list.container.tsx
+++ b/libs/core/discovery-device/components/available-device-list.container.tsx
@@ -20,6 +20,10 @@ const AvailableDeviceListContainer: FunctionComponent = () => {
   const devices = useSelector(getDevicesSelector)
 
   useEffect(() => {
+    dispatch(setDiscoveryStatus(DiscoveryStatus.Discovering))
+  })
+
+  useEffect(() => {
     if (devices.length === 0) {
       dispatch(setDiscoveryStatus(DiscoveryStatus.Aborted))
       history.push(URL_MAIN.news)

--- a/libs/core/discovery-device/components/available-device-list.container.tsx
+++ b/libs/core/discovery-device/components/available-device-list.container.tsx
@@ -21,7 +21,7 @@ const AvailableDeviceListContainer: FunctionComponent = () => {
 
   useEffect(() => {
     dispatch(setDiscoveryStatus(DiscoveryStatus.Discovering))
-  })
+  }, [dispatch])
 
   useEffect(() => {
     if (devices.length === 0) {

--- a/libs/core/overview/components/overview-screens/pure-overview/pure-overview.component.tsx
+++ b/libs/core/overview/components/overview-screens/pure-overview/pure-overview.component.tsx
@@ -28,7 +28,7 @@ import { ipcRenderer } from "electron-better-ipc"
 import React, { useCallback, useEffect, useState } from "react"
 import { CheckForUpdateState } from "Core/update/constants/check-for-update-state.constant"
 import { useWatchDeviceDataEffect } from "Core/overview/components/overview-screens/helpers/use-watch-device-data-effect"
-import { useRedirectOnActiveDeviceDetached } from "Core/overview/components/overview-screens/pure-overview/use-redirect-on-active-device-detached.hook"
+import { useDeactivateDeviceAndRedirect } from "Core/overview/components/overview-screens/pure-overview/use-deactivate-device-and-redirect.hook"
 import { useSelector } from "react-redux"
 import { isActiveDeviceAttachedSelector } from "Core/device-manager/selectors/is-active-device-attached.selector"
 
@@ -82,7 +82,7 @@ export const PureOverview: FunctionComponent<PureOverviewProps> = ({
 }) => {
   useWatchDeviceDataEffect()
   const activeDeviceAttached = useSelector(isActiveDeviceAttachedSelector)
-  const redirectOnActiveDeviceDetached = useRedirectOnActiveDeviceDetached()
+  const deactivateDeviceAndRedirect = useDeactivateDeviceAndRedirect()
 
   const [openModal, setOpenModal] = useState({
     backupStartModal: false,
@@ -132,7 +132,7 @@ export const PureOverview: FunctionComponent<PureOverviewProps> = ({
   const closeBackupDeviceFlowState = () => {
     setBackupDeviceFlowState(undefined)
     readBackupDeviceDataState()
-    redirectOnActiveDeviceDetached()
+    deactivateDeviceAndRedirect()
   }
 
   useEffect(() => {
@@ -158,11 +158,11 @@ export const PureOverview: FunctionComponent<PureOverviewProps> = ({
     setRestoreDeviceFlowState(undefined)
     readRestoreDeviceDataState()
     if (activeDeviceAttached) {
-      redirectOnActiveDeviceDetached()
+      deactivateDeviceAndRedirect()
     }
   }, [
     activeDeviceAttached,
-    redirectOnActiveDeviceDetached,
+    deactivateDeviceAndRedirect,
     readRestoreDeviceDataState,
   ])
 

--- a/libs/core/overview/components/overview-screens/pure-overview/pure-overview.component.tsx
+++ b/libs/core/overview/components/overview-screens/pure-overview/pure-overview.component.tsx
@@ -25,10 +25,12 @@ import logger from "Core/__deprecated__/main/utils/logger"
 import { FunctionComponent } from "Core/core/types/function-component.interface"
 import { noop } from "Core/__deprecated__/renderer/utils/noop"
 import { ipcRenderer } from "electron-better-ipc"
-import React, { useEffect, useState } from "react"
+import React, { useCallback, useEffect, useState } from "react"
 import { CheckForUpdateState } from "Core/update/constants/check-for-update-state.constant"
 import { useWatchDeviceDataEffect } from "Core/overview/components/overview-screens/helpers/use-watch-device-data-effect"
-import { useHandleActiveDeviceDetached } from "Core/overview/components/overview-screens/pure-overview/use-handle-active-device-detached.hook"
+import { useRedirectOnActiveDeviceDetached } from "Core/overview/components/overview-screens/pure-overview/use-redirect-on-active-device-detached.hook"
+import { useSelector } from "react-redux"
+import { isActiveDeviceAttachedSelector } from "Core/device-manager/selectors/is-active-device-attached.selector"
 
 export const PureOverview: FunctionComponent<PureOverviewProps> = ({
   batteryLevel = 0,
@@ -79,7 +81,8 @@ export const PureOverview: FunctionComponent<PureOverviewProps> = ({
   backupActionDisabled,
 }) => {
   useWatchDeviceDataEffect()
-  const handleActiveDeviceDetached = useHandleActiveDeviceDetached()
+  const activeDeviceAttached = useSelector(isActiveDeviceAttachedSelector)
+  const redirectOnActiveDeviceDetached = useRedirectOnActiveDeviceDetached()
 
   const [openModal, setOpenModal] = useState({
     backupStartModal: false,
@@ -129,7 +132,7 @@ export const PureOverview: FunctionComponent<PureOverviewProps> = ({
   const closeBackupDeviceFlowState = () => {
     setBackupDeviceFlowState(undefined)
     readBackupDeviceDataState()
-    handleActiveDeviceDetached()
+    redirectOnActiveDeviceDetached()
   }
 
   useEffect(() => {
@@ -151,11 +154,17 @@ export const PureOverview: FunctionComponent<PureOverviewProps> = ({
     setRestoreDeviceFlowState(RestoreDeviceFlowState.Start)
   }
 
-  const closeRestoreDeviceFlowState = () => {
+  const closeRestoreDeviceFlowState = useCallback(() => {
     setRestoreDeviceFlowState(undefined)
     readRestoreDeviceDataState()
-    handleActiveDeviceDetached()
-  }
+    if (activeDeviceAttached) {
+      redirectOnActiveDeviceDetached()
+    }
+  }, [
+    activeDeviceAttached,
+    redirectOnActiveDeviceDetached,
+    readRestoreDeviceDataState,
+  ])
 
   useEffect(() => {
     if (restoreDeviceState === State.Loading) {

--- a/libs/core/overview/components/overview-screens/pure-overview/pure-overview.component.tsx
+++ b/libs/core/overview/components/overview-screens/pure-overview/pure-overview.component.tsx
@@ -132,7 +132,9 @@ export const PureOverview: FunctionComponent<PureOverviewProps> = ({
   const closeBackupDeviceFlowState = () => {
     setBackupDeviceFlowState(undefined)
     readBackupDeviceDataState()
-    deactivateDeviceAndRedirect()
+    if (!activeDeviceAttached) {
+      void deactivateDeviceAndRedirect()
+    }
   }
 
   useEffect(() => {
@@ -157,8 +159,8 @@ export const PureOverview: FunctionComponent<PureOverviewProps> = ({
   const closeRestoreDeviceFlowState = useCallback(() => {
     setRestoreDeviceFlowState(undefined)
     readRestoreDeviceDataState()
-    if (activeDeviceAttached) {
-      deactivateDeviceAndRedirect()
+    if (!activeDeviceAttached) {
+      void deactivateDeviceAndRedirect()
     }
   }, [
     activeDeviceAttached,

--- a/libs/core/overview/components/overview-screens/pure-overview/use-deactivate-device-and-redirect.hook.ts
+++ b/libs/core/overview/components/overview-screens/pure-overview/use-deactivate-device-and-redirect.hook.ts
@@ -15,7 +15,7 @@ import {
 } from "Core/__deprecated__/renderer/constants/urls"
 import { setSelectDeviceDrawerOpen } from "Core/device-select/actions/set-select-device-drawer-open.action"
 
-export const useRedirectOnActiveDeviceDetached = () => {
+export const useDeactivateDeviceAndRedirect = () => {
   const history = useHistory()
   const dispatch = useDispatch<Dispatch>()
   const devices = useSelector(getDevicesSelector)

--- a/libs/core/overview/components/overview-screens/pure-overview/use-deactivate-device-and-redirect.hook.ts
+++ b/libs/core/overview/components/overview-screens/pure-overview/use-deactivate-device-and-redirect.hook.ts
@@ -4,10 +4,9 @@
  */
 
 import { useHistory } from "react-router-dom"
-import { useDispatch, useSelector } from "react-redux"
+import { useDispatch } from "react-redux"
 import { useCallback } from "react"
-import { Dispatch } from "Core/__deprecated__/renderer/store"
-import { getDevicesSelector } from "Core/device-manager/selectors/get-devices.selector"
+import { TmpDispatch } from "Core/__deprecated__/renderer/store"
 import { deactivateDevice } from "Core/device-manager/actions/deactivate-device.action"
 import {
   URL_DISCOVERY_DEVICE,
@@ -17,18 +16,18 @@ import { setSelectDeviceDrawerOpen } from "Core/device-select/actions/set-select
 
 export const useDeactivateDeviceAndRedirect = () => {
   const history = useHistory()
-  const dispatch = useDispatch<Dispatch>()
-  const devices = useSelector(getDevicesSelector)
+  const dispatch = useDispatch<TmpDispatch>()
 
-  return useCallback(() => {
-    void dispatch(deactivateDevice())
+  return useCallback(async () => {
+    const { payload: devices } = await dispatch(deactivateDevice())
+    dispatch(setSelectDeviceDrawerOpen(false))
+
     if (devices.length > 1) {
-      dispatch(setSelectDeviceDrawerOpen(false))
       history.push(URL_DISCOVERY_DEVICE.availableDeviceListModal)
     } else if (devices.length === 1) {
       history.push(URL_DISCOVERY_DEVICE.root)
     } else {
       history.push(URL_MAIN.news)
     }
-  }, [devices, history, dispatch])
+  }, [history, dispatch])
 }

--- a/libs/core/overview/components/overview-screens/pure-overview/use-handle-active-device-aborted.hook.ts
+++ b/libs/core/overview/components/overview-screens/pure-overview/use-handle-active-device-aborted.hook.ts
@@ -29,7 +29,7 @@ export const useHandleActiveDeviceAborted = () => {
     await dispatch(deactivateDevice())
     dispatch(setDiscoveryStatus(DiscoveryStatus.Aborted))
     dispatch(setDeviceInitializationStatus(DeviceInitializationStatus.Aborted))
-    if (devices.length && !pathname.includes(URL_DISCOVERY_DEVICE.root)) {
+    if (devices.length > 1 && !pathname.includes(URL_DISCOVERY_DEVICE.root)) {
       history.push(URL_DISCOVERY_DEVICE.availableDeviceListModal)
     } else {
       history.push(URL_MAIN.news)

--- a/libs/core/overview/components/overview-screens/pure-overview/use-handle-active-device-aborted.hook.ts
+++ b/libs/core/overview/components/overview-screens/pure-overview/use-handle-active-device-aborted.hook.ts
@@ -23,11 +23,13 @@ export const useHandleActiveDeviceAborted = () => {
   const dispatch = useDispatch<Dispatch>()
   const devices = useSelector(getDevicesSelector)
 
-  return useCallback(() => {
-    void dispatch(deactivateDevice())
+  return useCallback(async () => {
+    const pathname = history.location.pathname
+
+    await dispatch(deactivateDevice())
     dispatch(setDiscoveryStatus(DiscoveryStatus.Aborted))
     dispatch(setDeviceInitializationStatus(DeviceInitializationStatus.Aborted))
-    if (devices.length > 1) {
+    if (devices.length && !pathname.includes(URL_DISCOVERY_DEVICE.root)) {
       history.push(URL_DISCOVERY_DEVICE.availableDeviceListModal)
     } else {
       history.push(URL_MAIN.news)

--- a/libs/core/overview/components/overview-screens/pure-overview/use-handle-active-device-aborted.hook.ts
+++ b/libs/core/overview/components/overview-screens/pure-overview/use-handle-active-device-aborted.hook.ts
@@ -4,10 +4,9 @@
  */
 
 import { useHistory } from "react-router-dom"
-import { useDispatch, useSelector } from "react-redux"
+import { useDispatch } from "react-redux"
 import { useCallback } from "react"
-import { Dispatch } from "Core/__deprecated__/renderer/store"
-import { getDevicesSelector } from "Core/device-manager/selectors/get-devices.selector"
+import { TmpDispatch } from "Core/__deprecated__/renderer/store"
 import { deactivateDevice } from "Core/device-manager/actions/deactivate-device.action"
 import {
   URL_DISCOVERY_DEVICE,
@@ -20,13 +19,12 @@ import { DeviceInitializationStatus } from "Core/device-initialization/reducers/
 
 export const useHandleActiveDeviceAborted = () => {
   const history = useHistory()
-  const dispatch = useDispatch<Dispatch>()
-  const devices = useSelector(getDevicesSelector)
+  const dispatch = useDispatch<TmpDispatch>()
 
   return useCallback(async () => {
+    const { payload: devices } = await dispatch(deactivateDevice())
     const pathname = history.location.pathname
 
-    await dispatch(deactivateDevice())
     dispatch(setDiscoveryStatus(DiscoveryStatus.Aborted))
     dispatch(setDeviceInitializationStatus(DeviceInitializationStatus.Aborted))
     if (devices.length > 1 && !pathname.includes(URL_DISCOVERY_DEVICE.root)) {
@@ -34,5 +32,5 @@ export const useHandleActiveDeviceAborted = () => {
     } else {
       history.push(URL_MAIN.news)
     }
-  }, [devices, history, dispatch])
+  }, [history, dispatch])
 }

--- a/libs/core/overview/components/overview-screens/pure-overview/use-redirect-on-active-device-detached.hook.ts
+++ b/libs/core/overview/components/overview-screens/pure-overview/use-redirect-on-active-device-detached.hook.ts
@@ -7,30 +7,28 @@ import { useHistory } from "react-router-dom"
 import { useDispatch, useSelector } from "react-redux"
 import { useCallback } from "react"
 import { Dispatch } from "Core/__deprecated__/renderer/store"
-import { isActiveDeviceAttachedSelector } from "Core/device-manager/selectors/is-active-device-attached.selector"
 import { getDevicesSelector } from "Core/device-manager/selectors/get-devices.selector"
 import { deactivateDevice } from "Core/device-manager/actions/deactivate-device.action"
 import {
   URL_DISCOVERY_DEVICE,
   URL_MAIN,
 } from "Core/__deprecated__/renderer/constants/urls"
+import { setSelectDeviceDrawerOpen } from "Core/device-select/actions/set-select-device-drawer-open.action"
 
-export const useHandleActiveDeviceDetached = () => {
+export const useRedirectOnActiveDeviceDetached = () => {
   const history = useHistory()
   const dispatch = useDispatch<Dispatch>()
-  const activeDeviceAttached = useSelector(isActiveDeviceAttachedSelector)
   const devices = useSelector(getDevicesSelector)
 
   return useCallback(() => {
-    if (!activeDeviceAttached) {
-      void dispatch(deactivateDevice())
-      if (devices.length > 1) {
-        history.push(URL_DISCOVERY_DEVICE.availableDeviceListModal)
-      } else if (devices.length === 1) {
-        history.push(URL_DISCOVERY_DEVICE.root)
-      } else {
-        history.push(URL_MAIN.news)
-      }
+    void dispatch(deactivateDevice())
+    if (devices.length > 1) {
+      dispatch(setSelectDeviceDrawerOpen(false))
+      history.push(URL_DISCOVERY_DEVICE.availableDeviceListModal)
+    } else if (devices.length === 1) {
+      history.push(URL_DISCOVERY_DEVICE.root)
+    } else {
+      history.push(URL_MAIN.news)
     }
-  }, [devices, history, dispatch, activeDeviceAttached])
+  }, [devices, history, dispatch])
 }


### PR DESCRIPTION
JIRA Reference: [CP-2163]

### :memo: Description ️

#### Fix for Initialization Abort Process: 5bcb133a38f5b8be55da95848259959f1942caf6

- Enhanced the application's functionality so that when a user cancels the initialization process, the application correctly redirects to the news view.

#### Optimization of useDiscoveryRedirectEffect Logic: 15f01c3885d21736fa18ed806abf69573e37d695

- Improved the process of entering discovery mode, activated when a user manually checks the app version in settings.
- Fixed an issue with an endless loader that occurred when a user disconnects and reconnects the device.

#### Additional Fix: 15f01c3885d21736fa18ed806abf69573e37d695

- Resolved an issue with the 'disconnect' button, which did not function correctly in the previous version.

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2163]: https://appnroll.atlassian.net/browse/CP-2163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ