### PR TITLE
[CP-2995] Introduce adjustedOffset logic to handle tooltip flipping adjustments

### DIFF
--- a/libs/generic-view/ui/src/lib/interactive/tooltip/tooltip-helpers.tsx
+++ b/libs/generic-view/ui/src/lib/interactive/tooltip/tooltip-helpers.tsx
@@ -5,25 +5,44 @@
 
 import { TooltipPlacement } from "device/models"
 
+type PlacementMap = { [key in TooltipPlacement]: TooltipPlacement }
+
+const VERTICAL_FLIP_MAP: PlacementMap = {
+  "bottom-right": "top-right",
+  "bottom-left": "top-left",
+  "top-right": "bottom-right",
+  "top-left": "bottom-left",
+}
+
+const HORIZONTAL_FLIP_MAP: PlacementMap = {
+  "bottom-right": "bottom-left",
+  "bottom-left": "bottom-right",
+  "top-right": "top-left",
+  "top-left": "top-right",
+}
+
 export const flipVertical = (placement: TooltipPlacement): TooltipPlacement => {
-  return placement.startsWith("bottom")
-    ? (`top-${placement.split("-")[1]}` as TooltipPlacement)
-    : (`bottom-${placement.split("-")[1]}` as TooltipPlacement)
+  return VERTICAL_FLIP_MAP[placement]
 }
 
 export const flipHorizontal = (
   placement: TooltipPlacement
 ): TooltipPlacement => {
-  return placement.endsWith("right")
-    ? (`-${placement.replace("right", "left")}` as TooltipPlacement)
-    : (`-${placement.replace("left", "right")}` as TooltipPlacement)
+  return HORIZONTAL_FLIP_MAP[placement]
 }
 
 export const flipTooltipPlacement = (
   placement: TooltipPlacement
 ): TooltipPlacement => {
-  const [vertical, horizontal] = placement.split("-")
-  const flippedVertical = vertical === "bottom" ? "top" : "bottom"
-  const flippedHorizontal = horizontal === "right" ? "left" : "right"
-  return `${flippedVertical}-${flippedHorizontal}` as TooltipPlacement
+  return flipHorizontal(flipVertical(placement))
+}
+
+export const getFlipStatus = (
+  original: TooltipPlacement,
+  current: TooltipPlacement
+): { isFlippedVertically: boolean; isFlippedHorizontally: boolean } => {
+  const isFlippedVertically = VERTICAL_FLIP_MAP[original] === current
+  const isFlippedHorizontally = HORIZONTAL_FLIP_MAP[original] === current
+
+  return { isFlippedVertically, isFlippedHorizontally }
 }

--- a/libs/generic-view/ui/src/lib/interactive/tooltip/tooltip.tsx
+++ b/libs/generic-view/ui/src/lib/interactive/tooltip/tooltip.tsx
@@ -57,14 +57,14 @@ export const Tooltip: BaseGenericComponent<
         flipTooltipPlacement(placement),
       ]
 
-      const calculatePosition = (placment: TooltipPlacement): Position => {
+      const calculatePosition = (placement: TooltipPlacement): Position => {
         let top = 0
         let left = 0
 
         const adjustedOffset: TooltipOffsetType = { ...offset }
         const { isFlippedVertically, isFlippedHorizontally } = getFlipStatus(
           originalPlacement.current,
-          placment
+          placement
         )
 
         if (isFlippedVertically) {
@@ -74,7 +74,7 @@ export const Tooltip: BaseGenericComponent<
           adjustedOffset.x = -offset.x
         }
 
-        switch (placment) {
+        switch (placement) {
           case "bottom-right":
             top = anchorRect.top + anchorRect.height + adjustedOffset.y
             left = anchorRect.left + adjustedOffset.x
@@ -99,9 +99,6 @@ export const Tooltip: BaseGenericComponent<
               anchorRect.width +
               adjustedOffset.x
             break
-          default:
-            top = anchorRect.top + anchorRect.height + adjustedOffset.y
-            left = anchorRect.left + adjustedOffset.x
         }
 
         return { top, left }

--- a/libs/generic-view/ui/src/lib/interactive/tooltip/tooltip.tsx
+++ b/libs/generic-view/ui/src/lib/interactive/tooltip/tooltip.tsx
@@ -19,6 +19,7 @@ import {
   flipHorizontal,
   flipTooltipPlacement,
   flipVertical,
+  getFlipStatus,
 } from "./tooltip-helpers"
 
 interface Position {
@@ -35,6 +36,7 @@ export const Tooltip: BaseGenericComponent<
   Content: typeof TooltipContent
 } = ({ children, placement = "bottom-right", offset = { x: 0, y: 0 } }) => {
   const [contentPosition, setContentPosition] = useState<Partial<Position>>({})
+  const originalPlacement = useRef<TooltipPlacement>(placement)
 
   const contentRef = useRef<HTMLDivElement>(null)
 
@@ -59,30 +61,47 @@ export const Tooltip: BaseGenericComponent<
         let top = 0
         let left = 0
 
+        const adjustedOffset: TooltipOffsetType = { ...offset }
+        const { isFlippedVertically, isFlippedHorizontally } = getFlipStatus(
+          originalPlacement.current,
+          placment
+        )
+
+        if (isFlippedVertically) {
+          adjustedOffset.y = -offset.y
+        }
+        if (isFlippedHorizontally) {
+          adjustedOffset.x = -offset.x
+        }
+
         switch (placment) {
           case "bottom-right":
-            top = anchorRect.top + anchorRect.height + offset.y
-            left = anchorRect.left + offset.x
+            top = anchorRect.top + anchorRect.height + adjustedOffset.y
+            left = anchorRect.left + adjustedOffset.x
             break
           case "bottom-left":
-            top = anchorRect.top + anchorRect.height + offset.y
+            top = anchorRect.top + anchorRect.height + adjustedOffset.y
             left =
-              anchorRect.left - contentRect.width + anchorRect.width + offset.x
+              anchorRect.left -
+              contentRect.width +
+              anchorRect.width +
+              adjustedOffset.x
             break
           case "top-right":
-            top =
-              anchorRect.top - contentRect.height - anchorRect.height - offset.y
-            left = anchorRect.left + offset.x
+            top = anchorRect.top + adjustedOffset.y - contentRect.height
+            left = anchorRect.left + adjustedOffset.x
             break
           case "top-left":
-            top =
-              anchorRect.top - contentRect.height - anchorRect.height - offset.y
+            top = anchorRect.top + adjustedOffset.y - contentRect.height
             left =
-              anchorRect.left - contentRect.width + anchorRect.width + offset.x
+              anchorRect.left -
+              contentRect.width +
+              anchorRect.width +
+              adjustedOffset.x
             break
           default:
-            top = anchorRect.top + anchorRect.height + offset.y
-            left = anchorRect.left + offset.x
+            top = anchorRect.top + anchorRect.height + adjustedOffset.y
+            left = anchorRect.left + adjustedOffset.x
         }
 
         return { top, left }
@@ -214,7 +233,6 @@ const Content = styled.div<{
   ${({ $defaultStyles, theme, $placement }) =>
     $defaultStyles &&
     css`
-      margin-top: 1rem;
       display: flex;
       flex-direction: column;
       align-items: flex-start;


### PR DESCRIPTION
JIRA Reference: [CP-2995]

### :memo: Description ️

Refactor tooltip positioning logic by introducing adjustedOffset to handle flipping adjustments for more consistent and maintainable offset calculations.


```


// @ts-ignore
const view: View = {
  phoneDropdownCounterBadge: {
    component: "button-text",
    config: {
      actions: [],
      modifiers: ["hover-background"],
    },
    layout: {
      padding: "2px 5px",
    },
    dataProvider: {
      source: "entities-field",
      entitiesType: "contacts",
      fields: [
        {
          slice: [1],
          flat: "phoneNumber",
          providerField: "phoneNumbers",
          componentField: "extra-data.tooltip.contentList",
        },
      ],
    },
    extra: {
      tooltip: {
        placement: "bottom-left",
        offset: {
          x: 0,
          y: 15,
        },
      },
    },
    childrenKeys: ["phoneDropdownCounterBadgeText"],
  },
  columnCheckbox: {
    component: "table.cell",
    config: {
      width: "74",
    },
    layout: {
      padding: "0 0 0 32px",
    },
    childrenKeys: ["contactCheckbox"],
  },
  contactCheckbox: {
    component: "form.checkboxInput",
    config: {
      name: "selectedContacts",
      size: "small",
    },
    dataProvider: {
      source: "entities-field",
      entitiesType: "contacts",
      fields: [
        {
          providerField: "contactId",
          componentField: "config.value",
        },
      ],
    },
    extra: {
      tooltip: {
        contentText: "Select",
        offset: {
          x: 0,
          y: 15,
        },
      },
    },
  },
}

export default view
```

<details>

<img width="1392" alt="Zrzut ekranu 2024-10-4 o 10 58 48" src="https://github.com/user-attachments/assets/18ad3cc2-d340-414d-99b4-c69de6ba57c7">
<img width="1392" alt="Zrzut ekranu 2024-10-4 o 10 58 46" src="https://github.com/user-attachments/assets/986d692f-d638-4722-8467-ead3c7f643db">
<img width="1392" alt="Zrzut ekranu 2024-10-4 o 10 21 45" src="https://github.com/user-attachments/assets/2837c02f-d282-4509-9fd8-426b1ce515eb">
<img width="1392" alt="Zrzut ekranu 2024-10-4 o 10 58 41" src="https://github.com/user-attachments/assets/74cb9603-2445-490a-b51a-1fd2e73d7db9">


</details>

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2995]: https://appnroll.atlassian.net/browse/CP-2995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ