### PR TITLE
[CP-2949] Contacts > Search - layout is broken

### DIFF
--- a/libs/core/contacts/components/contact-search-results/contact-search-results.component.tsx
+++ b/libs/core/contacts/components/contact-search-results/contact-search-results.component.tsx
@@ -77,6 +77,16 @@ const SelectableContacts = styled(Table)<{ mouseLock?: boolean }>`
   }
 `
 
+const PhoneNumberCol = styled(Col)`
+  overflow: hidden;
+  height: calc(100% - 1rem);
+
+  > p {
+    height: 100%;
+    margin: 0;
+  }
+`
+
 interface ContactSearchResultProps {
   selectedContact: Contact | null
   onSelect: (contact: Contact) => void
@@ -158,12 +168,16 @@ const ContactSearchResults: FunctionComponent<ContactSearchResultProps> = ({
                         id: "module.contacts.listUnnamedContact",
                       })}
                   </ClickableCol>
-                  <Col>{phoneNumber}</Col>
-                  <Col>
-                    {contact.primaryPhoneNumber &&
-                      contact.secondaryPhoneNumber &&
-                      contact.secondaryPhoneNumber}
-                  </Col>
+                  <PhoneNumberCol>
+                    <p>{phoneNumber}</p>
+                  </PhoneNumberCol>
+                  <PhoneNumberCol>
+                    <p>
+                      {contact.primaryPhoneNumber &&
+                        contact.secondaryPhoneNumber &&
+                        contact.secondaryPhoneNumber}
+                    </p>
+                  </PhoneNumberCol>
                   <Col>
                     <Actions>
                       <Dropdown onOpen={disableScroll} onClose={enableScroll}>


### PR DESCRIPTION
JIRA Reference: [CP-2949]

### :memo: Description ️

### MAC

#### MAC - before

<img width="1392" alt="Zrzut ekranu 2024-08-20 o 15 37 32" src="https://github.com/user-attachments/assets/b8348362-c229-4d87-a4b3-e638b3efd406">

#### MAC - after

<img width="1392" alt="Zrzut ekranu 2024-08-20 o 15 36 08" src="https://github.com/user-attachments/assets/bb56e70b-f2ba-4cbc-bd6e-17c505dca2d6">


### Windows

#### Windows - before

![Zrzut ekranu 2024-08-20 163525](https://github.com/user-attachments/assets/22d5443c-d97a-4be0-99e7-723b0c8b223c)

#### Windows - after

![Zrzut ekranu 2024-08-20 163431](https://github.com/user-attachments/assets/129d837f-fbc0-479e-b727-3ddfab575a60)

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2949]: https://appnroll.atlassian.net/browse/CP-2949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ