### PR TITLE
[CP-3096] "Skip password" is not possible if user will activate "Repeat password" but doesn't type any char for any field for backup creation

### DIFF
--- a/libs/generic-view/ui/src/lib/predefined/backup/backup-password.tsx
+++ b/libs/generic-view/ui/src/lib/predefined/backup/backup-password.tsx
@@ -89,7 +89,7 @@ export const BackupPassword: FunctionComponent<Props> = ({
           label: intl.formatMessage(messages.passwordRepeatPlaceholder),
           type: "password",
           validation: {
-            validate: (value: string, formValues) => {
+            validate: (value = "", formValues) => {
               const password = formValues.password || ""
               return (
                 value === password ||

--- a/libs/generic-view/ui/src/lib/predefined/backup/backup-password.tsx
+++ b/libs/generic-view/ui/src/lib/predefined/backup/backup-password.tsx
@@ -54,8 +54,8 @@ export const BackupPassword: FunctionComponent<Props> = ({
   nextAction,
 }) => {
   const { watch, formState } = useFormContext()
-  const password = watch("password")
-  const passwordRepeat = watch("passwordRepeat")
+  const password = watch("password") || ""
+  const passwordRepeat = watch("passwordRepeat") || ""
 
   const passwordsMatching = password === passwordRepeat
 
@@ -90,8 +90,9 @@ export const BackupPassword: FunctionComponent<Props> = ({
           type: "password",
           validation: {
             validate: (value: string, formValues) => {
+              const password = formValues.password || ""
               return (
-                value === formValues.password ||
+                value === password ||
                 intl.formatMessage(messages.passwordRepeatNotMatchingError)
               )
             },


### PR DESCRIPTION
JIRA Reference: [CP-3096]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-3096]: https://appnroll.atlassian.net/browse/CP-3096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ