### PR TITLE
[CP-2894] Fixed Pure device name on data migration tab

### DIFF
--- a/libs/generic-view/store/src/lib/selectors/data-migration-devices.ts
+++ b/libs/generic-view/store/src/lib/selectors/data-migration-devices.ts
@@ -8,6 +8,7 @@ import { createSelector } from "@reduxjs/toolkit"
 import pureBlackImage from "Core/__deprecated__/renderer/images/pure-black-render.png"
 import pureGreyImage from "Core/__deprecated__/renderer/images/pure-gray-render.png"
 import { kompaktImg } from "Root/demo-data/kompakt-img"
+import { getDeviceTypeName } from "Core/discovery-device/utils/get-device-type-name"
 
 // FIXME: The device name should be moved to the API config response of API device
 const messages = {
@@ -20,7 +21,7 @@ export const selectDataMigrationSourceDevices = createSelector(
     devices
       .filter(({ deviceType }) => deviceType === "MuditaPure")
       .map((device) => ({
-        name: device.deviceType!,
+        name: getDeviceTypeName(device.deviceType!),
         image: device.caseColour === "black" ? pureBlackImage : pureGreyImage,
         serialNumber: device.serialNumber!,
       }))


### PR DESCRIPTION
JIRA Reference: [CP-2894]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2894]: https://appnroll.atlassian.net/browse/CP-2894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ