### PR TITLE
[CP-XXX] Downgrade `node-ipc` to v10.1.0 for Compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@vscode/sudo-prompt": "^9.3.1",
         "crypto-js": "^4.2.0",
         "js-crc": "^0.2.0",
-        "node-ipc": "^11.1.0",
+        "node-ipc": "^10.1.0",
         "react-is": "18.2.0",
         "react-markdown": "^9.0.1",
         "serialport": "10.1.0",
@@ -32205,14 +32205,13 @@
       "dev": true
     },
     "node_modules/node-ipc": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/node-ipc/-/node-ipc-11.1.0.tgz",
-      "integrity": "sha512-BfE098Uyx06O//uatDNbSNxa5HLejwd2gV33yU0VfYv5wm4e22Um3VnNTOacqSxcl02v4fx6ZNUqJG9ZK+0Ufg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/node-ipc/-/node-ipc-10.1.0.tgz",
+      "integrity": "sha512-JBHRlMU8xAoo1kPtcvlBAa/6OBi/FUZoO/NbZf63q5Fe8q2aDhVJFryBFSq5T3E7EM13NnAUyEYk1b0IF6QV3Q==",
       "dependencies": {
         "event-pubsub": "5.0.3",
         "js-message": "1.0.7",
         "js-queue": "2.0.2",
-        "peacenotwar": "^9.1.5",
         "strong-type": "^1.0.1"
       },
       "engines": {
@@ -33682,14 +33681,6 @@
       },
       "engines": {
         "node": ">=0.12"
-      }
-    },
-    "node_modules/peacenotwar": {
-      "version": "9.1.7",
-      "resolved": "https://registry.npmjs.org/peacenotwar/-/peacenotwar-9.1.7.tgz",
-      "integrity": "sha512-tMTCcK/MFZQXg6cJPYv1rYAU5V4G1jw7vyJ6cxX35BZ+Jb58of7TTTwktK6LCGouPlyEkIDFLT0KYq/hE1Lstg==",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/peek-stream": {

--- a/package.json
+++ b/package.json
@@ -276,7 +276,7 @@
     "@vscode/sudo-prompt": "^9.3.1",
     "crypto-js": "^4.2.0",
     "js-crc": "^0.2.0",
-    "node-ipc": "^11.1.0",
+    "node-ipc": "10.1.0",
     "react-is": "18.2.0",
     "react-markdown": "^9.0.1",
     "serialport": "10.1.0",


### PR DESCRIPTION
JIRA Reference: [CP-XXX]

### :memo: Description ️

This PR downgrades `node-ipc` to version `10.1.0` to address the issue of the unwanted creation of the `WITH-LOVE-FROM-AMERICA.txt` file, as recommended by the library's author in https://github.com/RIAEvangelist/node-ipc/issues/3. The change includes updating `package.json` and appropriately modifying `package-lock.json`."

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated
