### PR TITLE
[CP-2798][CP-2799][CP-2800][CP-2805]

### DIFF
--- a/libs/core/__deprecated__/renderer/wrappers/app-update-step-modal/app-update-step-modal.component.tsx
+++ b/libs/core/__deprecated__/renderer/wrappers/app-update-step-modal/app-update-step-modal.component.tsx
@@ -61,7 +61,7 @@ const AppUpdateStepModal: FunctionComponent<Props> = ({
     })
 
     return () => unregister()
-  })
+  }, [appCurrentVersion, appLatestVersion])
 
   useEffect(() => {
     const unregister = registerErrorAppUpdateListener(() => {
@@ -70,10 +70,15 @@ const AppUpdateStepModal: FunctionComponent<Props> = ({
         toCenterVersion: appLatestVersion,
         state: TrackCenterUpdateState.Fail,
       })
-      setAppUpdateStep(AppUpdateStep.Error)
+      setAppUpdateStep((prevAppUpdateStep) => {
+        // allow user to try updating before throw error to handle no network connection
+        return prevAppUpdateStep === AppUpdateStep.Updating
+          ? AppUpdateStep.Error
+          : prevAppUpdateStep
+      })
     })
     return () => unregister()
-  })
+  }, [appCurrentVersion, appLatestVersion])
 
   const handleProcessDownload = () => {
     void trackCenterUpdate({

--- a/libs/core/app-initialization/selectors/is-app-update-process-passed.selector.ts
+++ b/libs/core/app-initialization/selectors/is-app-update-process-passed.selector.ts
@@ -8,8 +8,17 @@ import { settingsStateSelector } from "Core/settings/selectors"
 
 export const isAppUpdateProcessPassed = createSelector(
   settingsStateSelector,
-  (settingsState): boolean => {
-    const { updateAvailable, updateAvailableSkipped, checkingForUpdateFailed } = settingsState
-    return checkingForUpdateFailed || updateAvailableSkipped || updateAvailable === false
+  ({
+    updateAvailable,
+    updateAvailableSkipped,
+    checkingForUpdateFailed,
+    updateRequired,
+  }): boolean => {
+    return (
+      !updateRequired &&
+      (checkingForUpdateFailed ||
+        updateAvailableSkipped ||
+        updateAvailable === false)
+    )
   }
 )

--- a/libs/core/app-initialization/selectors/should-app-update-flow-visible.selector.ts
+++ b/libs/core/app-initialization/selectors/should-app-update-flow-visible.selector.ts
@@ -8,8 +8,7 @@ import { settingsStateSelector } from "Core/settings/selectors"
 
 export const shouldAppUpdateFlowVisible = createSelector(
   settingsStateSelector,
-  (settingsState): boolean => {
-    const { updateAvailable, updateAvailableSkipped } = settingsState
-    return updateAvailable === true && !updateAvailableSkipped
+  ({ updateAvailable, updateAvailableSkipped, updateRequired }): boolean => {
+    return (updateAvailable && !updateAvailableSkipped) || updateRequired
   }
 )

--- a/libs/core/settings/actions/base.action.ts
+++ b/libs/core/settings/actions/base.action.ts
@@ -15,6 +15,8 @@ export const setSettings = createAction<
     | "updateAvailable"
     | "latestVersion"
     | "updateAvailableSkipped"
+    | "checkingForUpdate"
+    | "checkingForUpdateFailed"
   >
 >(SettingsEvent.SetSettings)
 

--- a/libs/core/settings/actions/load-settings.action.test.ts
+++ b/libs/core/settings/actions/load-settings.action.test.ts
@@ -63,8 +63,6 @@ test("`loadSettings` action dispatch SettingsEvent.LoadSettings event and calls 
     {
       type: SettingsEvent.SetSettings,
       payload: {
-        checkingForUpdate: false,
-        checkingForUpdateFailed: false,
         collectingData: false,
         currentVersion: `${packageInfo.version}`,
         lowestSupportedVersions: {

--- a/libs/core/settings/actions/load-settings.action.ts
+++ b/libs/core/settings/actions/load-settings.action.ts
@@ -44,8 +44,6 @@ export const loadSettings = createAsyncThunk<
       ...settings,
       updateRequired,
       currentVersion: packageInfo.version,
-      checkingForUpdate: false,
-      checkingForUpdateFailed: false,
       lowestSupportedVersions: {
         lowestSupportedCenterVersion: configuration.centerVersion,
         lowestSupportedProductVersion: configuration.productVersions,


### PR DESCRIPTION
JIRA Reference: [CP-2798] [CP-2799] [CP-2800] [CP-2805]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2798]: https://appnroll.atlassian.net/browse/CP-2798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[CP-2799]: https://appnroll.atlassian.net/browse/CP-2799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[CP-2800]: https://appnroll.atlassian.net/browse/CP-2800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[CP-2805]: https://appnroll.atlassian.net/browse/CP-2805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
