### PR TITLE
[CP-2914] Device flashing workaround added for Linux - vol.2

### DIFF
--- a/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/linux-device-flash.service.ts
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/linux-device-flash.service.ts
@@ -13,6 +13,35 @@ function splitPathToDirnameAndBasename(currentPath: string) {
   return [dirname, basename]
 }
 
+function extractPartitions(input: string): string[] {
+  const lines = input.split('\n');
+  const partitions: string[] = [];
+
+  for (const line of lines) {
+    const trimmedLine = line.trim();
+
+    if (!trimmedLine || trimmedLine.startsWith('NAME') || trimmedLine.startsWith('MOUNTPOINT') || trimmedLine === 'sdb') {
+      continue;
+    }
+
+    const lineWithoutTree = trimmedLine.replace(/^[^\w]*([\w\d]+)/, '$1');
+
+    const partitionNameMatch = lineWithoutTree.match(/^(\S+)/);
+    if (partitionNameMatch) {
+      const partitionName = partitionNameMatch[1];
+      if (partitionName && partitionName !== 'sdb') {
+        partitions.push(partitionName);
+      }
+    }
+  }
+
+  return partitions;
+}
+
+const options = {
+  name: "Mudita Auto Flash",
+}
+
 class LinuxDeviceFlashService implements IDeviceFlash {
   async findDeviceByDeviceName(deviceName: string): Promise<string> {
     console.log(`Searching for device with model name: ${deviceName}`)
@@ -42,7 +71,7 @@ class LinuxDeviceFlashService implements IDeviceFlash {
     const partitions = await this.getPartitions(device)
 
     for (const partition of partitions) {
-      await execPromise(`sudo umount /dev/${partition}`)
+      await execCommandWithSudo(`umount /dev/${partition}`, options)
     }
   }
 
@@ -51,20 +80,22 @@ class LinuxDeviceFlashService implements IDeviceFlash {
     imagePath: string,
     scriptPath: string
   ): Promise<void> {
-    await execCommandWithSudo(`chmod +x ${scriptPath}`, {
-      name: "Mudita Auto Flash",
-    })
+    await execCommandWithSudo(`chmod +x ${scriptPath}`, options)
 
     const [path, scriptBasename] = splitPathToDirnameAndBasename(scriptPath)
     const [, imageBasename] = splitPathToDirnameAndBasename(imagePath)
 
-    await execPromise(
-      `cd ${path} && sudo ./${scriptBasename} ${imageBasename} /dev/${device}`
-    )
+    try {
+      await execCommandWithSudo(
+        `cd ${path} && ./${scriptBasename} ${imageBasename} /dev/${device}`
+      , options)
+    } catch (error) {
+      console.error("Flash process successfully failed with error: ", error)
+    }
   }
 
   async ejectDevice(device: string): Promise<void> {
-    await execPromise(`sudo eject /dev/${device}`)
+    await execCommandWithSudo(`eject /dev/${device}`, options)
   }
 
   private async getDevices(): Promise<string[]> {
@@ -78,12 +109,7 @@ class LinuxDeviceFlashService implements IDeviceFlash {
       `lsblk /dev/${device} -o NAME,MOUNTPOINT`
     )
 
-    return (
-      partitions
-        ?.split("\n")
-        .filter((line) => line.includes(`/dev/${device}`) && line.includes("/"))
-        .map((line) => line.split(" ")[0]) ?? []
-    )
+    return extractPartitions(partitions ?? "")
   }
 }
 

--- a/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/linux-device-flash.service.ts
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/linux-device-flash.service.ts
@@ -47,7 +47,7 @@ class LinuxDeviceFlashService implements IDeviceFlash {
       .map((partition) => `/dev/${partition}`)
       .join(" ")
 
-    return `umount ${partitionsString}`
+    return `umount -f ${partitionsString}`
   }
 
   private async getFlashImageToDeviceCommand(

--- a/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/linux-device-flash.service.ts
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/linux-device-flash.service.ts
@@ -6,7 +6,7 @@
 import path from "path"
 import { execPromise, execCommandWithSudo } from "shared/utils"
 import IDeviceFlash from "./device-flash.interface"
-import LinuxPartitionParser from "Libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/linux-partition-parser"
+import LinuxPartitionParser from "./linux-partition-parser"
 
 class LinuxDeviceFlashService implements IDeviceFlash {
   async findDeviceByDeviceName(deviceName: string): Promise<string> {

--- a/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/linux-device-flash.service.ts
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/linux-device-flash.service.ts
@@ -47,7 +47,7 @@ class LinuxDeviceFlashService implements IDeviceFlash {
       .map((partition) => `/dev/${partition}`)
       .join(" ")
 
-    return `umount -f ${partitionsString}`
+    return `umount ${partitionsString} 2>/dev/null || true`
   }
 
   private async getFlashImageToDeviceCommand(

--- a/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/linux-device-flash.service.ts
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/linux-device-flash.service.ts
@@ -31,7 +31,7 @@ function extractPartitions(input: string): string[] {
 
     const lineWithoutTree = trimmedLine.replace(/^[^\w]*([\w\d]+)/, "$1")
 
-    const partitionNameMatch = lineWithoutTree.match(/^(\S+)/)
+    const partitionNameMatch = /^(\S+)/.exec(lineWithoutTree)
     if (partitionNameMatch) {
       const partitionName = partitionNameMatch[1]
       if (partitionName && partitionName !== "sdb") {

--- a/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/linux-device-flash.service.ts
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/linux-device-flash.service.ts
@@ -62,7 +62,7 @@ class LinuxDeviceFlashService implements IDeviceFlash {
   }
 
   private async getEjectDeviceCommand(device: string): Promise<string> {
-    return `eject /dev/${device}`
+    return `eject /dev/${device} 2>/dev/null || true`
   }
 
   private async getDevices(): Promise<string[]> {

--- a/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/linux-partition-parser.test.ts
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/linux-partition-parser.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) Mudita sp. z o.o. All rights reserved.
+ * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
+ */
+
+import LinuxPartitionParser from "./linux-partition-parser"
+
+describe("LinuxPartitionParser", () => {
+  test("correctly parses partitions from 'sdb' device output", () => {
+    const execOutput = `
+NAME   MOUNTPOINT
+sdb
+├─sdb1 /media/system_a
+├─sdb2 /media/system_b
+└─sdb3 /media/user
+`
+    const result = LinuxPartitionParser.parsePartitions(execOutput)
+    expect(result).toEqual(["sdb1", "sdb2", "sdb3"])
+  })
+
+  test("correctly parses partitions from a device with a custom name", () => {
+    const execOutput = `
+NAME        MOUNTPOINT
+nvme0n1
+├─nvme0n1p1 /boot
+├─nvme0n1p2 /
+└─nvme0n1p3 /home
+`
+    const result = LinuxPartitionParser.parsePartitions(execOutput)
+    expect(result).toEqual(["nvme0n1p1", "nvme0n1p2", "nvme0n1p3"])
+  })
+
+  test("returns an empty array when no partitions are found", () => {
+    const execOutput = `
+NAME   MOUNTPOINT
+sdb
+`
+    const result = LinuxPartitionParser.parsePartitions(execOutput)
+    expect(result).toEqual([])
+  })
+
+  test("correctly handles irregular formatting", () => {
+    const execOutput = `
+NAME   MOUNTPOINT
+  sdb
+├─   sdb1   /media/system_a
+├─sdb2       /media/system_b
+└─sdb3       /media/user
+`
+    const result = LinuxPartitionParser.parsePartitions(execOutput)
+    expect(result).toEqual(["sdb1", "sdb2", "sdb3"])
+  })
+
+  test("correctly parses partitions when mountpoints are missing", () => {
+    const execOutput = `
+NAME   MOUNTPOINT
+sdb
+├─sdb1
+├─sdb2
+└─sdb3
+`
+    const result = LinuxPartitionParser.parsePartitions(execOutput)
+    expect(result).toEqual(["sdb1", "sdb2", "sdb3"])
+  })
+
+  test('ignores non-partition lines like "NAME" and "MOUNTPOINT"', () => {
+    const execOutput = `
+NAME   MOUNTPOINT
+sdb
+├─sdb1 /media/system_a
+├─sdb2 /media/system_b
+NAME
+MOUNTPOINT
+└─sdb3 /media/user
+`
+    const result = LinuxPartitionParser.parsePartitions(execOutput)
+    expect(result).toEqual(["sdb1", "sdb2", "sdb3"])
+  })
+})

--- a/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/linux-partition-parser.ts
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/linux-partition-parser.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Mudita sp. z o.o. All rights reserved.
+ * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
+ */
+
+export class LinuxPartitionParser {
+  public static parsePartitions(execOutput: string): string[] {
+    const partitions: string[] = [];
+    const lines = execOutput.split("\n");
+
+    let deviceName: string | null = null;
+
+    for (const rawLine of lines) {
+      const line = rawLine.trim();
+
+      if (!line || line.startsWith("NAME") || line.startsWith("MOUNTPOINT")) {
+        continue;
+      }
+
+      const name = LinuxPartitionParser.extractName(line);
+
+      if (!name) {
+        continue;
+      }
+
+      if (!deviceName) {
+        deviceName = name;
+        continue;
+      }
+
+      if (name !== deviceName) {
+        partitions.push(name);
+      }
+    }
+
+    return partitions;
+  }
+
+  private static extractName(line: string): string | null {
+    const match = /^\W*(\w+)/.exec(line);
+    return match ? match[1] : null;
+  }
+}
+
+export default LinuxPartitionParser;

--- a/libs/shared/utils/src/lib/exec-command-with-sudo.ts
+++ b/libs/shared/utils/src/lib/exec-command-with-sudo.ts
@@ -16,11 +16,11 @@ export const execCommandWithSudo = (
         return reject(`Error: ${error.message}`);
       }
 
-      if (stderr) {
-        const output = stderr?.toString().trim();
-        console.error(`Command stderr output: ${output}`);
-        return reject(`Error: ${stderr.toString().trim()}`);
-      }
+      // if (stderr) {
+      //   const output = stderr?.toString().trim();
+      //   console.error(`Command stderr output: ${output}`);
+      //   return reject(`Error: ${stderr.toString().trim()}`);
+      // }
 
       const output = stdout?.toString().trim() || "Command executed successfully but produced no output.";
 

--- a/libs/shared/utils/src/lib/exec-command-with-sudo.ts
+++ b/libs/shared/utils/src/lib/exec-command-with-sudo.ts
@@ -16,11 +16,11 @@ export const execCommandWithSudo = (
         return reject(`Error: ${error.message}`);
       }
 
-      // if (stderr) {
-      //   const output = stderr?.toString().trim();
-      //   console.error(`Command stderr output: ${output}`);
-      //   return reject(`Error: ${stderr.toString().trim()}`);
-      // }
+      if (stderr && !stdout) {
+        const output = stderr?.toString().trim();
+        console.error(`Command stderr output: ${output}`);
+        return reject(`Error: ${stderr.toString().trim()}`);
+      }
 
       const output = stdout?.toString().trim() || "Command executed successfully but produced no output.";
 


### PR DESCRIPTION
JIRA Reference: [CP-2914]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2914]: https://appnroll.atlassian.net/browse/CP-2914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ