### PR TITLE
[CP-2870] Improper handling of an incorrectly entered passcode

### DIFF
--- a/libs/core/device-initialization/components/passcode-modal/passcode-modal.component.tsx
+++ b/libs/core/device-initialization/components/passcode-modal/passcode-modal.component.tsx
@@ -11,9 +11,10 @@ import { AppError } from "Core/core/errors"
 import { ModalDialogProps } from "Core/ui"
 import { ModalLayers } from "Core/modals-manager/constants/modal-layers.enum"
 import { useHelpShortcut } from "help/store"
+import { UnlockStatus } from "Core/device"
 
 export type UnlockDeviceReturnType = Promise<
-  PayloadAction<boolean, string, unknown, AppError>
+  PayloadAction<UnlockStatus, string, unknown, AppError>
 >
 
 interface Props extends Omit<ModalDialogProps, "close" | "open"> {
@@ -79,7 +80,7 @@ const PasscodeModal: FunctionComponent<Props> = ({
         return
       }
 
-      if (!unlockDeviceStatus.payload) {
+      if (unlockDeviceStatus.payload !== "UNLOCKED") {
         setErrorState(ErrorState.BadPasscode)
         return
       }


### PR DESCRIPTION
JIRA Reference: [CP-2870]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2870]: https://appnroll.atlassian.net/browse/CP-2870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ