### PR TITLE
[CP-2813] Stress test - sometimes "Unfortunately, synchronization failed" error appears and passcode modal appears for a second

### DIFF
--- a/libs/core/device-initialization/actions/initialize-mudita-pure.action.ts
+++ b/libs/core/device-initialization/actions/initialize-mudita-pure.action.ts
@@ -55,11 +55,9 @@ export const initializeMuditaPure = createAsyncThunk<
       return DeviceInitializationStatus.Aborted
     }
     const unlockStatus = await dispatch(getUnlockStatus())
-    if (!unlockStatus.payload) {
+    if (unlockStatus.payload === "LOCKED") {
       return DeviceInitializationStatus.Initializing
-    }
-
-    if (!isActiveDeviceAttachedSelector(getState())) {
+    } else if (unlockStatus.payload === "ABORTED") {
       dispatch(
         setDeviceInitializationStatus(DeviceInitializationStatus.Aborted)
       )

--- a/libs/core/device/actions/get-unlock-status.action.ts
+++ b/libs/core/device/actions/get-unlock-status.action.ts
@@ -4,19 +4,22 @@
  */
 
 import { createAsyncThunk } from "@reduxjs/toolkit"
-import { DeviceEvent } from "Core/device/constants"
+import { DeviceCommunicationError, DeviceEvent } from "Core/device/constants"
 import { unlockDeviceStatusRequest } from "Core/device/requests"
 import { ReduxRootState } from "Core/__deprecated__/renderer/store"
-import { setLockTime } from "Core/device/actions/base.action"
+import { setLockTime, setUnlockedStatus } from "Core/device/actions/base.action"
 import { getLeftTimeSelector } from "Core/device/selectors"
 import { handleCommunicationError } from "Core/device/actions/handle-communication-error.action"
 
+export type UnlockStatus = "UNLOCKED" | "LOCKED" | "ABORTED"
+
 export const getUnlockStatus = createAsyncThunk<
-  boolean,
+  UnlockStatus,
   void,
   { state: ReduxRootState }
 >(DeviceEvent.GetUnlockedStatus, async (_, { dispatch, getState }) => {
-  const { ok, error } = await unlockDeviceStatusRequest()
+  const result = await unlockDeviceStatusRequest()
+  const { ok, error } = result
   const leftTime = getLeftTimeSelector(getState())
 
   if (ok && leftTime !== undefined) {
@@ -27,5 +30,15 @@ export const getUnlockStatus = createAsyncThunk<
     await dispatch(handleCommunicationError(error))
   }
 
-  return ok
+  if (error?.type === DeviceCommunicationError.DeviceLocked) {
+    dispatch(setUnlockedStatus(false))
+    return "LOCKED"
+  }
+
+  if (ok) {
+    dispatch(setUnlockedStatus(true))
+    return "UNLOCKED"
+  } else {
+    return "ABORTED"
+  }
 })

--- a/libs/core/device/reducers/device.reducer.ts
+++ b/libs/core/device/reducers/device.reducer.ts
@@ -5,7 +5,6 @@
 
 import { createReducer } from "@reduxjs/toolkit"
 import {
-  getUnlockStatus,
   loadDeviceData,
   loadStorageInfoAction,
   setCriticalBatteryLevelStatus,
@@ -108,15 +107,6 @@ export const deviceReducer = createReducer<DeviceState>(
         return {
           ...state,
           error: action.payload as AppError,
-        }
-      })
-      .addCase(getUnlockStatus.fulfilled, (state, action) => {
-        return {
-          ...state,
-          status: {
-            ...state.status,
-            unlocked: action.payload,
-          },
         }
       })
       .addCase(setLockTime, (state, action) => {


### PR DESCRIPTION
JIRA Reference: [CP-2797] [CP-2804] [CP-2813]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2813]: https://appnroll.atlassian.net/browse/CP-2813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CP-2797]: https://appnroll.atlassian.net/browse/CP-2797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-2804]: https://appnroll.atlassian.net/browse/CP-2804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ