### PR TITLE
[CP-2845] Kompakt's loader after selection Pure or Harmony as an active device

### DIFF
--- a/libs/core/__deprecated__/renderer/wrappers/layout-blank-wrapper.tsx
+++ b/libs/core/__deprecated__/renderer/wrappers/layout-blank-wrapper.tsx
@@ -5,7 +5,6 @@
 
 import * as React from "react"
 import styled from "styled-components"
-import { connect } from "react-redux"
 import { FunctionComponent } from "Core/core/types/function-component.interface"
 import {
   textColor,
@@ -18,8 +17,6 @@ import Text, {
 } from "Core/__deprecated__/renderer/components/core/text/text.component"
 import { LayoutBlankWrapperTestIds } from "Core/__deprecated__/renderer/wrappers/wrappers-test-ids.enum"
 import { IconType } from "Core/__deprecated__/renderer/components/core/icon/icon-type"
-import { RootState, ReduxRootState } from "Core/__deprecated__/renderer/store"
-import { State } from "Core/core/constants"
 import { useHandleActiveDeviceAborted } from "Core/overview/components/overview-screens/pure-overview/use-handle-active-device-aborted.hook"
 import { DisplayStyle } from "Core/__deprecated__/renderer/components/core/button/button.config"
 import { Close } from "Core/__deprecated__/renderer/components/core/modal/modal.styled.elements"
@@ -64,41 +61,19 @@ const Header = styled.header`
   }
 `
 
-interface ComponentProps {
-  recoveryMode?: boolean
-  onClose?: () => void
-}
-interface StateProps {
-  closeable: boolean
-}
-
-type Props = ComponentProps & StateProps
-
 const MainTitle = styled(Text)`
   padding-top: 0.3rem;
 `
 
-const mapStateToProps = (
-  state: RootState & ReduxRootState,
-  ownProps: ComponentProps
-): Props => {
-  return {
-    closeable: !(
-      state.update.needsForceUpdate ||
-      state.update.forceUpdateState === State.Loading ||
-      state.update.updateOsState === State.Loading ||
-      state.activeDeviceRegistry.activeDeviceId
-    ),
-    recoveryMode: ownProps.recoveryMode,
-    onClose: ownProps.onClose,
-  }
+interface Props {
+  closeable?: boolean
+  onClose?: () => void
 }
 
 const LayoutBlankWrapper: FunctionComponent<Props> = ({
   children,
-  recoveryMode,
   onClose,
-  closeable,
+  closeable = true,
 }) => {
   const handleActiveDeviceAborted = useHandleActiveDeviceAborted()
 
@@ -115,7 +90,7 @@ const LayoutBlankWrapper: FunctionComponent<Props> = ({
           displayStyle={TextDisplayStyle.Paragraph3}
           message={{ id: "module.onboarding.mainTitle" }}
         />
-        {!recoveryMode && closeable && (
+        {closeable && (
           <Close
             onClick={handleClosePage}
             data-testid={LayoutBlankWrapperTestIds.Close}
@@ -129,4 +104,4 @@ const LayoutBlankWrapper: FunctionComponent<Props> = ({
   )
 }
 
-export default connect(mapStateToProps)(LayoutBlankWrapper)
+export default LayoutBlankWrapper

--- a/libs/core/connecting/components/connecting-content.component.tsx
+++ b/libs/core/connecting/components/connecting-content.component.tsx
@@ -3,42 +3,44 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import React from "react"
-import { FunctionComponent } from "Core/core/types/function-component.interface"
-import Text, {
-  TextDisplayStyle,
-} from "Core/__deprecated__/renderer/components/core/text/text.component"
+/* eslint-disable @typescript-eslint/no-unsafe-return */
 
-import Loader from "Core/__deprecated__/renderer/components/core/loader/loader.component"
-import { LoaderType } from "Core/__deprecated__/renderer/components/core/loader/loader.interface"
+import React from "react"
 import styled from "styled-components"
-import { backgroundColor } from "Core/core/styles/theming/theme-getters"
+import { defineMessages } from "react-intl"
+import { SpinnerLoader } from "generic-view/ui"
+import { GenericThemeProvider } from "generic-view/theme"
+import { FunctionComponent } from "Core/core/types/function-component.interface"
+import { intl } from "Core/__deprecated__/renderer/utils/intl"
+
+const messages = defineMessages({
+  connectingMessage: {
+    id: "module.onboarding.connectingMessage",
+  },
+  connectingLongMessage: {
+    id: "module.onboarding.connectingLongMessage",
+  },
+})
 
 export const Container = styled.section`
-  display: grid;
-  grid-template-areas: "Header" "Main" "Footer";
-  grid-row-gap: 0;
-  grid-template-rows: 6.5rem 1fr 14rem;
-
-  main {
-    grid-area: Main;
-    text-align: center;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-  }
-`
-
-const LoaderWrapper = styled.div`
-  width: 20rem;
-  height: 20rem;
   display: flex;
-  border-radius: 50%;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  background-color: ${backgroundColor("icon")};
-  margin-bottom: 4rem;
+  background-color: rgba(0, 0, 0, 0.3);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  overflow: auto;
+`
+
+const ConnectingText = styled.p`
+  font-size: ${({ theme }) => theme.fontSize.headline3};
+  line-height: ${({ theme }) => theme.lineHeight.headline3};
+  color: ${({ theme }) => theme.color.white};
+  font-weight: ${({ theme }) => theme.fontWeight.bold};
+  margin: 2.4rem 0 0;
 `
 
 interface Props {
@@ -46,23 +48,20 @@ interface Props {
   longerConnection?: boolean
 }
 
-const ConnectingContent: FunctionComponent<Props> = ({ longerConnection = false }) => {
+const ConnectingContent: FunctionComponent<Props> = ({
+  longerConnection = false,
+}) => {
   return (
-    <Container>
-      <main>
-        <LoaderWrapper>
-          <Loader type={LoaderType.Spinner} size={6} />
-        </LoaderWrapper>
-        <Text
-          displayStyle={TextDisplayStyle.Headline3}
-          message={{
-            id: longerConnection
-              ? "module.onboarding.connectingLongMessage"
-              : "module.onboarding.connectingMessage",
-          }}
-        />
-      </main>
-    </Container>
+    <GenericThemeProvider>
+      <Container>
+        <SpinnerLoader />
+        <ConnectingText>
+          {longerConnection
+            ? intl.formatMessage(messages.connectingLongMessage)
+            : intl.formatMessage(messages.connectingMessage)}
+        </ConnectingText>
+      </Container>
+    </GenericThemeProvider>
   )
 }
 

--- a/libs/core/core/components/apps/base-app/base-app-routes.tsx
+++ b/libs/core/core/components/apps/base-app/base-app-routes.tsx
@@ -59,7 +59,7 @@ export default () => (
       </Route>
 
       <Route exact path={[...Object.values(URL_DISCOVERY_DEVICE)]}>
-        <LayoutBlankWrapper>
+        <LayoutBlankWrapper closeable={false}>
           <Route
             path={URL_DISCOVERY_DEVICE.root}
             component={ConfiguredDevicesDiscovery}
@@ -79,7 +79,7 @@ export default () => (
       </Route>
 
       <Route exact path={[...Object.values(URL_DEVICE_INITIALIZATION)]}>
-        <LayoutBlankWrapper>
+        <LayoutBlankWrapper closeable={false}>
           <Route
             path={URL_DEVICE_INITIALIZATION.root}
             component={DevicesInitialization}

--- a/libs/core/device-initialization/components/devices-initialization-modal-flows/api-device-initialization-modal-flow.tsx
+++ b/libs/core/device-initialization/components/devices-initialization-modal-flows/api-device-initialization-modal-flow.tsx
@@ -9,7 +9,6 @@ import React, { useCallback, useEffect, useMemo, useRef } from "react"
 import { useDispatch, useSelector } from "react-redux"
 import { useHistory } from "react-router-dom"
 import { defineMessages } from "react-intl"
-import ReactModal from "react-modal"
 import styled from "styled-components"
 import { useFilteredRoutesHistory } from "shared/utils"
 import { useDataMigrationDeviceSelector } from "shared/feature"
@@ -22,13 +21,12 @@ import {
   selectDataMigrationTargetDevice,
   setSourceDevice,
 } from "generic-view/store"
-import { Modal, SpinnerLoader } from "generic-view/ui"
+import { Modal } from "generic-view/ui"
 import { GenericThemeProvider } from "generic-view/theme"
 import { ButtonAction, IconType } from "generic-view/utils"
 import { FunctionComponent } from "Core/core/types/function-component.interface"
 import { Dispatch, ReduxRootState } from "Core/__deprecated__/renderer/store"
 import { intl } from "Core/__deprecated__/renderer/utils/intl"
-import { ModalLayers } from "Core/modals-manager/constants/modal-layers.enum"
 import {
   URL_DEVICE_INITIALIZATION,
   URL_DISCOVERY_DEVICE,
@@ -40,9 +38,6 @@ import { DeviceInitializationStatus } from "Core/device-initialization/reducers/
 import { useDeactivateDeviceAndRedirect } from "Core/overview/components/overview-screens/pure-overview/use-deactivate-device-and-redirect.hook"
 
 const messages = defineMessages({
-  connectingModalParagraph: {
-    id: "module.onboarding.connectingMessage",
-  },
   lockedModalHeadline: {
     id: "component.deviceLockedModalHeadline",
   },
@@ -146,28 +141,6 @@ export const APIDeviceInitializationModalFlow: FunctionComponent = () => {
   return (
     <GenericThemeProvider>
       <Wrapper>
-        <ReactModal
-          isOpen
-          overlayClassName="generic-modal-overlay"
-          style={{
-            overlay: {
-              zIndex: ModalLayers.Default,
-            },
-            content: {
-              backgroundColor: "transparent",
-              border: "none",
-              display: "flex",
-              flexDirection: "column",
-              justifyContent: "center",
-              alignItems: "center",
-            },
-          }}
-        >
-          <SpinnerLoader />
-          <ConnectingText>
-            {intl.formatMessage(messages.connectingModalParagraph)}
-          </ConnectingText>
-        </ReactModal>
         <Modal
           componentKey={"device-initialization"}
           config={{
@@ -192,12 +165,4 @@ const Wrapper = styled.div`
   height: 100%;
   width: 100%;
   background: ${({ theme }) => theme.color.grey6};
-`
-
-const ConnectingText = styled.p`
-  font-size: ${({ theme }) => theme.fontSize.headline3};
-  line-height: ${({ theme }) => theme.lineHeight.headline3};
-  color: ${({ theme }) => theme.color.white};
-  font-weight: ${({ theme }) => theme.fontWeight.bold};
-  margin: 2.4rem 0 0;
 `

--- a/libs/core/device-initialization/components/devices-initialization.component.tsx
+++ b/libs/core/device-initialization/components/devices-initialization.component.tsx
@@ -46,9 +46,7 @@ const DevicesInitialization: FunctionComponent = () => {
   return (
     <>
       <DevicesInitializationModalFlow activeDevice={activeDevice} />
-      {activeDevice?.deviceType !== DeviceType.APIDevice && (
-        <ConnectingContent />
-      )}
+      <ConnectingContent />
     </>
   )
 }

--- a/libs/core/device-initialization/components/passcode-modal/passcode-modal-ui.component.tsx
+++ b/libs/core/device-initialization/components/passcode-modal/passcode-modal-ui.component.tsx
@@ -94,6 +94,7 @@ const PasscodeModalUI: FunctionComponent<PasscodeModalProps> = ({
       closeButton={false}
       closeModal={canBeClosed ? close : undefined}
       title={muditaLogo}
+      noOverlayBg={true}
     >
       <PasscodeModalContent>
         <span></span>

--- a/libs/core/ui/components/modal-dialog/get-modal-dialog-style.helper.ts
+++ b/libs/core/ui/components/modal-dialog/get-modal-dialog-style.helper.ts
@@ -3,9 +3,7 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import muditaTheme, {
-  Theme,
-} from "Core/core/styles/theming/theme"
+import muditaTheme, { Theme } from "Core/core/styles/theming/theme"
 import {
   backgroundColor,
   zIndex as getZIndex,
@@ -16,6 +14,7 @@ import { Styles } from "react-modal"
 
 export interface GetModalDialogStyleProps {
   size: ModalProps["size"]
+  noOverlayBg?: boolean
   zIndex?: number
   theme?: Theme
 }
@@ -49,12 +48,15 @@ export const getModalDialogStyle = ({
   zIndex,
   size,
   theme = muditaTheme,
+  noOverlayBg = false,
 }: GetModalDialogStyleProps): Styles => {
   return {
     overlay: {
       // AUTO DISABLED - fix me if you like :)
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      backgroundColor: backgroundColor("modalBackdrop")({ theme }),
+      backgroundColor: noOverlayBg
+        ? "transparent"
+        : backgroundColor("modalBackdrop")({ theme }),
       // AUTO DISABLED - fix me if you like :)
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       zIndex: zIndex ? zIndex : getZIndex("modalBackdrop")({ theme }),

--- a/libs/core/ui/components/modal-dialog/modal-dialog.component.tsx
+++ b/libs/core/ui/components/modal-dialog/modal-dialog.component.tsx
@@ -65,6 +65,7 @@ export const ModalDialog: FunctionComponent<ModalDialogProps> = withTheme(
     actionButtonSize,
     actionButtonDisabled,
     theme,
+    noOverlayBg,
     ...props
   }) => {
     const closeModalByButtonClick = () => {
@@ -87,39 +88,43 @@ export const ModalDialog: FunctionComponent<ModalDialogProps> = withTheme(
         isOpen={open}
         // AUTO DISABLED - fix me if you like :)
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        style={getModalDialogStyle({ zIndex: layer, size, theme })}
+        style={getModalDialogStyle({ zIndex: layer, size, theme, noOverlayBg })}
         shouldCloseOnOverlayClick={false}
         // AUTO DISABLED - fix me if you like :)
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         onAfterClose={onClose}
         {...props}
       >
-        {(title || subtitle || closeModal) && <Header
-          // AUTO DISABLED - fix me if you like :)
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          titleOrder={titleOrder}
-          subtitleGap={Boolean(subtitle)}
-          data-testid={ModalTestIds.Header}
-        >
-          {title && <ModalTitle
-            displayStyle={getTitleStyle(size)}
+        {(title || subtitle || closeModal) && (
+          <Header
             // AUTO DISABLED - fix me if you like :)
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-            subTitle={subtitle}
-            element={"h2"}
-            data-testid={ModalTestIds.Title}
+            titleOrder={titleOrder}
+            subtitleGap={Boolean(subtitle)}
+            data-testid={ModalTestIds.Header}
           >
-            {title}
-          </ModalTitle>}
-          {Boolean(closeModal) && close}
-          <ModalSubTitle
-            displayStyle={getSubtitleStyle(size)}
-            color="secondary"
-            element={"p"}
-          >
-            {subtitle}
-          </ModalSubTitle>
-        </Header>}
+            {title && (
+              <ModalTitle
+                displayStyle={getTitleStyle(size)}
+                // AUTO DISABLED - fix me if you like :)
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                subTitle={subtitle}
+                element={"h2"}
+                data-testid={ModalTestIds.Title}
+              >
+                {title}
+              </ModalTitle>
+            )}
+            {Boolean(closeModal) && close}
+            <ModalSubTitle
+              displayStyle={getSubtitleStyle(size)}
+              color="secondary"
+              element={"p"}
+            >
+              {subtitle}
+            </ModalSubTitle>
+          </Header>
+        )}
         {children}
         {actionButtonLabel || closeButton ? (
           // AUTO DISABLED - fix me if you like :)

--- a/libs/core/ui/components/modal-dialog/modal-dialog.interface.ts
+++ b/libs/core/ui/components/modal-dialog/modal-dialog.interface.ts
@@ -14,6 +14,7 @@ export interface ModalDialogProps extends Omit<Props, "isOpen">, ModalProps {
   close?: ComponentProps<typeof Button>
   closeModal?: () => void
   open: boolean
+  noOverlayBg?: boolean
   theme?: GetModalDialogStyleProps["theme"]
   layer?: ModalLayers
 }


### PR DESCRIPTION
JIRA Reference: [CP-2845]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2845]: https://appnroll.atlassian.net/browse/CP-2845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ