### PR TITLE
[CP-2819] Two dots appearing after pressing F1, F2, etc., while entering the password

### DIFF
--- a/libs/core/device-initialization/components/passcode-modal/passcode-inputs.component.tsx
+++ b/libs/core/device-initialization/components/passcode-modal/passcode-inputs.component.tsx
@@ -86,7 +86,7 @@ export const PasscodeInputs: FunctionComponent<Props> = ({
   const onKeyDownHandler =
     (number: number) =>
     (e: { key: string; code: string; preventDefault: () => void }) => {
-      if (/[0-9]/.test(e.key)) {
+      if (/^[0-9]$/.test(e.key)) {
         const backspaceEdgeCase = activeInput === 0 && e.key === ""
         if (
           activeInput !== undefined &&

--- a/libs/core/device-initialization/components/passcode-modal/passcode-modal.test.tsx
+++ b/libs/core/device-initialization/components/passcode-modal/passcode-modal.test.tsx
@@ -46,6 +46,13 @@ const letterKeyEvent = {
   charCode: 0,
 } as KeyboardEvent
 
+const F1KeyEvent = {
+  key: "F1",
+  code: "F1",
+  keyCode: 112,
+  charCode: 0,
+} as KeyboardEvent
+
 const backspaceKeyEvent = {
   key: "Backspace",
   code: "Backspace",
@@ -88,9 +95,19 @@ test("Passcode inputs are disabled when filled", () => {
   expect(inputsList()[0]).toHaveStyleRule("background-color", "#f4f5f6")
 })
 
-test("Show typing error message", async () => {
+test("Show typing error message when a latter is typed", async () => {
   const { inputsList, errorMessage } = renderer()
   fireEvent.keyDown(inputsList()[0] as Element, letterKeyEvent)
+  await waitFor(() =>
+    expect(errorMessage()).toHaveTextContent(
+      "[value] component.passcodeModalErrorTyping"
+    )
+  )
+})
+
+test("Show typing error message when F1 is typed", async () => {
+  const { inputsList, errorMessage } = renderer()
+  fireEvent.keyDown(inputsList()[0] as Element, F1KeyEvent)
   await waitFor(() =>
     expect(errorMessage()).toHaveTextContent(
       "[value] component.passcodeModalErrorTyping"


### PR DESCRIPTION
JIRA Reference: [CP-2819]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated
