### PR TITLE
CP-3154 fix selector and tests for "Create backup"  and "backupInfo" on overview - Kompakt

### DIFF
--- a/apps/mudita-center-e2e/src/page-objects/modal-backup-kompakt.page.ts
+++ b/apps/mudita-center-e2e/src/page-objects/modal-backup-kompakt.page.ts
@@ -6,11 +6,8 @@
 import { OverviewPage } from "./overview.page"
 
 class ModalBackupKompaktPage extends OverviewPage {
-  public get backupInfo() {
-    return $('//div[@data-testid="block-box-backup"]//p')
-  }
   public get createBackupButton() {
-    return $('//button[@type="button" and .//span[text()="Create backup"]]')
+    return $('[data-testid="primary-button-backupcreate-backup-button"]')
   }
   public get createBackupProceedNext() {
     return $('[data-testid="backup-features-modal-create-action"]')

--- a/apps/mudita-center-e2e/src/page-objects/overview-kompakt.page.ts
+++ b/apps/mudita-center-e2e/src/page-objects/overview-kompakt.page.ts
@@ -31,7 +31,7 @@ class OverviewKompaktPage extends OverviewPage {
   }
 
   public get backupInfo() {
-    return $(`//div[@data-testid="block-box-backup"]//p`)
+    return $('div[data-testid="block-box-backup"] p')
   }
 
   public get serialNumberLabel() {

--- a/apps/mudita-center-e2e/src/page-objects/overview.page.ts
+++ b/apps/mudita-center-e2e/src/page-objects/overview.page.ts
@@ -55,7 +55,7 @@ export class OverviewPage extends Page {
   }
 
   public get createBackupButton() {
-    return $('//button[@type="button" and .//span[text()="Create backup"]]')
+    return $('[data-testid="primary-button-backupcreate-backup-button"]')
   }
 
   public get restoreBackupButton() {


### PR DESCRIPTION
…ted backupInfo selector for kompakt-overview test and kompakt-backup-getting-initial-info

JIRA Reference: [CP-3154]

### :memo: Description ️
fix selector and tests for "Create backup"  and "backupInfo" on overview - Kompakt
-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-3154]: https://appnroll.atlassian.net/browse/CP-3154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ