### PR TITLE
[CP-3119] [CP-3122] Added data-testid to Backup Modal

### DIFF
--- a/libs/core/contact-support/containers/contact-support-flow.container.test.tsx
+++ b/libs/core/contact-support/containers/contact-support-flow.container.test.tsx
@@ -15,6 +15,14 @@ jest.mock("Core/settings/store/schemas/generate-application-id", () => ({
   generateApplicationId: () => "123",
 }))
 
+jest.mock("e2e-test-ids", () => {
+  return {
+    ModalTestIds: {
+      Modal: "modal-content",
+    },
+  }
+})
+
 type Props = ComponentProps<typeof ModalsManager>
 
 const defaultProps: Props = {}

--- a/libs/e2e-test-ids/src/e2e-test-ids.ts
+++ b/libs/e2e-test-ids/src/e2e-test-ids.ts
@@ -28,3 +28,14 @@ export enum ContactSupportModalTestIds {
   Description = "contact-support-modal-success-description",
   CloseButton = "contact-support-modal-success-close-button",
 }
+
+export enum BackupModalTestIds {
+  Title = "backup-features-modal-title",
+  Description = "backup-features-modal-description",
+  FeatureElementActive = "backup-features-modal-element-active",
+  FeatureElementInactive = "backup-features-modal-element-inactive",
+}
+
+export enum ModalTestIds {
+  Modal = "modal-content",
+}

--- a/libs/generic-view/ui/src/lib/interactive/modal/modal.tsx
+++ b/libs/generic-view/ui/src/lib/interactive/modal/modal.tsx
@@ -16,6 +16,7 @@ import { ModalScrollableContent } from "./helpers/modal-scrollable-content"
 import { ModalContent } from "./helpers/modal-content"
 import { ModalConfig } from "generic-view/models"
 import { ModalVisibilityController } from "./helpers/modal-visibility-controller"
+import { ModalTestIds } from "e2e-test-ids"
 
 export const Modal: BaseGenericComponent<
   undefined,
@@ -48,7 +49,12 @@ export const Modal: BaseGenericComponent<
       {config.closeButtonAction && (
         <ModalCloseButton config={{ action: config.closeButtonAction }} />
       )}
-      <ModalContent className={"modal-content"}>{children}</ModalContent>
+      <ModalContent
+        className={"modal-content"}
+        data-testid={`${ModalTestIds.Modal}-${componentKey}`}
+      >
+        {children}
+      </ModalContent>
     </ModalBase>
   )
 }

--- a/libs/generic-view/ui/src/lib/predefined/backup/backup-features.tsx
+++ b/libs/generic-view/ui/src/lib/predefined/backup/backup-features.tsx
@@ -12,6 +12,7 @@ import { Modal } from "../../interactive/modal"
 import { defineMessages } from "react-intl"
 import { intl } from "Core/__deprecated__/renderer/utils/intl"
 import { BackupFeature } from "generic-view/models"
+import { BackupModalTestIds } from "e2e-test-ids"
 
 const messages = defineMessages({
   title: {
@@ -57,17 +58,29 @@ export const BackupFeatures: FunctionComponent<Props> = ({
   return (
     <>
       <Modal.TitleIcon config={{ type: IconType.Backup }} />
-      <Modal.Title>{intl.formatMessage(messages.title)}</Modal.Title>
+      <Modal.Title data-testid={BackupModalTestIds.Title}>
+        {intl.formatMessage(messages.title)}
+      </Modal.Title>
       <Article>
-        <p>{intl.formatMessage(messages.description)}</p>
+        <p data-testid={BackupModalTestIds.Description}>
+          {intl.formatMessage(messages.description)}
+        </p>
         <Modal.ScrollableContent>
           <ul>
             {features.map((feature, index) => (
-              <li key={feature.key + index}>{feature.label}</li>
+              <li
+                key={feature.key + index}
+                data-testid={BackupModalTestIds.FeatureElementActive}
+              >
+                {feature.label}
+              </li>
             ))}
             {Object.entries(comingSoonMessages).map(([key, message], index) => {
               return (
-                <ComingSoonListItem key={key + index}>
+                <ComingSoonListItem
+                  key={key + index}
+                  data-testid={BackupModalTestIds.FeatureElementInactive}
+                >
                   {intl.formatMessage(message)}
                 </ComingSoonListItem>
               )


### PR DESCRIPTION
JIRA Reference: [CP-3119] [CP-3122]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-3119]: https://appnroll.atlassian.net/browse/CP-3119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-3122]: https://appnroll.atlassian.net/browse/CP-3122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ