### PR TITLE
CP-2919-pause-fix added loop and pause

### DIFF
--- a/apps/mudita-center-e2e/src/specs/stress-tests/device-drawer-stress-test.ts
+++ b/apps/mudita-center-e2e/src/specs/stress-tests/device-drawer-stress-test.ts
@@ -60,11 +60,11 @@ describe("Kompakt switching devices", () => {
         serialNumber: device.serialNumber,
       })
 
-      await browser.pause(6000)
-
       // Add a 4-second wait after adding the first device
       if (i === 0) {
-        await browser.pause(4000)
+        await browser.pause(10000)
+      } else {
+        await browser.pause(6000)
       }
     }
   })

--- a/apps/mudita-center-e2e/src/specs/stress-tests/device-drawer-stress-test.ts
+++ b/apps/mudita-center-e2e/src/specs/stress-tests/device-drawer-stress-test.ts
@@ -46,7 +46,8 @@ describe("Kompakt switching devices", () => {
       },
     ]
 
-    for (const device of devices) {
+    for (let i = 0; i < devices.length; i++) {
+      const device = devices[i]
       E2EMockClient.mockResponse({
         path: device.path,
         body: device.body,
@@ -60,6 +61,11 @@ describe("Kompakt switching devices", () => {
       })
 
       await browser.pause(6000)
+
+      // Add a 4-second wait after adding the first device
+      if (i === 0) {
+        await browser.pause(4000)
+      }
     }
   })
 


### PR DESCRIPTION
JIRA Reference: [CP-3068]

### :memo: Description ️
Test fixes the device-drawer stress test. Now only device drawer is displayed instead of select device modal
-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-3068]: https://appnroll.atlassian.net/browse/CP-3068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ