### PR TITLE
[CP-XXX] POC for running E2E tests with Mock Device on Windows and Linux in CI/CD

### DIFF
--- a/.github/workflows/e2e-feature-branch.yml
+++ b/.github/workflows/e2e-feature-branch.yml
@@ -47,7 +47,7 @@ jobs:
           DEV_DEVICE_LOGGER_ENABLED: ${{ secrets.DEV_DEVICE_LOGGER_ENABLED }}
           FEATURE_TOGGLE_RELEASE_ENVIRONMENT: ${{ secrets.FEATURE_TOGGLE_RELEASE_ENVIRONMENT }}
           MUDITA_CENTER_PRERELEASE_ENABLED: ${{ secrets.MUDITA_CENTER_PRERELEASE_ENABLED }}
-          MOCK_SERVICE_ENABLED: ${{ secrets.MOCK_SERVICE_ENABLED }}
+          MOCK_SERVICE_ENABLED: "1"
         run: |
           printenv > .env
       - name: Setup environment variables for Windows
@@ -78,7 +78,7 @@ jobs:
           DEV_DEVICE_LOGGER_ENABLED: ${{ secrets.DEV_DEVICE_LOGGER_ENABLED }}
           FEATURE_TOGGLE_RELEASE_ENVIRONMENT: ${{ secrets.FEATURE_TOGGLE_RELEASE_ENVIRONMENT }}
           MUDITA_CENTER_PRERELEASE_ENABLED: ${{ secrets.MUDITA_CENTER_PRERELEASE_ENABLED }}
-          MOCK_SERVICE_ENABLED: ${{ secrets.MOCK_SERVICE_ENABLED }}
+          MOCK_SERVICE_ENABLED: "1"
           NEW_HELP_ENABLED: ${{ secrets.NEW_HELP_ENABLED }}
         shell: cmd
         run: |

--- a/apps/mudita-center-e2e/wdio.conf.ts
+++ b/apps/mudita-center-e2e/wdio.conf.ts
@@ -123,6 +123,23 @@ export const config: Options.Testrunner = {
       toRelativePath(TestFilesPaths.newsPageOnlineTest),
       toRelativePath(TestFilesPaths.termsOfServiceTest),
       toRelativePath(TestFilesPaths.contactSupportUnhappyPath),
+
+
+      toRelativePath(TestFilesPaths.contactSupportUnhappyPath),
+      toRelativePath(TestFilesPaths.mcCheckForUpdatesTest),
+      toRelativePath(TestFilesPaths.mcCheckForUpdatesOfflineTest),
+      toRelativePath(TestFilesPaths.newsPageOfflineTest),
+
+      toRelativePath(TestFilesPaths.mcHomePageForceUpdateTest),
+      toRelativePath(TestFilesPaths.mcHomePageForceUpdateErrorTest),
+      toRelativePath(TestFilesPaths.mcHomePageSoftUpdateTest),
+      toRelativePath(TestFilesPaths.mcHomePageSoftUpdateErrorTest),
+      toRelativePath(TestFilesPaths.kompaktOverview),
+      toRelativePath(TestFilesPaths.kompaktSwitchingDevices),
+      toRelativePath(TestFilesPaths.kompaktAbout),
+      toRelativePath(TestFilesPaths.kompaktConnectedDevicesModalStressTest),
+      toRelativePath(TestFilesPaths.kompaktDrawerStressTest),
+      toRelativePath(TestFilesPaths.kompaktBackupModalGettingInitialInfo),
     ],
     cicdMock: [
       toRelativePath(TestFilesPaths.contactSupportUnhappyPath),


### PR DESCRIPTION
JIRA Reference: [CP-XXX]

### :memo: Description ️

Implemented a Proof of Concept for running end-to-end (E2E) tests using a Mock Device on both Windows and Linux, with tests successfully passing in both environments. To run these tests in CI/CD, I adjusted the scope of the executed tests and modified an environment variable to ensure the application builds with the mock for testing purposes.

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated
