### PR TITLE
[CP-3145] Add Bottom-Left Position for Tooltip

### DIFF
--- a/libs/device/models/src/lib/feature/extra-config.ts
+++ b/libs/device/models/src/lib/feature/extra-config.ts
@@ -5,14 +5,14 @@
 
 import { z } from "zod"
 
-const TooltipPlaceEnum = z.enum(["bottom-right", "bottom-left"]);
+const TooltipPlacementEnum = z.enum(["bottom-right", "bottom-left"]);
 
-export type TooltipPlace = z.infer<typeof TooltipPlaceEnum>;
+export type TooltipPlacement = z.infer<typeof TooltipPlacementEnum>;
 
 const tooltipSchema = z.object({
   contentText: z.string().optional(),
   contentList: z.array(z.string()).optional(),
-  place: TooltipPlaceEnum.optional(),
+  placement: TooltipPlacementEnum.optional(),
 })
 
 export const extraConfigSchema = z.object({

--- a/libs/device/models/src/lib/feature/extra-config.ts
+++ b/libs/device/models/src/lib/feature/extra-config.ts
@@ -5,12 +5,18 @@
 
 import { z } from "zod"
 
+const TooltipPlaceEnum = z.enum(["bottom-right", "bottom-left"]);
+
+export type TooltipPlace = z.infer<typeof TooltipPlaceEnum>;
+
 const tooltipSchema = z.object({
-  contentText: z.string(),
+  contentText: z.string().optional(),
+  contentList: z.array(z.string()).optional(),
+  place: TooltipPlaceEnum.optional(),
 })
 
 export const extraConfigSchema = z.object({
-  tooltip: tooltipSchema,
+  tooltip: tooltipSchema.optional(),
 })
 
 export type ExtraConfig = z.infer<typeof extraConfigSchema>

--- a/libs/generic-view/feature/src/lib/setup-component.tsx
+++ b/libs/generic-view/feature/src/lib/setup-component.tsx
@@ -169,7 +169,7 @@ export const setupComponent = <P extends object>(
       )
 
       return extra?.tooltip ? (
-        <Tooltip>
+        <Tooltip place={extra.tooltip.place}>
           <Tooltip.Anchor>{componentElement}</Tooltip.Anchor>
           <Tooltip.Content $defaultStyles>
             <Paragraph5>{extra.tooltip.contentText}</Paragraph5>

--- a/libs/generic-view/feature/src/lib/setup-component.tsx
+++ b/libs/generic-view/feature/src/lib/setup-component.tsx
@@ -169,7 +169,7 @@ export const setupComponent = <P extends object>(
       )
 
       return extra?.tooltip ? (
-        <Tooltip place={extra.tooltip.place}>
+        <Tooltip placement={extra.tooltip.placement}>
           <Tooltip.Anchor>{componentElement}</Tooltip.Anchor>
           <Tooltip.Content $defaultStyles>
             <Paragraph5>{extra.tooltip.contentText}</Paragraph5>

--- a/libs/generic-view/ui/src/lib/interactive/tooltip/tooltip.tsx
+++ b/libs/generic-view/ui/src/lib/interactive/tooltip/tooltip.tsx
@@ -14,16 +14,16 @@ import React, {
 } from "react"
 import styled, { css } from "styled-components"
 import { BaseGenericComponent } from "generic-view/utils"
-import { TooltipPlace } from "device/models"
+import { TooltipPlacement } from "device/models"
 
 export const Tooltip: BaseGenericComponent<
   undefined,
   undefined,
-  { place?: TooltipPlace }
+  { placement?: TooltipPlacement }
 > & {
   Anchor: typeof TooltipAnchor
   Content: typeof TooltipContent
-} = ({ children, place = "bottom-right" }) => {
+} = ({ children, placement = "bottom-right" }) => {
   const [anchorPosition, setAnchorPosition] = useState<{
     top?: number
     left?: number
@@ -40,19 +40,19 @@ export const Tooltip: BaseGenericComponent<
         return
       }
 
-      if (place === "bottom-right") {
+      if (placement === "bottom-right") {
         const top = anchorRect.top + anchorRect.height
         const left = anchorRect.left
 
         setAnchorPosition({ left, top })
-      } else if (place === "bottom-left") {
+      } else if (placement === "bottom-left") {
         const top = anchorRect.top + anchorRect.height
         const left = anchorRect.left - contentReact.width + anchorRect.width
 
         setAnchorPosition({ left, top })
       }
     },
-    [place]
+    [placement]
   )
 
   const anchor = useMemo(() => {


### PR DESCRIPTION
JIRA Reference: [CP-3145]

### :memo: Description ️

<details>
<img width="1392" alt="Zrzut ekranu 2024-10-2 o 15 06 39" src="https://github.com/user-attachments/assets/694d1bc2-046f-4fbf-baa5-dc510e397109">

</details>

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-3145]: https://appnroll.atlassian.net/browse/CP-3145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ