### PR TITLE
[CP-2953] Empty device selection drawer appears during connect/disconnect stress tests

### DIFF
--- a/libs/core/device-select/components/device-select-drawer.component.tsx
+++ b/libs/core/device-select/components/device-select-drawer.component.tsx
@@ -95,7 +95,7 @@ const DeviceSelectDrawer: FunctionComponent = () => {
   return (
     <DrawerWrapper>
       <Drawer
-        open={isOpen}
+        open={isOpen || devices.length !== 0}
         onClose={() => {
           dispatch(setSelectDeviceDrawerOpen(false))
         }}

--- a/libs/core/device-select/components/device-select-drawer.component.tsx
+++ b/libs/core/device-select/components/device-select-drawer.component.tsx
@@ -32,6 +32,7 @@ import { DrawerDevice } from "Core/device-select/components/drawer-device.compon
 import { defineMessages } from "react-intl"
 import { DeviceId } from "Core/device/constants/device-id"
 import { ModalLayers } from "Core/modals-manager/constants/modal-layers.enum"
+import { useEffect } from "react"
 
 const messages = defineMessages({
   changeDevice: { id: "component.drawer.headerTitle" },
@@ -92,10 +93,16 @@ const DeviceSelectDrawer: FunctionComponent = () => {
     }
   }
 
+  useEffect(() => {
+    if (devices.length === 0) {
+      dispatch(setSelectDeviceDrawerOpen(false))
+    }
+  }, [dispatch, devices.length])
+
   return (
     <DrawerWrapper>
       <Drawer
-        open={isOpen || devices.length !== 0}
+        open={isOpen}
         onClose={() => {
           dispatch(setSelectDeviceDrawerOpen(false))
         }}


### PR DESCRIPTION
JIRA Reference: [CP-2953]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2953]: https://appnroll.atlassian.net/browse/CP-2953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ