### PR TITLE
[CP-XXX] Improve log readability by adding customizable spacing

### DIFF
--- a/libs/core/core/decorators/log.decorator.ts
+++ b/libs/core/core/decorators/log.decorator.ts
@@ -11,14 +11,31 @@ export enum LogConfig {
   ReturnValue,
 }
 
+interface LogOptions {
+  logConfig?: LogConfig
+  space?: number
+}
+
+const resolveLogOptions = (options?: LogOptions | LogConfig): LogOptions => {
+  const defaultOptions: LogOptions = { logConfig: LogConfig.ReturnValue, space: 2 };
+
+  if (typeof options === "number") {
+    return { ...defaultOptions, logConfig: options };
+  }
+
+  return { ...defaultOptions, ...options };
+}
+
 const logger = LoggerFactory.getInstance()
 
-export function log(message: string, logConfig = LogConfig.ReturnValue) {
+export function log(message: string, options?: LogOptions | LogConfig) {
   return function (
     target: unknown,
     propertyKey: string,
     descriptor: PropertyDescriptor
   ): PropertyDescriptor {
+    const { logConfig, space } = resolveLogOptions(options)
+
     // AUTO DISABLED - fix me if you like :)
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const targetMethod = descriptor.value
@@ -39,13 +56,17 @@ export function log(message: string, logConfig = LogConfig.ReturnValue) {
             Object.prototype.hasOwnProperty.call(value, "ok")
           ) {
             logger.info(
-              JSON.stringify([(value as ResultObject<unknown>).data], null, 2)
+              JSON.stringify(
+                [(value as ResultObject<unknown>).data],
+                null,
+                space
+              )
             )
           } else {
-            logger.info(JSON.stringify([value], null, 2))
+            logger.info(JSON.stringify([value], null, space))
           }
         } else {
-          logger.info(JSON.stringify(args, null, 2))
+          logger.info(JSON.stringify(args, null, space))
         }
       })
 

--- a/libs/core/device-manager/services/device-manager.service.ts
+++ b/libs/core/device-manager/services/device-manager.service.ts
@@ -139,9 +139,7 @@ export class DeviceManager {
     return device.request(config)
   }
 
-  public connectDevice(
-    id: DeviceId
-  ): Promise<ResultObject<undefined>> {
+  public connectDevice(id: DeviceId): Promise<ResultObject<undefined>> {
     const device = this.devicesMap.get(id) as CoreDevice
     return device.connect()
   }
@@ -204,7 +202,7 @@ export class DeviceManager {
     })
   }
 
-  @log("==== device manager: list ====")
+  @log("==== device manager: list ====", { space: 0 })
   private getSerialPortList(): Promise<SerialPortInfo[]> {
     return SerialPort.list()
   }


### PR DESCRIPTION
JIRA Reference: [CP-XXX]

### :memo: Description ️

Enhanced the @log decorator to allow specifying the spacing in structured log output. This tweak helps in maintaining concise and readable logs, especially in environments where space conservation is essential. The update is fully backward compatible, promoting a seamless transition.

- Introduced a `space` parameter to control JSON formatting in logs.
- Default behavior remains unchanged for existing implementations.

#### after improve

![Zrzut ekranu 2024-03-11 o 10 56 30](https://github.com/mudita/mudita-center/assets/17147149/a815e7d4-9782-4bdf-83b9-484f43a1907b)


#### before improve
![Zrzut ekranu 2024-03-11 o 11 02 57](https://github.com/mudita/mudita-center/assets/17147149/631dd786-43ff-40c9-b169-fac63f4d9fa7)



### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated
