### PR TITLE
[CP-2484][Multidevice] white device on drawer is displayed initially a black for a very short moment

### DIFF
--- a/libs/core/device-select/components/device-select-drawer.component.tsx
+++ b/libs/core/device-select/components/device-select-drawer.component.tsx
@@ -18,7 +18,7 @@ import styled from "styled-components"
 import { Close } from "Core/__deprecated__/renderer/components/core/modal/modal.styled.elements"
 import { DisplayStyle } from "Core/__deprecated__/renderer/components/core/button/button.config"
 import { IconType } from "Core/__deprecated__/renderer/components/core/icon/icon-type"
-import { getDevicesSelector } from "Core/device-manager/selectors/get-devices.selector"
+import { getAvailableDevicesSelector } from "Core/device-manager/selectors/get-available-devices.selector"
 import { activeDeviceIdSelector } from "Core/device-manager/selectors/active-device-id.selector"
 import { useHistory } from "react-router-dom"
 import { handleDeviceActivated } from "Core/device-manager/actions/handle-device-activated.action"
@@ -71,7 +71,7 @@ const DevicesContainer = styled("div")`
 
 const DeviceSelectDrawer: FunctionComponent = () => {
   const isOpen = useSelector(isSelectDeviceDrawerOpenSelector)
-  const devices = useSelector(getDevicesSelector)
+  const devices = useSelector(getAvailableDevicesSelector)
   const activeDeviceId = useSelector(activeDeviceIdSelector)
   const dispatch = useDispatch<Dispatch>()
   const history = useHistory()


### PR DESCRIPTION

JIRA Reference: [CP-2484]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated
