### PR TITLE
[CP-2295] handle autoupdate timeout

### DIFF
--- a/apps/mudita-center-e2e/src/page-objects/modal.page.ts
+++ b/apps/mudita-center-e2e/src/page-objects/modal.page.ts
@@ -2,26 +2,27 @@
  * Copyright (c) Mudita sp. z o.o. All rights reserved.
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
-import { ChainablePromiseElement } from "webdriverio"
+
 /**
  * main page object containing all methods, selectors and functionality
  * that is shared across all page objects
  */
+
 export default class ModalPage {
-  public get modalHeader(): ChainablePromiseElement<
-    Promise<WebdriverIO.Element>
-  > {
+  public static get modalHeader() {
     return $('[data-testid="modal-header"]')
   }
 
-  public get modalCloseButton(): ChainablePromiseElement<
-    Promise<WebdriverIO.Element>
-  > {
+  public static get modalCloseButton() {
     return this.modalHeader.$('[data-testid="icon-Close"]')
   }
 
+  public static get modalOverlay() {
+    return $("div.ReactModal__Overlay")
+  }
+
   async closeModalButtonClick() {
-    await this.modalCloseButton.waitForClickable()
-    await this.modalCloseButton.click()
+    await ModalPage.modalCloseButton.waitForClickable()
+    await ModalPage.modalCloseButton.click()
   }
 }

--- a/apps/mudita-center-e2e/src/page-objects/modal.page.ts
+++ b/apps/mudita-center-e2e/src/page-objects/modal.page.ts
@@ -21,7 +21,7 @@ export default class ModalPage {
     return $("div.ReactModal__Overlay")
   }
 
-  async closeModalButtonClick() {
+  static async closeModalButtonClick() {
     await ModalPage.modalCloseButton.waitForClickable()
     await ModalPage.modalCloseButton.click()
   }

--- a/apps/mudita-center-e2e/src/specs/settings/terms-of-service.e2e.ts
+++ b/apps/mudita-center-e2e/src/specs/settings/terms-of-service.e2e.ts
@@ -10,6 +10,11 @@ import ModalTermsOfServicePage from "../../page-objects/modal-terms-of-service.p
 
 describe("Checking Terms of service", () => {
   before(async function () {
+    // Wait 10 seconds to allow the update checking process to potentially timeout.
+    await browser.executeAsync((done) => {
+      setTimeout(done, 10000)
+    })
+
     const notNowButton = await HomePage.notNowButton
     await notNowButton.waitForDisplayed()
     await notNowButton.click()

--- a/apps/mudita-center-e2e/src/specs/settings/terms-of-service.e2e.ts
+++ b/apps/mudita-center-e2e/src/specs/settings/terms-of-service.e2e.ts
@@ -7,14 +7,10 @@ import SettingsPage from "../../page-objects/settings.page"
 import NavigationTabs from "../../page-objects/tabs.page"
 import HomePage from "../../page-objects/home.page"
 import ModalTermsOfServicePage from "../../page-objects/modal-terms-of-service.page"
+import ModalPage from "../../page-objects/modal.page"
 
 describe("Checking Terms of service", () => {
   before(async function () {
-    // Wait 10 seconds to allow the update checking process to potentially timeout.
-    await browser.executeAsync((done) => {
-      setTimeout(done, 10000)
-    })
-
     const notNowButton = await HomePage.notNowButton
     await notNowButton.waitForDisplayed()
     await notNowButton.click()
@@ -28,6 +24,10 @@ describe("Checking Terms of service", () => {
     const aboutTab = await SettingsPage.aboutTab
     await aboutTab.waitForDisplayed()
     await aboutTab.click()
+
+    // Wait 10 seconds to allow the update checking process to potentially timeout.
+    const modalOverlay = await ModalPage.modalOverlay
+    await modalOverlay.waitForDisplayed({ timeout: 10000, reverse: true });
 
     const aboutTermsOfServiceTextLabel =
       await SettingsPage.aboutTermsOfServiceTextLabel

--- a/apps/mudita-center-e2e/src/specs/settings/terms-of-service.e2e.ts
+++ b/apps/mudita-center-e2e/src/specs/settings/terms-of-service.e2e.ts
@@ -25,9 +25,9 @@ describe("Checking Terms of service", () => {
     await aboutTab.waitForDisplayed()
     await aboutTab.click()
 
-    // Wait 10 seconds to allow the update checking process to potentially timeout.
+    // Wait 15 seconds to allow the update checking process to potentially timeout.
     const modalOverlay = await ModalPage.modalOverlay
-    await modalOverlay.waitForDisplayed({ timeout: 10000, reverse: true });
+    await modalOverlay.waitForDisplayed({ timeout: 15000, reverse: true });
 
     const aboutTermsOfServiceTextLabel =
       await SettingsPage.aboutTermsOfServiceTextLabel

--- a/apps/mudita-center-e2e/wdio.conf.ts
+++ b/apps/mudita-center-e2e/wdio.conf.ts
@@ -64,7 +64,7 @@ export const config: Options.Testrunner = {
     standalone: [
       toRelativePath(TestFilesPaths.helpWindowCheckTest),
       toRelativePath(TestFilesPaths.mcCheckForUpdatesTest),
-      toRelativePath(TestFilesPaths.homePageTestDeviceNotConnectedTest)
+      toRelativePath(TestFilesPaths.homePageTestDeviceNotConnectedTest),
       toRelativePath(TestFilesPaths.termsOfServiceTest),
     ],
     multidevicePureHarmony: [],

--- a/libs/core/core/hooks/use-application-update-effects.ts
+++ b/libs/core/core/hooks/use-application-update-effects.ts
@@ -4,7 +4,7 @@
  */
 
 import { useEffect } from "react"
-import { useDispatch } from "react-redux"
+import { useDispatch, useSelector } from "react-redux"
 import { Dispatch } from "Core/__deprecated__/renderer/store"
 import registerAvailableAppUpdateListener from "Core/__deprecated__/main/functions/register-avaible-app-update-listener"
 import { setCheckingForUpdateFailed } from "Core/settings/actions/base.action"
@@ -15,9 +15,11 @@ import {
 } from "Core/settings/actions"
 import registerNotAvailableAppUpdateListener from "Core/__deprecated__/main/functions/register-not-avaible-app-update-listener"
 import registerErrorAppUpdateListener from "Core/__deprecated__/main/functions/register-error-app-update-listener"
+import { settingsStateSelector } from "Core/settings/selectors"
 
 export const useApplicationUpdateEffects = () => {
   const dispatch = useDispatch<Dispatch>()
+  const { checkingForUpdate } = useSelector(settingsStateSelector)
 
   useEffect(() => {
     const unregister = registerErrorAppUpdateListener(() => {
@@ -26,6 +28,17 @@ export const useApplicationUpdateEffects = () => {
     })
     return () => unregister()
   }, [dispatch])
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      if (checkingForUpdate) {
+        dispatch(setCheckingForUpdateFailed(true))
+        dispatch(setCheckingForUpdate(false))
+      }
+    }, 10000)
+
+    return () => clearTimeout(timeoutId)
+  }, [dispatch, checkingForUpdate])
 
   useEffect(() => {
     const unregister = registerAvailableAppUpdateListener((version) => {


### PR DESCRIPTION
JIRA Reference: [CP-2295]

### :memo: Description ️

This PR fixes a timeout issue where the auto-update process gets stuck in E2E testing environments on Linux, due to improper dependency handling. It also prevents a potential problem in production environments should the checking process stall.


### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2295]: https://appnroll.atlassian.net/browse/CP-2295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ