### PR TITLE
[CP-2980] add data-testids for select device

### DIFF
--- a/libs/core/device-select/components/device-select-drawer.component.tsx
+++ b/libs/core/device-select/components/device-select-drawer.component.tsx
@@ -37,6 +37,10 @@ import { DrawerDevice } from "Core/device-select/components/drawer-device.compon
 import { DeviceId } from "Core/device/constants/device-id"
 import { ModalLayers } from "Core/modals-manager/constants/modal-layers.enum"
 
+const dataTestIds = {
+  drawerContent: "device-select-drawer-content",
+}
+
 const messages = defineMessages({
   changeDevice: { id: "component.drawer.headerTitle" },
 })
@@ -108,7 +112,7 @@ const DeviceSelectDrawer: FunctionComponent = () => {
         size="36.9rem"
         zIndex={ModalLayers.Drawer}
       >
-        <DrawerChildrenContainer>
+        <DrawerChildrenContainer data-testid={dataTestIds.drawerContent}>
           <Header>
             <Text
               displayStyle={TextDisplayStyle.Headline4}

--- a/libs/core/device-select/components/drawer-device.component.tsx
+++ b/libs/core/device-select/components/drawer-device.component.tsx
@@ -23,6 +23,13 @@ import { getDeviceTypeName } from "Core/discovery-device/utils/get-device-type-n
 import { intl } from "Core/__deprecated__/renderer/utils/intl"
 import { getSerialNumberValue } from "Core/utils/get-serial-number-value"
 
+const dataTestIds = {
+  deviceImage: "drawer-device-image",
+  deviceSerialNumberValue: "drawer-device-serial-number-value",
+  deviceType: "drawer-device-type",
+  drawerDeviceWrapper: "drawer-device-wrapper",
+}
+
 const Device = styled("div")<{ active: boolean }>`
   padding: 1.8rem 2.4rem 1.8rem 1rem;
   display: flex;
@@ -122,14 +129,22 @@ export const DrawerDevice: FunctionComponent<DrawerDeviceProps> = ({
       active={deviceId == activeDeviceId}
       key={deviceId}
       onClick={deviceId === activeDeviceId ? () => {} : onClick}
+      data-testid={`${dataTestIds.drawerDeviceWrapper}-${serialNumberValue}`}
     >
       <DeviceImageContainer>
-        <DeviceImageStyled deviceType={deviceType} caseColour={caseColour} />
+        <DeviceImageStyled
+          deviceType={deviceType}
+          caseColour={caseColour}
+          data-testid={dataTestIds.deviceImage}
+        />
       </DeviceImageContainer>
 
       <DeviceDetailsWrapper>
         <DeviceDetails>
-          <DeviceName displayStyle={TextDisplayStyle.Headline4}>
+          <DeviceName
+            displayStyle={TextDisplayStyle.Headline4}
+            data-testid={dataTestIds.deviceType}
+          >
             {getDeviceTypeName(deviceType, caseColour)}
             {deviceId === activeDeviceId &&
               intl.formatMessage({
@@ -147,7 +162,10 @@ export const DrawerDevice: FunctionComponent<DrawerDeviceProps> = ({
                   id: "module.availableDeviceList.serialNumber",
                 })}
               </Text>
-              <Text displayStyle={TextDisplayStyle.Paragraph1}>
+              <Text
+                displayStyle={TextDisplayStyle.Paragraph1}
+                data-testid={dataTestIds.deviceSerialNumberValue}
+              >
                 {serialNumberValue}
               </Text>
             </>


### PR DESCRIPTION
JIRA Reference: [CP-2980]
[CP-2981]
[CP-2982]
[CP-2983]
[CP-2984]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2980]: https://appnroll.atlassian.net/browse/CP-2980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-2981]: https://appnroll.atlassian.net/browse/CP-2981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-2982]: https://appnroll.atlassian.net/browse/CP-2982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-2983]: https://appnroll.atlassian.net/browse/CP-2983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-2984]: https://appnroll.atlassian.net/browse/CP-2984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ