### PR TITLE
[CP-2749] Extended `MockUpdaterStateService` to handle downloaded state

### DIFF
--- a/libs/e2e-mock/server/README.md
+++ b/libs/e2e-mock/server/README.md
@@ -47,13 +47,15 @@ E2EMockClient.mockHttpResponse({
 The `setMockUpdateState` function is a method provided by the `E2EMockClient` to simulate different update states of the application, use the following command:
 
 ```javascript
-E2EMockClient.setMockUpdateState({ available: boolean, version?: string })
+E2EMockClient.setMockUpdateState({ available: boolean, downloaded?: boolean, version?: string })
 ```
 
 ### Parameters
 - `available` (boolean): This parameter indicates whether an update is available (`true`) or not (`false`).
 
 - `version` (string, optional): This parameter specifies the version of the update that is available. It is only required if `available` is set to `true`.
+
+- `downloaded` (boolean, optional): This parameter indicates whether the download process was successful (`true`) or not (`false`). When downloaded is `true`, the modal shows in-progress indefinitely, and in the production environment, the application closes to complete the installation process. When downloaded is `false`, the application displays an error message.
 
 ## Usage Examples
 
@@ -69,6 +71,20 @@ E2EMockClient.setMockUpdateState({ available: false })
 To set the response indicating that an update is available with a specified version, use the following command:
 ```javascript
 E2EMockClient.setMockUpdateState({ available: true, version: "4.0.0" })
+```
+
+### Update Available with Download Failure
+
+To set the response indicating that an update is available with a specified version, but the download process fails, use the following command:
+```javascript
+E2EMockClient.setMockUpdateState({ available: true, version: "4.0.0", downloaded: false })
+```
+
+### Update Available with Successful Download
+
+To set the response indicating that an update is available with a specified version and the download process is successful, use the following command:
+```javascript
+E2EMockClient.setMockUpdateState({ available: true, version: "4.0.0", downloaded: true })
 ```
 
 ### Required Mudita Center Update

--- a/libs/e2e-mock/server/src/lib/mock-updater-state.service.ts
+++ b/libs/e2e-mock/server/src/lib/mock-updater-state.service.ts
@@ -5,20 +5,24 @@
 
 export interface UpdateState {
   available: boolean
+  downloaded?: boolean
   version?: string
 }
 
+const defaultUpdateState: UpdateState = {
+  available: false,
+  downloaded: true,
+}
+
 export class MockUpdaterStateService {
-  private _updateState: UpdateState = {
-    available: false,
-  }
+  private _updateState = { ...defaultUpdateState }
 
   get updateState(): UpdateState {
     return this._updateState
   }
 
   set updateState(value: UpdateState) {
-    this._updateState = value
+    this._updateState = { ...defaultUpdateState, ...value }
   }
 }
 

--- a/libs/electron/application-updater/src/lib/mock-application-updater.service.ts
+++ b/libs/electron/application-updater/src/lib/mock-application-updater.service.ts
@@ -14,12 +14,14 @@ export class MockApplicationUpdaterService extends BaseApplicationUpdaterService
   ) {
     super()
   }
-  public quitAndInstall(): void {
-    this.onError()
-  }
+  public quitAndInstall(): void {}
 
   public async downloadUpdate(): Promise<void> {
-    this.onError()
+    if (this.isUpdateDownloaded()) {
+      this.onUpdateDownloaded()
+    } else {
+      this.onError()
+    }
   }
 
   public async checkForUpdatesAndNotify(): Promise<void> {
@@ -33,6 +35,11 @@ export class MockApplicationUpdaterService extends BaseApplicationUpdaterService
       this.onUpdateNotAvailable()
     }
   }
+
+  private isUpdateDownloaded(): boolean {
+    return this.mockUpdaterStateService.updateState.downloaded ?? true
+  }
+
   private isUpdateAvailable(): boolean {
     return this.mockUpdaterStateService.updateState.available
   }


### PR DESCRIPTION
JIRA Reference: [CP-2749]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2749]: https://appnroll.atlassian.net/browse/CP-2749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ