### PR TITLE
[CP-2831] Download failed modal is not displayed after disconnecting the internet while updating 

### DIFF
--- a/libs/core/app-initialization/selectors/is-app-update-process-passed.selector.ts
+++ b/libs/core/app-initialization/selectors/is-app-update-process-passed.selector.ts
@@ -7,23 +7,25 @@ import { createSelector } from "@reduxjs/toolkit"
 import { settingsStateSelector } from "Core/settings/selectors"
 import { shouldAppUpdateFlowVisible } from "Core/app-initialization/selectors/should-app-update-flow-visible.selector"
 
-export const isAppUpdateProcessPassed = createSelector(
+const isNoDataAboutUpdateAvaible = createSelector(
   settingsStateSelector,
-  shouldAppUpdateFlowVisible,
-  (
-    {
-      updateAvailable,
-      updateAvailableSkipped,
-      checkingForUpdateFailed,
-      updateRequired,
-    },
-    appUpdateFlowVisible
-  ): boolean => {
+  ({
+    updateAvailable,
+    updateAvailableSkipped,
+    checkingForUpdateFailed,
+  }): boolean => {
     return (
-      !appUpdateFlowVisible ||
-      (updateAvailableSkipped === undefined &&
-        updateAvailable === undefined &&
-        checkingForUpdateFailed)
+      updateAvailableSkipped === undefined &&
+      updateAvailable === undefined &&
+      checkingForUpdateFailed
     )
+  }
+)
+
+export const isAppUpdateProcessPassed = createSelector(
+  isNoDataAboutUpdateAvaible,
+  shouldAppUpdateFlowVisible,
+  (noDataAboutUpdateAvaible, appUpdateFlowVisible): boolean => {
+    return !appUpdateFlowVisible || noDataAboutUpdateAvaible
   }
 )

--- a/libs/core/app-initialization/selectors/is-app-update-process-passed.selector.ts
+++ b/libs/core/app-initialization/selectors/is-app-update-process-passed.selector.ts
@@ -7,7 +7,7 @@ import { createSelector } from "@reduxjs/toolkit"
 import { settingsStateSelector } from "Core/settings/selectors"
 import { shouldAppUpdateFlowVisible } from "Core/app-initialization/selectors/should-app-update-flow-visible.selector"
 
-const isNoDataAboutUpdateAvaible = createSelector(
+const selectNoDataAboutUpdateAvaible = createSelector(
   settingsStateSelector,
   ({
     updateAvailable,
@@ -23,7 +23,7 @@ const isNoDataAboutUpdateAvaible = createSelector(
 )
 
 export const isAppUpdateProcessPassed = createSelector(
-  isNoDataAboutUpdateAvaible,
+  selectNoDataAboutUpdateAvaible,
   shouldAppUpdateFlowVisible,
   (noDataAboutUpdateAvaible, appUpdateFlowVisible): boolean => {
     return !appUpdateFlowVisible || noDataAboutUpdateAvaible

--- a/libs/core/app-initialization/selectors/is-app-update-process-passed.selector.ts
+++ b/libs/core/app-initialization/selectors/is-app-update-process-passed.selector.ts
@@ -5,20 +5,25 @@
 
 import { createSelector } from "@reduxjs/toolkit"
 import { settingsStateSelector } from "Core/settings/selectors"
+import { shouldAppUpdateFlowVisible } from "Core/app-initialization/selectors/should-app-update-flow-visible.selector"
 
 export const isAppUpdateProcessPassed = createSelector(
   settingsStateSelector,
-  ({
-    updateAvailable,
-    updateAvailableSkipped,
-    checkingForUpdateFailed,
-    updateRequired,
-  }): boolean => {
+  shouldAppUpdateFlowVisible,
+  (
+    {
+      updateAvailable,
+      updateAvailableSkipped,
+      checkingForUpdateFailed,
+      updateRequired,
+    },
+    appUpdateFlowVisible
+  ): boolean => {
     return (
-      !updateRequired &&
-      (checkingForUpdateFailed ||
-        updateAvailableSkipped ||
-        updateAvailable === false)
+      !appUpdateFlowVisible ||
+      (updateAvailableSkipped === undefined &&
+        updateAvailable === undefined &&
+        checkingForUpdateFailed)
     )
   }
 )


### PR DESCRIPTION
JIRA Reference: [CP-2831]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2831]: https://appnroll.atlassian.net/browse/CP-2831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ