### PR TITLE
[CP-2216] Implement Group Membership Check for Serial Port Access and Prevent Auto-Connect When Disabled

### DIFF
--- a/libs/core/app-initialization/components/app-initialization-flow.component.tsx
+++ b/libs/core/app-initialization/components/app-initialization-flow.component.tsx
@@ -11,21 +11,18 @@ import { shouldPrivacyPolicyVisible } from "Core/app-initialization/selectors/sh
 import { shouldAppUpdateFlowVisible } from "Core/app-initialization/selectors/should-app-update-flow-visible.selector"
 import { AppUpdateFlow } from "Core/settings/components/app-update-flow/app-update-flow.component"
 import USBAccessFlowContainer from "Core/settings/components/usb-access/usb-access-flow.container"
-import { ReduxRootState } from "Core/__deprecated__/renderer/store"
-import { ModalsManagerState } from "Core/modals-manager/reducers/modals-manager.interface"
+import { modalsManagerStateSelector } from "Core/modals-manager/selectors"
+import { appInitializationState } from "Core/app-initialization/selectors/app-initialization-state.selector"
 
 const AppInitializationFlow: FunctionComponent = () => {
   const privacyPolicyVisible = useSelector(shouldPrivacyPolicyVisible)
   const appUpdateFlowVisible = useSelector(shouldAppUpdateFlowVisible)
-  const { usbAccessFlowShow } = useSelector(
-    (state: ReduxRootState): ModalsManagerState => state.modalsManager
-  )
-  const appInitPrepFinished = useSelector(
-    (state: ReduxRootState): boolean =>
-      state.appInitialization.appInitializationPreparationFinished
+  const { usbAccessFlowShow } = useSelector(modalsManagerStateSelector)
+  const { appInitializationPreparationFinished } = useSelector(
+    appInitializationState
   )
 
-  if (!appInitPrepFinished) {
+  if (!appInitializationPreparationFinished) {
     return <></>
   }
 

--- a/libs/core/core/hooks/use-discovery-redirect-effect.ts
+++ b/libs/core/core/hooks/use-discovery-redirect-effect.ts
@@ -13,6 +13,8 @@ import { isInitializationDeviceInProgress } from "Core/device-initialization/sel
 import { URL_DISCOVERY_DEVICE } from "Core/__deprecated__/renderer/constants/urls"
 import { getAppInitializationStatus } from "Core/app-initialization/selectors/get-app-initialization-status.selector"
 import { AppInitializationStatus } from "Core/app-initialization/reducers/app-initialization.interface"
+import { isUsbAccessRestartSelector } from "Core/settings/selectors/is-usb-access-restart.selector"
+import { modalsManagerStateSelector } from "Core/modals-manager"
 
 export const useDiscoveryRedirectEffect = () => {
   const history = useHistory()
@@ -23,11 +25,15 @@ export const useDiscoveryRedirectEffect = () => {
     isInitializationDeviceInProgress
   )
   const appInitializationStatus = useSelector(getAppInitializationStatus)
+  const usbAccessRestart = useSelector(isUsbAccessRestartSelector)
+  const { usbAccessFlowShow } = useSelector(modalsManagerStateSelector)
   const previousAppInitializationStatus = useRef(appInitializationStatus)
 
   useEffect(() => {
-
-    if(previousAppInitializationStatus.current === AppInitializationStatus.Initialized){
+    if (
+      previousAppInitializationStatus.current ===
+      AppInitializationStatus.Initialized
+    ) {
       return
     }
 
@@ -41,7 +47,9 @@ export const useDiscoveryRedirectEffect = () => {
       deviceListEmpty ||
       activeDeviceSet ||
       discoveryDeviceInProgress ||
-      initializationDeviceInProgress
+      initializationDeviceInProgress ||
+      usbAccessRestart ||
+      usbAccessFlowShow
     ) {
       return
     }
@@ -55,5 +63,7 @@ export const useDiscoveryRedirectEffect = () => {
     history,
     initializationDeviceInProgress,
     previousAppInitializationStatus,
+    usbAccessRestart,
+    usbAccessFlowShow,
   ])
 }

--- a/libs/core/desktop/desktop.constants.ts
+++ b/libs/core/desktop/desktop.constants.ts
@@ -5,6 +5,6 @@
 
 export enum IpcDesktopEvent {
   IsLinux = "desktop_is-linux",
-  IsUserInSerialPortGroup = "desktop_is-user-in-serial-port-group",
+  HasUserSerialPortAccess = "desktop_has-user-serial-port-access",
   AddUserToSerialPortGroup = "desktop_add-user-to-serial-port-group",
 }

--- a/libs/core/desktop/desktop.controller.ts
+++ b/libs/core/desktop/desktop.controller.ts
@@ -15,9 +15,9 @@ export class DesktopController {
     return this.desktopService.isLinux()
   }
 
-  @IpcEvent(IpcDesktopEvent.IsUserInSerialPortGroup)
-  public async isUserInSerialPortGroup(): Promise<boolean> {
-    return this.desktopService.isUserInSerialPortGroup()
+  @IpcEvent(IpcDesktopEvent.HasUserSerialPortAccess)
+  public async hasUserSerialPortAccess(): Promise<boolean> {
+    return this.desktopService.hasUserSerialPortAccess()
   }
 
   @IpcEvent(IpcDesktopEvent.AddUserToSerialPortGroup)

--- a/libs/core/desktop/desktop.service.test.tsx
+++ b/libs/core/desktop/desktop.service.test.tsx
@@ -3,261 +3,68 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { DesktopService } from "Core/desktop/desktop.service"
-import sudoPrompt from "@vscode/sudo-prompt"
-import childProcess from "child_process"
-import EventEmitter from "events"
+import { DesktopService } from "Core/desktop/desktop.service";
+import sudoPrompt from "@vscode/sudo-prompt";
 
-afterEach(() => {
-  jest.resetAllMocks()
-})
+import * as childProcess from "child_process";
 
-const desktopService = new DesktopService()
+jest.mock('child_process', () => ({
+  exec: jest.fn().mockImplementation((_cmd, _options, callback) => {
+    callback(null, "", null);
+  }),
+}));
 
-const originalPlatform = process.platform
-const originalGetuid = process.getuid
+jest.mock("@vscode/sudo-prompt", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  exec: jest.fn().mockImplementation((_cmd, _options, callback) => callback(null)),
+}));
+
+const desktopService = new DesktopService();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 describe("isLinux", () => {
-  beforeEach(() => {
-    jest.resetModules()
-  })
-
   test("os is not linux", async () => {
-    Object.defineProperty(process, "platform", {
-      value: "win32",
-    })
+    Object.defineProperty(process, "platform", { value: "win32" });
+    expect(await desktopService.isLinux()).toEqual(false);
+  });
 
-    expect(await desktopService.isLinux()).toEqual(false)
-  })
   test("os is linux", async () => {
-    Object.defineProperty(process, "platform", {
-      value: "linux",
-    })
+    Object.defineProperty(process, "platform", { value: "linux" });
+    expect(await desktopService.isLinux()).toEqual(true);
+  });
+});
 
-    expect(await desktopService.isLinux()).toEqual(true)
-  })
-
-  afterEach(() => {
-    Object.defineProperty(process, "platform", {
-      value: originalPlatform,
-    })
-  })
-})
-
-describe("isUserInSerialPortGroup", () => {
+describe("hasUserSerialPortAccess", () => {
   test("user is in serial port group", async () => {
-    const getGroupsAssignedToSerialPortSpy = jest
-      .spyOn(desktopService, "getGroupsAssignedToSerialPort")
-      .mockImplementation(() => new Promise((resolve) => resolve("uucp")))
-
-    const getUserGroupsSpy = jest
-      .spyOn(desktopService, "getUserGroups")
-      .mockImplementation(() => new Promise((resolve) => resolve("uucp")))
-
-    expect(await desktopService.isUserInSerialPortGroup()).toEqual(true)
-
-    getGroupsAssignedToSerialPortSpy.mockClear()
-    getUserGroupsSpy.mockClear()
-  })
+    // @ts-ignore
+    childProcess.exec.mockImplementationOnce((_, cb) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return cb(null, "dialout uucp", null)
+    });
+    expect(await desktopService.hasUserSerialPortAccess()).toEqual(true);
+  });
 
   test("user is not in serial port group", async () => {
-    const getGroupsAssignedToSerialPortSpy = jest
-      .spyOn(desktopService, "getGroupsAssignedToSerialPort")
-      .mockImplementation(() => new Promise((resolve) => resolve("uucp")))
-
-    const getUserGroupsSpy = jest
-      .spyOn(desktopService, "getUserGroups")
-      .mockImplementation(() => new Promise((resolve) => resolve("")))
-
-    expect(await desktopService.isUserInSerialPortGroup()).toEqual(false)
-
-    getGroupsAssignedToSerialPortSpy.mockClear()
-    getUserGroupsSpy.mockClear()
-  })
-})
-
-describe("getGroupsAssignedToSerialPort", () => {
-  test("getting groups ends with error", async () => {
-    const execSpy = jest
-      .spyOn(childProcess, "exec")
-      .mockImplementation((command, options, callback) => {
-        if (typeof callback === "function") {
-          const err = new Error("error-message")
-          err.name = "error-name"
-          callback(err, "", "")
-        }
-
-        return new EventEmitter() as childProcess.ChildProcess
-      })
-
-    try {
-      await desktopService.getGroupsAssignedToSerialPort()
-    } catch (err) {
-      expect(err).toEqual(`error-name - error-message`)
-    }
-
-    execSpy.mockClear()
-  })
-
-  test("getting groups ends with stderr", async () => {
-    const execSpy = jest
-      .spyOn(childProcess, "exec")
-      .mockImplementation((command, options, callback) => {
-        if (typeof callback === "function") {
-          const err = new Error("error-message")
-          err.name = "error-name"
-          callback(null, "", "stderr")
-        }
-
-        return new EventEmitter() as childProcess.ChildProcess
-      })
-
-    try {
-      await desktopService.getGroupsAssignedToSerialPort()
-    } catch (err) {
-      expect(err).toEqual(`stderr`)
-    }
-
-    execSpy.mockClear()
-  })
-
-  test("getting groups works", async () => {
-    const execSpy = jest
-      .spyOn(childProcess, "exec")
-      .mockImplementation((command, options, callback) => {
-        if (typeof callback === "function") {
-          const err = new Error("error-message")
-          err.name = "error-name"
-          callback(null, "uucp", "")
-        }
-
-        return new EventEmitter() as childProcess.ChildProcess
-      })
-
-    try {
-      const result = await desktopService.getGroupsAssignedToSerialPort()
-      expect(result).toBe("uucp")
-      // eslint-disable-next-line no-empty
-    } catch (err) {}
-
-    execSpy.mockClear()
-  })
-})
-
-describe("getUserGroups", () => {
-  test("getting user groups ends with error", async () => {
-    const execSpy = jest
-      .spyOn(childProcess, "exec")
-      .mockImplementation((command, options, callback) => {
-        if (typeof callback === "function") {
-          const err = new Error("error-message")
-          err.name = "error-name"
-          callback(err, "", "")
-        }
-
-        return new EventEmitter() as childProcess.ChildProcess
-      })
-
-    try {
-      await desktopService.getUserGroups()
-    } catch (err) {
-      expect(err).toEqual(`error-name - error-message`)
-    }
-
-    execSpy.mockClear()
-  })
-
-  test("getting user groups ends with stderr", async () => {
-    const execSpy = jest
-      .spyOn(childProcess, "exec")
-      .mockImplementation((command, options, callback) => {
-        if (typeof callback === "function") {
-          const err = new Error("error-message")
-          err.name = "error-name"
-          callback(null, "", "stderr")
-        }
-
-        return new EventEmitter() as childProcess.ChildProcess
-      })
-
-    try {
-      await desktopService.getUserGroups()
-    } catch (err) {
-      expect(err).toEqual(`stderr`)
-    }
-
-    execSpy.mockClear()
-  })
-
-  test("getting user groups works", async () => {
-    const execSpy = jest
-      .spyOn(childProcess, "exec")
-      .mockImplementation((command, options, callback) => {
-        if (typeof callback === "function") {
-          const err = new Error("error-message")
-          err.name = "error-name"
-          callback(null, "uucp", "")
-        }
-
-        return new EventEmitter() as childProcess.ChildProcess
-      })
-
-    try {
-      const result = await desktopService.getUserGroups()
-      expect(result).toBe("uucp")
-      // eslint-disable-next-line no-empty
-    } catch (err) {}
-
-    execSpy.mockClear()
-  })
-})
-
-//
+    // @ts-ignore
+    childProcess.exec.mockImplementationOnce((_, cb) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return cb(null, "", null)
+    });
+    expect(await desktopService.hasUserSerialPortAccess()).toEqual(false);
+  });
+});
 
 describe("addUserToSerialPortGroup", () => {
-  test("user not added to serial port group", async () => {
-    const getGroupsAssignedToSerialPortSpy = jest
-      .spyOn(desktopService, "getGroupsAssignedToSerialPort")
-      .mockImplementation(() => new Promise((resolve) => resolve("uucp")))
-
-    const execSudoSpy = jest
-      .spyOn(sudoPrompt, "exec")
-      .mockImplementation((_, callback) => {
-        if (typeof callback === "function") {
-          callback(new Error("blabla"))
-        }
-      })
-
-    try {
-      await desktopService.addUserToSerialPortGroup()
-    } catch (err) {
-      expect(err).toBe("Could not add user")
-    }
-
-    getGroupsAssignedToSerialPortSpy.mockClear()
-    execSudoSpy.mockClear()
-  })
-
-  test("user added to serial port group", async () => {
-    const getGroupsAssignedToSerialPortSpy = jest
-      .spyOn(desktopService, "getGroupsAssignedToSerialPort")
-      .mockImplementation(() => new Promise((resolve) => resolve("uucp")))
-
-    const execSpy = jest
-      .spyOn(sudoPrompt, "exec")
-      .mockImplementation((_, callback) => {
-        if (typeof callback === "function") {
-          callback(undefined)
-        }
-      })
-
-    try {
-      await desktopService.addUserToSerialPortGroup()
-      expect(sudoPrompt.exec).toHaveBeenCalled()
-      // eslint-disable-next-line no-empty
-    } catch (err) {}
-
-    getGroupsAssignedToSerialPortSpy.mockClear()
-    execSpy.mockClear()
-  })
-})
+  test("user not in any serial port group and added to dialout", async () => {
+    // @ts-ignore
+    childProcess.exec.mockImplementationOnce((_, cb) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return cb(null, "", null)
+    });
+    await desktopService.addUserToSerialPortGroup();
+    expect(sudoPrompt.exec).toHaveBeenCalledWith(expect.stringContaining("usermod -aG dialout $USER"), expect.anything(), expect.any(Function));
+  });
+});

--- a/libs/core/desktop/desktop.service.ts
+++ b/libs/core/desktop/desktop.service.ts
@@ -11,26 +11,26 @@ enum SerialPortGroup {
   uucp = "uucp",
 }
 
-export class DesktopService {
-  private potentialGroups = [SerialPortGroup.dialout, SerialPortGroup.uucp];
+const POTENTIAL_GROUPS = [SerialPortGroup.dialout, SerialPortGroup.uucp];
 
+export class DesktopService {
   public async isLinux(): Promise<boolean> {
     return process.platform === "linux"
   }
 
   public async hasUserSerialPortAccess(): Promise<boolean> {
     const userGroups = await this.getUserGroups();
-    return this.potentialGroups.some(group => userGroups.includes(group));
+    return POTENTIAL_GROUPS.some(group => userGroups.includes(group));
   }
 
   public async addUserToSerialPortGroup(): Promise<void> {
     const userGroups = await this.getUserGroups();
-    const groupName = this.potentialGroups.find(group => !userGroups.includes(group));
+    const groupName = POTENTIAL_GROUPS.find(group => !userGroups.includes(group));
 
     if (groupName) {
       const command = `usermod -aG ${groupName} $USER`;
       // Set simpler process.title, otherwise, there is an error from sudoPrompt.exec - 'process.title cannot be used as a valid name.'
-      process.title = "dummy";
+      process.title = "Mudita Center: assign serial port access";
 
       return new Promise<void>((resolve, reject) => {
         sudoPrompt.exec(command, { name: 'User Serial Port Access' }, (error) => {

--- a/libs/core/desktop/desktop.service.ts
+++ b/libs/core/desktop/desktop.service.ts
@@ -11,83 +11,49 @@ enum SerialPortGroup {
   uucp = "uucp",
 }
 
-const hardwareSerialPort = "/dev/ttyACM0"
-
 export class DesktopService {
+  private potentialGroups = [SerialPortGroup.dialout, SerialPortGroup.uucp];
+
   public async isLinux(): Promise<boolean> {
     return process.platform === "linux"
   }
 
-  private async getSerialPortGroup(): Promise<string> {
-    const serialPortGroup = await this.getGroupsAssignedToSerialPort()
-
-    const isDialout = serialPortGroup.includes(SerialPortGroup.dialout)
-    const isUUCP = serialPortGroup.includes(SerialPortGroup.uucp)
-    let group = ""
-    if (isDialout) {
-      group = SerialPortGroup.dialout
-    } else if (isUUCP) {
-      group = SerialPortGroup.uucp
-    }
-
-    return group
-  }
-
-  public async isUserInSerialPortGroup(): Promise<boolean> {
-    const userGroups = await this.getUserGroups()
-    const serialPortGroup = await this.getSerialPortGroup()
-
-    const isInGroup =
-      serialPortGroup !== "" ? userGroups.includes(serialPortGroup) : false
-
-    return isInGroup
-  }
-
-  public async getGroupsAssignedToSerialPort(): Promise<string> {
-    return new Promise((resolve, reject) => {
-      exec(`ls -l ${hardwareSerialPort}`, (error, stdout, stderr) => {
-        if (error) {
-          reject(`${error.name} - ${error.message}`)
-        } else if (stderr) {
-          reject(stderr)
-        } else {
-          resolve(stdout)
-        }
-      })
-    })
-  }
-
-  public async getUserGroups(): Promise<string> {
-    return new Promise((resolve, reject) => {
-      exec("groups", (error, stdout, stderr) => {
-        if (error) {
-          reject(`${error.name} - ${error.message}`)
-        } else if (stderr) {
-          reject(stderr)
-        } else {
-          resolve(stdout)
-        }
-      })
-    })
+  public async hasUserSerialPortAccess(): Promise<boolean> {
+    const userGroups = await this.getUserGroups();
+    return this.potentialGroups.some(group => userGroups.includes(group));
   }
 
   public async addUserToSerialPortGroup(): Promise<void> {
-    const serialPortGroup = await this.getSerialPortGroup()
-    return new Promise((resolve, reject) => {
-      if (serialPortGroup !== "") {
-        const command = `usermod -aG ${serialPortGroup} $USER`
+    const userGroups = await this.getUserGroups();
+    const groupName = this.potentialGroups.find(group => !userGroups.includes(group));
 
-        //set simpler process.title, otherwise there is en error from sudoPrompt.exec - 'process.title cannot be used as a valid name.'
-        process.title = "dummy"
+    if (groupName) {
+      const command = `usermod -aG ${groupName} $USER`;
+      // Set simpler process.title, otherwise, there is an error from sudoPrompt.exec - 'process.title cannot be used as a valid name.'
+      process.title = "dummy";
 
-        sudoPrompt.exec(command, (error) => {
+      return new Promise<void>((resolve, reject) => {
+        sudoPrompt.exec(command, { name: 'User Serial Port Access' }, (error) => {
           if (error === null) {
-            resolve()
+            resolve();
           } else {
-            reject("Could not add user")
+            reject("Could not add user to serial port group");
           }
-        })
-      }
-    })
+        });
+      });
+    }
+  }
+
+  private async getUserGroups(): Promise<string[]> {
+    return new Promise<string[]>((resolve, reject) => {
+      exec("groups", (error, stdout, stderr) => {
+        if (error || stderr) {
+          reject(`${error?.name} - ${error?.message} - ${stderr}`);
+        } else {
+          const groups = stdout.trim().split(/\s+/);
+          resolve(groups);
+        }
+      });
+    });
   }
 }

--- a/libs/core/desktop/requests/is-user-in-serial-port-group.request.ts
+++ b/libs/core/desktop/requests/is-user-in-serial-port-group.request.ts
@@ -6,6 +6,6 @@
 import { ipcRenderer } from "electron-better-ipc"
 import { IpcDesktopEvent } from "Core/desktop/desktop.constants"
 
-export const isUserInSerialPortGroup = (): Promise<boolean> => {
-  return ipcRenderer.callMain(IpcDesktopEvent.IsUserInSerialPortGroup)
+export const hasUserSerialPortAccess = (): Promise<boolean> => {
+  return ipcRenderer.callMain(IpcDesktopEvent.HasUserSerialPortAccess)
 }

--- a/libs/core/modals-manager/actions/check-app-requires-serial-port-group-to-show.action.ts
+++ b/libs/core/modals-manager/actions/check-app-requires-serial-port-group-to-show.action.ts
@@ -9,6 +9,7 @@ import { showModal } from "Core/modals-manager/actions/base.action"
 import { ModalStateKey } from "Core/modals-manager/reducers"
 import { isUserInSerialPortGroup } from "Core/desktop/requests/is-user-in-serial-port-group.request"
 import { isLinux } from "Core/desktop/requests/is-linux.request"
+import { setUSBAccessRestart } from "Core/settings/actions/set-usb-access-restart-needed.action"
 
 export const checkAppRequiresSerialPortGroup = createAsyncThunk<
   void,
@@ -21,6 +22,8 @@ export const checkAppRequiresSerialPortGroup = createAsyncThunk<
 
       if (!userInGroup) {
         dispatch(showModal(ModalStateKey.UsbAccessFlowShow))
+      } else {
+        await dispatch(setUSBAccessRestart(false))
       }
     }
   }

--- a/libs/core/modals-manager/actions/check-app-requires-serial-port-group-to-show.action.ts
+++ b/libs/core/modals-manager/actions/check-app-requires-serial-port-group-to-show.action.ts
@@ -7,7 +7,7 @@ import { createAsyncThunk } from "@reduxjs/toolkit"
 import { ModalsManagerEvent } from "Core/modals-manager/constants"
 import { showModal } from "Core/modals-manager/actions/base.action"
 import { ModalStateKey } from "Core/modals-manager/reducers"
-import { isUserInSerialPortGroup } from "Core/desktop/requests/is-user-in-serial-port-group.request"
+import { hasUserSerialPortAccess } from "Core/desktop/requests/is-user-in-serial-port-group.request"
 import { isLinux } from "Core/desktop/requests/is-linux.request"
 import { setUSBAccessRestart } from "Core/settings/actions/set-usb-access-restart-needed.action"
 
@@ -18,9 +18,9 @@ export const checkAppRequiresSerialPortGroup = createAsyncThunk<
   ModalsManagerEvent.ShowAppRequiresSerialPortGroup,
   async (_, { dispatch }) => {
     if (await isLinux()) {
-      const userInGroup = await isUserInSerialPortGroup()
+      const userHasSerialPortAccess = await hasUserSerialPortAccess()
 
-      if (!userInGroup) {
+      if (!userHasSerialPortAccess) {
         dispatch(showModal(ModalStateKey.UsbAccessFlowShow))
       } else {
         await dispatch(setUSBAccessRestart(false))

--- a/libs/core/modals-manager/selectors/modals-manager-state.selector.ts
+++ b/libs/core/modals-manager/selectors/modals-manager-state.selector.ts
@@ -3,11 +3,9 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { Selector } from "reselect"
 import { ReduxRootState } from "Core/__deprecated__/renderer/store"
 import { ModalsManagerState } from "Core/modals-manager/reducers"
 
-export const modalsManagerStateSelector: Selector<
-  ReduxRootState,
-  ModalsManagerState
-> = (state) => state.modalsManager
+export const modalsManagerStateSelector = (
+  state: ReduxRootState
+): ModalsManagerState => state.modalsManager

--- a/libs/core/overview/components/overview-screens/pure-overview/use-handle-active-device-aborted.hook.ts
+++ b/libs/core/overview/components/overview-screens/pure-overview/use-handle-active-device-aborted.hook.ts
@@ -11,6 +11,7 @@ import { deactivateDevice } from "Core/device-manager/actions/deactivate-device.
 import {
   URL_DISCOVERY_DEVICE,
   URL_MAIN,
+  URL_ONBOARDING,
 } from "Core/__deprecated__/renderer/constants/urls"
 import { setDiscoveryStatus } from "Core/discovery-device/actions/base.action"
 import { DiscoveryStatus } from "Core/discovery-device/reducers/discovery-device.interface"
@@ -27,7 +28,12 @@ export const useHandleActiveDeviceAborted = () => {
 
     dispatch(setDiscoveryStatus(DiscoveryStatus.Aborted))
     dispatch(setDeviceInitializationStatus(DeviceInitializationStatus.Aborted))
-    if (devices.length > 1 && !pathname.includes(URL_DISCOVERY_DEVICE.root)) {
+    if (pathname === URL_ONBOARDING.welcome) {
+      history.push(URL_MAIN.news)
+    } else if (
+      devices.length > 1 &&
+      !pathname.includes(URL_DISCOVERY_DEVICE.root)
+    ) {
       history.push(URL_DISCOVERY_DEVICE.availableDeviceListModal)
     } else {
       history.push(URL_MAIN.news)

--- a/libs/core/settings/components/usb-access/usb-access-flow.container.tsx
+++ b/libs/core/settings/components/usb-access/usb-access-flow.container.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState } from "react"
 import { useSelector, useDispatch } from "react-redux"
-import { ReduxRootState, AppDispatch } from "Core/__deprecated__/renderer/store"
+import { AppDispatch } from "Core/__deprecated__/renderer/store"
 import { hideModals } from "Core/modals-manager/actions/base.action"
 import { ModalLayers } from "Core/modals-manager/constants/modal-layers.enum"
 import AllowUSBPortAccessModal from "Core/settings/components/usb-access/allow-usb-port-access.modal"
@@ -13,9 +13,9 @@ import USBAccessGrantedModal from "Core/settings/components/usb-access/usb-acces
 import RestartYourComputerToConnectModal from "Core/settings/components/usb-access/restart-your-computer-to-connect.modal"
 import CantConnectWithoutUSBPortAccessModal from "Core/settings/components/usb-access/cant-connect-without-usb-port-access.modal"
 import { addUserToSerialPortGroup } from "Core/desktop/requests/add-user-to-serial-port-group.request"
-import { SettingsState } from "Core/settings/reducers"
 import { setUSBAccessRestart } from "Core/settings/actions/set-usb-access-restart-needed.action"
 import { UsbAccessFlowTestIds } from "Core/settings/components/usb-access/usb-access-flow-test-ids.enum"
+import { isUsbAccessRestartSelector } from "Core/settings/selectors/is-usb-access-restart.selector"
 
 enum USBAccessState {
   notGranted = "not-granted",
@@ -26,9 +26,7 @@ enum USBAccessState {
 
 const USBAccessFlowContainer = () => {
   const dispatch = useDispatch<AppDispatch>()
-  const { usbAccessRestart } = useSelector(
-    (state: ReduxRootState): SettingsState => state.settings
-  )
+  const usbAccessRestart = useSelector(isUsbAccessRestartSelector)
   const [accessState, setAccessState] = useState<USBAccessState>(
     usbAccessRestart
       ? USBAccessState.grantedNeedsRestart
@@ -47,7 +45,7 @@ const USBAccessFlowContainer = () => {
         layer={ModalLayers.LinuxSerialPortGroup}
         onActionButtonClick={async () => {
           await addUserToSerialPortGroup()
-          dispatch(setUSBAccessRestart(true))
+          await dispatch(setUSBAccessRestart(true))
           setAccessState(USBAccessState.granted)
         }}
         actionButtonLabel="ALLOW"

--- a/libs/core/settings/reducers/settings.reducer.ts
+++ b/libs/core/settings/reducers/settings.reducer.ts
@@ -28,6 +28,7 @@ import {
 import { deleteCollectingData } from "Core/settings/actions/delete-collecting-data.action"
 import { setCheckingForUpdateFailed } from "../actions/set-checking-for-update-failed.action"
 import { skipAvailableUpdate } from "Core/settings/actions/skip-available-update.action"
+import { setUSBAccessRestart } from "Core/settings/actions/set-usb-access-restart-needed.action"
 
 export const initialState: SettingsState = {
   applicationId: "",
@@ -140,6 +141,9 @@ export const settingsReducer = createReducer<SettingsState>(
       .addCase(setIncomingCalls.fulfilled, (state, action) => {
         state.incomingCalls = action.payload
       })
+      .addCase(setUSBAccessRestart.fulfilled, (state, action) => {
+        state.usbAccessRestart = action.payload
+      })
 
       .addCase(setCheckingForUpdate, (state, action) => {
         state.checkingForUpdate = action.payload
@@ -147,7 +151,7 @@ export const settingsReducer = createReducer<SettingsState>(
       .addCase(setCheckingForUpdateFailed, (state, action) => {
         state.checkingForUpdateFailed = action.payload
       })
-      .addCase(skipAvailableUpdate, (state, action) => {
+      .addCase(skipAvailableUpdate, (state) => {
         state.updateAvailableSkipped = true
       })
   }

--- a/libs/core/settings/selectors/is-usb-access-restart.selector.ts
+++ b/libs/core/settings/selectors/is-usb-access-restart.selector.ts
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Mudita sp. z o.o. All rights reserved.
+ * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
+ */
+
+import { createSelector } from "@reduxjs/toolkit"
+import { settingsStateSelector } from "Core/settings/selectors/get-settings-state.selector"
+
+export const isUsbAccessRestartSelector = createSelector(
+  settingsStateSelector,
+  ({ usbAccessRestart }): boolean => {
+    return usbAccessRestart
+  }
+)


### PR DESCRIPTION
JIRA Reference: [CP-2216]

### :memo: Description ️

- Updated serial port access check: Shifted from device path checking to verifying group membership.
- Implemented auto-connect prevention without permissions: Now preventing automatic connection when access permissions are lacking.
- Created an access management guide: Developed "How to Manage Serial Port Access Permissions on Linux" documentation, available [here](https://appnroll.atlassian.net/wiki/spaces/CP/pages/2178285882/How+to+Manage+Serial+Port+Access+Permissions+on+Linux).

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2216]: https://appnroll.atlassian.net/browse/CP-2216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ