### PR TITLE
[CP-2883] Fix unhandled serial port parser case

### DIFF
--- a/libs/core/device/modules/mudita-os/parsers/serial-port-parser.test.ts
+++ b/libs/core/device/modules/mudita-os/parsers/serial-port-parser.test.ts
@@ -21,36 +21,59 @@ describe("`Parser.createValidRequest`", () => {
 })
 
 describe("`Parser.parse`", () => {
+  describe("when header is split into multiple packets", () => {
+    const parser = new SerialPortParser()
+    const endpoint = Buffer.from([35])
+    const payload = { entry: [] }
+    const payloadStringify = JSON.stringify(payload)
+    const payloadStringifyLength = JSON.stringify(payload).length
+    const size = Buffer.from(
+      String(payloadStringifyLength).padStart(9, "0"),
+      "utf-8"
+    )
+
+    const payloadAsBuffer = Buffer.from(payloadStringify, 'utf-8')
+    const fullPacket = Buffer.concat([endpoint, size, payloadAsBuffer])
+    const splitPoint = 3
+    const firstBuffer = fullPacket.subarray(0, splitPoint)
+    const secondBuffer = fullPacket.subarray(splitPoint)
+
+    test("method correctly parse message split at header", () => {
+      parser.parse(firstBuffer)
+      expect(parser.parse(secondBuffer)).toEqual(payload)
+    })
+  })
+
   describe("when data is packed in single packet", () => {
     const parser = new SerialPortParser()
     const endpoint = Buffer.from([35])
-    const paylaod = { entry: [] }
-    const payloadStringify = JSON.stringify(paylaod)
+    const payload = { entry: [] }
+    const payloadStringify = JSON.stringify(payload)
     const payloadStringifyLength = payloadStringify.length
     const size = Buffer.from(
       String(payloadStringifyLength).padStart(9, "0"),
       "utf-8"
     )
-    const payload = Buffer.from(payloadStringify, "utf-8")
-    const buffer = Buffer.concat([endpoint, size, payload])
+    const payloadAsBuffer = Buffer.from(payloadStringify, "utf-8")
+    const buffer = Buffer.concat([endpoint, size, payloadAsBuffer])
 
     test("payload is return properly", () => {
-      expect(parser.parse(buffer)).toEqual(paylaod)
+      expect(parser.parse(buffer)).toEqual(payload)
     })
   })
 
   describe("when endpoint is unknown", () => {
     const parser = new SerialPortParser()
     const endpoint = Buffer.from([999])
-    const paylaod = { entry: [] }
-    const payloadStringify = JSON.stringify(paylaod)
+    const payload = { entry: [] }
+    const payloadStringify = JSON.stringify(payload)
     const payloadStringifyLength = payloadStringify.length
     const size = Buffer.from(
       String(payloadStringifyLength).padStart(9, "0"),
       "utf-8"
     )
-    const payload = Buffer.from(payloadStringify, "utf-8")
-    const buffer = Buffer.concat([endpoint, size, payload])
+    const payloadAsBuffer = Buffer.from(payloadStringify, "utf-8")
+    const buffer = Buffer.concat([endpoint, size, payloadAsBuffer])
 
     test("method thrown error", () => {
       expect(() => parser.parse(buffer)).toThrow()
@@ -60,11 +83,11 @@ describe("`Parser.parse`", () => {
   describe("when size is NaN", () => {
     const parser = new SerialPortParser()
     const endpoint = Buffer.from([35])
-    const paylaod = { entry: [] }
-    const payloadStringify = JSON.stringify(paylaod)
+    const payload = { entry: [] }
+    const payloadStringify = JSON.stringify(payload)
     const size = Buffer.from(String("bad_number").padStart(9, "0"), "utf-8")
-    const payload = Buffer.from(payloadStringify, "utf-8")
-    const buffer = Buffer.concat([endpoint, size, payload])
+    const payloadAsBuffer = Buffer.from(payloadStringify, "utf-8")
+    const buffer = Buffer.concat([endpoint, size, payloadAsBuffer])
 
     test("method thrown error", () => {
       expect(() => parser.parse(buffer)).toThrow()
@@ -74,9 +97,9 @@ describe("`Parser.parse`", () => {
   describe("when data is chunks to more than one packet", () => {
     const parser = new SerialPortParser()
     const endpoint = Buffer.from([35])
-    const paylaod = { entry: [] }
-    const payloadStringify = JSON.stringify(paylaod)
-    const payloadStringifyLength = JSON.stringify(paylaod).length
+    const payload = { entry: [] }
+    const payloadStringify = JSON.stringify(payload)
+    const payloadStringifyLength = JSON.stringify(payload).length
     const firstPayload = payloadStringify.slice(0, 6)
     const secondPayload = payloadStringify.slice(6)
     const size = Buffer.from(
@@ -90,7 +113,7 @@ describe("`Parser.parse`", () => {
 
     test("method concatenate whole payload", () => {
       parser.parse(firstBuffer)
-      expect(parser.parse(secondBuffer)).toEqual(paylaod)
+      expect(parser.parse(secondBuffer)).toEqual(payload)
     })
   })
 })

--- a/libs/core/device/modules/mudita-os/parsers/serial-port.parser.ts
+++ b/libs/core/device/modules/mudita-os/parsers/serial-port.parser.ts
@@ -9,50 +9,115 @@ import { PacketType } from "Core/device/modules/mudita-os/constants"
 import { SerialPortParserBase } from "Core/device/modules/mudita-os/parsers/serial-port-base.parser"
 import { APIRequestData } from "Libs/device/models/src"
 
+enum State {
+  Idle,
+  ReceivedPartialHeader,
+  ReceivedPartialPayload,
+}
+
 export class SerialPortParser extends SerialPortParserBase {
-  private dataRaw = Buffer.alloc(0)
-  private dataSizeToRead = -1
-  private needMoreData = false
+  private headerLength = 10
+
+  private parserState = State.Idle
+  private header = Buffer.alloc(0)
+  private payload = Buffer.alloc(0)
+  private expectedPayloadLength = 0
 
   public parse(data: Buffer): undefined | Response {
-    if (this.needMoreData) {
-      return this.readPayload(data)
+    switch (this.parserState) {
+      case State.Idle:
+        return this.parseNewHeader(data)
+      case State.ReceivedPartialHeader:
+        return this.parsePartialHeader(data)
+      case State.ReceivedPartialPayload:
+        return this.parsePartialPayload(data)
     }
-
-    const endpoint = data[0]
-    if (
-      !(endpoint === PacketType.Endpoint || endpoint === PacketType.RawData)
-    ) {
-      throw new Error("Invalid or unknown data type")
-    }
-
-    this.dataRaw = Buffer.alloc(0)
-
-    const size = Number(data.subarray(1, 10))
-
-    if (isNaN(size) || size === 0) {
-      throw new Error(`Can't parse data size as number`)
-    }
-
-    this.dataSizeToRead = size
-    return this.readPayload(data.subarray(10))
   }
 
-  private readPayload(buffer: Buffer): undefined | Response {
-    const corruptPacket = buffer.length > this.dataSizeToRead
-
-    if (corruptPacket) {
-      return undefined
+  private parseNewHeader(data: Buffer): undefined | Response {
+    const endpointMarker = data[0]
+    if (
+      endpointMarker !== PacketType.Endpoint &&
+      endpointMarker !== PacketType.RawData
+    ) {
+      throw new Error(
+        `Invalid or unknown message type: '${String.fromCharCode(
+          endpointMarker
+        )}'`
+      )
     }
 
-    this.dataRaw = Buffer.concat([this.dataRaw, buffer])
-    this.needMoreData = this.dataRaw.length < this.dataSizeToRead
-
-    if (this.needMoreData) {
+    if (data.length < this.headerLength) {
+      this.header = Buffer.concat([this.header, data])
+      this.parserState = State.ReceivedPartialHeader
       return undefined
     } else {
-      return JSON.parse(this.dataRaw.toString()) as Response
+      this.header = data.subarray(0, this.headerLength)
+      this.updateExpectedPayloadLength()
+      return this.parseNewPayload(data.subarray(this.headerLength)) // Pass rest of the received data without header
     }
+  }
+
+  private parsePartialHeader(data: Buffer): undefined | Response {
+    const remainingHeaderLength = this.headerLength - this.header.length
+    if (data.length < remainingHeaderLength) {
+      this.header = Buffer.concat([this.header, data])
+      return undefined
+    } else {
+      this.header = Buffer.concat([
+        this.header,
+        data.subarray(0, remainingHeaderLength),
+      ])
+      this.updateExpectedPayloadLength()
+      return this.parseNewPayload(data.subarray(remainingHeaderLength))
+    }
+  }
+
+  private parseNewPayload(data: Buffer): undefined | Response {
+    if (data.length < this.expectedPayloadLength) {
+      this.payload = Buffer.concat([this.payload, data]) // Message split to chunks, insert next chunk
+      this.parserState = State.ReceivedPartialPayload
+      return undefined
+    }
+    if (data.length == this.expectedPayloadLength) {
+      this.payload = data
+      return this.parsePayload() // All message received in one chunk
+    }
+    return undefined // Corrupted message
+  }
+
+  private parsePartialPayload(data: Buffer): undefined | Response {
+    const remainingPayloadLength = this.expectedPayloadLength - this.payload.length
+    if (data.length < remainingPayloadLength) {
+      this.payload = Buffer.concat([this.payload, data])
+      return undefined
+    }
+    if (data.length == remainingPayloadLength) {
+      this.payload = Buffer.concat([this.payload, data])
+      return this.parsePayload() // Whole message received, parse it
+    }
+    return undefined // Corrupted message
+  }
+
+  private parsePayload(): undefined | Response {
+    const parsedMessage = JSON.parse(this.payload.toString()) as Response
+    this.resetState()
+    return parsedMessage
+  }
+
+  private updateExpectedPayloadLength(): void {
+    this.expectedPayloadLength = Number(this.header.subarray(1, this.headerLength)) // Skip message marker
+    if (isNaN(this.expectedPayloadLength) || this.expectedPayloadLength === 0) {
+      throw new Error(`Can't parse data size as number`)
+    }
+  }
+
+  private resetState(): void {
+    this.header = Buffer.alloc(0)
+    this.payload = Buffer.alloc(0)
+    this.expectedPayloadLength = 0
+
+    this.parserState = State.Idle
   }
 
   public createRequest(


### PR DESCRIPTION
JIRA Reference: [CP-2883](https://appnroll.atlassian.net/browse/CP-2883)

### :memo: Description ️

* Fix of the issue that serial port parser improperly handled 
case where message was split into two packets at the
header part.
* Added UT checking that case.

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated
