### PR TITLE
[CP-2292] Skip USB Access Validation in CI

### DIFF
--- a/libs/core/modals-manager/actions/check-app-requires-serial-port-group-to-show.action.ts
+++ b/libs/core/modals-manager/actions/check-app-requires-serial-port-group-to-show.action.ts
@@ -19,7 +19,9 @@ export const checkAppRequiresSerialPortGroup = createAsyncThunk<
   ModalsManagerEvent.ShowAppRequiresSerialPortGroup,
   async (_, { dispatch }) => {
     const runningOnLinux = await isLinux()
-    if (!runningOnLinux) {
+    const runningOnCI = process.env.CI === "true"
+
+    if (!runningOnLinux || runningOnCI) {
       dispatch(setUserHasSerialPortAccess(true))
       return
     }


### PR DESCRIPTION
JIRA Reference: [CP-2292]

### :memo: Description ️

Temporarily bypass USB group check in CI until DevOps updates the runner setup.


### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2292]: https://appnroll.atlassian.net/browse/CP-2292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ