### PR TITLE
[CP-2817] Empty settings page after unsuccessful force update on 0.0.1-qa-2.3.0-rc3

### DIFF
--- a/libs/core/analytic-data-tracker/services/analytic-data-tracker.service.ts
+++ b/libs/core/analytic-data-tracker/services/analytic-data-tracker.service.ts
@@ -91,7 +91,9 @@ export class AnalyticDataTrackerService implements AnalyticDataTrackerClass {
     this.visitorMetadata = visitorMetadata
   }
 
-  private trackRequest(event: TrackEvent): Promise<AxiosResponse | undefined> {
+  private async trackRequest(
+    event: TrackEvent
+  ): Promise<AxiosResponse | undefined> {
     const params: AxiosRequestConfig["params"] = {
       rec: 1,
       apiv: 1,
@@ -101,10 +103,12 @@ export class AnalyticDataTrackerService implements AnalyticDataTrackerClass {
       ...event,
     }
 
-    return this.httpClient.post(this.apiUrl, undefined, {
-      // AUTO DISABLED - fix me if you like :)
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      params,
-    })
+    try {
+      return await this.httpClient.post(this.apiUrl, undefined, {
+        params,
+      })
+    } catch {
+      return undefined
+    }
   }
 }


### PR DESCRIPTION
JIRA Reference: [CP-2817]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2817]: https://appnroll.atlassian.net/browse/CP-2817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ