### PR TITLE
[CP-2820] Add data-testid selector to "Change Backup location" button

### DIFF
--- a/libs/core/settings/components/backup/__snapshots__/backup-ui.test.tsx.snap
+++ b/libs/core/settings/components/backup/__snapshots__/backup-ui.test.tsx.snap
@@ -211,6 +211,7 @@ exports[`matches snapshot 1`] = `
       >
         <button
           class="c11 c12"
+          data-testid="settings-backup-change-location-button"
           size="1"
           type="button"
         >

--- a/libs/core/settings/components/backup/backup-ui.component.tsx
+++ b/libs/core/settings/components/backup/backup-ui.component.tsx
@@ -23,6 +23,7 @@ import ElementWithTooltip, {
 } from "Core/__deprecated__/renderer/components/core/tooltip/element-with-tooltip.component"
 import { TextTooltip } from "Core/ui/components/text-tooltip/text-tooltip.component"
 import Text from "Core/__deprecated__/renderer/components/core/text/text.component"
+import { SettingsBackupTestIds } from "Core/settings/components/backup/settings-backup-test-ids.enum"
 
 const BackupTableRow = styled(SettingsTableRow)`
   grid-template-areas: "Checkbox Actions";
@@ -92,6 +93,7 @@ const BackupUI: FunctionComponent<Props> = ({ backupLocation, openDialog }) => (
           label={intl.formatMessage({
             id: "module.settings.backupButtonLabel",
           })}
+          data-testid={SettingsBackupTestIds.ChangeLocationButton}
         />
       </BackupActionsWrapper>
     </BackupTableRow>

--- a/libs/core/settings/components/backup/settings-backup-test-ids.enum.ts
+++ b/libs/core/settings/components/backup/settings-backup-test-ids.enum.ts
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Mudita sp. z o.o. All rights reserved.
+ * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
+ */
+
+export enum SettingsBackupTestIds {
+  ChangeLocationButton = "settings-backup-change-location-button",
+}


### PR DESCRIPTION
JIRA Reference: [CP-2820]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2820]: https://appnroll.atlassian.net/browse/CP-2820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ