### PR TITLE
[CP-3128] Improve Flashing Process to Handle macOS Specific Path and Flash Completion

### DIFF
--- a/libs/core/core/components/apps/base-app/base-app.component.tsx
+++ b/libs/core/core/components/apps/base-app/base-app.component.tsx
@@ -3,7 +3,7 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import React, { useEffect } from "react"
+import React from "react"
 import { FunctionComponent } from "Core/core/types/function-component.interface"
 import AppInitialization from "Core/app-initialization/components/app-initialization.component"
 import { useDeviceConnectedEffect } from "Core/core/hooks/use-device-connected-effect"
@@ -16,6 +16,7 @@ import { useDeviceLockedEffect } from "Core/core/hooks/use-device-locked-effect"
 import { useDeviceDetachedEffect } from "Core/core/hooks/use-device-detached-effect"
 import { useDeviceConnectFailedEffect } from "Core/core/hooks/use-device-connect-failed-effect"
 import { useDiscoveryRedirectEffect } from "Core/core/hooks/use-discovery-redirect-effect"
+import { useAbortFlashingOnDeviceDetached } from "Core/core/hooks/use-abort-flashing-on-device-detached"
 import { useRouterListener } from "Core/core/hooks"
 import {
   OutboxWrapper,
@@ -26,14 +27,6 @@ import {
 import { useFileDialogEventListener, useOnlineListener } from "shared/app-state"
 import { useCoreDeviceProtocolListeners } from "core-device/feature"
 import { useHelp } from "help/store"
-import { abortMscFlashing } from "msc-flash-harmony"
-import { useDispatch } from "react-redux"
-import { Dispatch } from "Core/__deprecated__/renderer/store"
-import { answerMain } from "shared/utils"
-import {
-  DeviceBaseProperties,
-  DeviceProtocolMainEvent,
-} from "device-protocol/models"
 
 const BaseApp: FunctionComponent = () => {
   useRouterListener()
@@ -54,17 +47,8 @@ const BaseApp: FunctionComponent = () => {
   useFileDialogEventListener()
   useHelp()
 
-  // tmp solution
-  const dispatch = useDispatch<Dispatch>()
-
-  useEffect(() => {
-    return answerMain<DeviceBaseProperties>(
-      DeviceProtocolMainEvent.DeviceDetached,
-      () => {
-        dispatch(abortMscFlashing())
-      }
-    )
-  }, [dispatch])
+  // MSC
+  useAbortFlashingOnDeviceDetached()
 
   return (
     <>

--- a/libs/core/core/components/apps/base-app/base-app.component.tsx
+++ b/libs/core/core/components/apps/base-app/base-app.component.tsx
@@ -3,7 +3,7 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import React from "react"
+import React, { useEffect } from "react"
 import { FunctionComponent } from "Core/core/types/function-component.interface"
 import AppInitialization from "Core/app-initialization/components/app-initialization.component"
 import { useDeviceConnectedEffect } from "Core/core/hooks/use-device-connected-effect"
@@ -26,6 +26,14 @@ import {
 import { useFileDialogEventListener, useOnlineListener } from "shared/app-state"
 import { useCoreDeviceProtocolListeners } from "core-device/feature"
 import { useHelp } from "help/store"
+import { abortMscFlashing } from "msc-flash-harmony"
+import { useDispatch } from "react-redux"
+import { Dispatch } from "Core/__deprecated__/renderer/store"
+import { answerMain } from "shared/utils"
+import {
+  DeviceBaseProperties,
+  DeviceProtocolMainEvent,
+} from "device-protocol/models"
 
 const BaseApp: FunctionComponent = () => {
   useRouterListener()
@@ -45,6 +53,18 @@ const BaseApp: FunctionComponent = () => {
   useBackupList()
   useFileDialogEventListener()
   useHelp()
+
+  // tmp solution
+  const dispatch = useDispatch<Dispatch>()
+
+  useEffect(() => {
+    return answerMain<DeviceBaseProperties>(
+      DeviceProtocolMainEvent.DeviceDetached,
+      () => {
+        dispatch(abortMscFlashing())
+      }
+    )
+  }, [dispatch])
 
   return (
     <>

--- a/libs/core/core/hooks/use-abort-flashing-on-device-detached.ts
+++ b/libs/core/core/hooks/use-abort-flashing-on-device-detached.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Mudita sp. z o.o. All rights reserved.
+ * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
+ */
+
+import { useEffect } from "react"
+import { useDispatch } from "react-redux"
+import { answerMain } from "shared/utils"
+import {
+  DeviceBaseProperties,
+  DeviceProtocolMainEvent,
+} from "device-protocol/models"
+import { abortMscFlashing } from "msc-flash-harmony"
+import { Dispatch } from "Core/__deprecated__/renderer/store"
+
+export const useAbortFlashingOnDeviceDetached = () => {
+  const dispatch = useDispatch<Dispatch>()
+
+  useEffect(() => {
+    return answerMain<DeviceBaseProperties>(
+      DeviceProtocolMainEvent.DeviceDetached,
+      () => {
+        dispatch(abortMscFlashing())
+      }
+    )
+  }, [dispatch])
+}

--- a/libs/core/core/hooks/use-device-detached-effect.ts
+++ b/libs/core/core/hooks/use-device-detached-effect.ts
@@ -39,7 +39,6 @@ export const useDeviceDetachedEffect = () => {
 }
 
 const useHandleDevicesDetached = () => {
-  const dispatch = useDispatch<Dispatch>()
   const processActiveDevicesDetachment = useProcessActiveDevicesDetachment()
   const processSingleDeviceRemaining = useProcessSingleDeviceRemaining()
 

--- a/libs/generic-view/store/src/lib/action-names.ts
+++ b/libs/generic-view/store/src/lib/action-names.ts
@@ -86,4 +86,6 @@ export enum ActionName {
 
   MscFlashingGetFilesDetails = "msc-flashing/get-files-details",
   MscFlashingSetProcessState = "msc-flashing/set-process-state",
+  MscFlashingSetAbort = "msc-flashing/set-abort",
+  MscFlashingAbort = "msc-flashing/abort",
 }

--- a/libs/msc-flash/msc-flash-harmony/src/lib/actions/abort-msc-flashing.ts
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/actions/abort-msc-flashing.ts
@@ -7,15 +7,24 @@ import { createAsyncThunk } from "@reduxjs/toolkit"
 import { ActionName } from "generic-view/store"
 import { ReduxRootState } from "Core/__deprecated__/renderer/store"
 import { selectFlashingAbortController } from "../selectors/select-flashing-abort-controller"
+import { setFlashingProcessState } from "./set-flashing-process-state/set-flashing-process-state.action"
+import { FlashingProcessState } from "../constants"
 
 export const abortMscFlashing = createAsyncThunk<
   void,
-  undefined,
+  { reason?: Extract<FlashingProcessState, "canceled" | "failed"> } | undefined,
   { state: ReduxRootState }
->(ActionName.MscFlashingAbort, async (_, { getState }) => {
-  const abortController = selectFlashingAbortController(getState())
+>(
+  ActionName.MscFlashingAbort,
+  async ({ reason } = {}, { dispatch, getState }) => {
+    const abortController = selectFlashingAbortController(getState())
 
-  abortController?.abort?.()
+    abortController?.abort?.()
 
-  return
-})
+    if (reason) {
+      dispatch(setFlashingProcessState(reason))
+    }
+
+    return
+  }
+)

--- a/libs/msc-flash/msc-flash-harmony/src/lib/actions/abort-msc-flashing.ts
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/actions/abort-msc-flashing.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Mudita sp. z o.o. All rights reserved.
+ * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
+ */
+
+import { createAsyncThunk } from "@reduxjs/toolkit"
+import { ActionName } from "generic-view/store"
+import { ReduxRootState } from "Core/__deprecated__/renderer/store"
+import { selectFlashingAbortController } from "../selectors/select-flashing-abort-controller"
+
+export const abortMscFlashing = createAsyncThunk<
+  void,
+  undefined,
+  { state: ReduxRootState }
+>(ActionName.MscFlashingAbort, async (_, { getState }) => {
+  const abortController = selectFlashingAbortController(getState())
+
+  abortController?.abort?.()
+
+  return
+})

--- a/libs/msc-flash/msc-flash-harmony/src/lib/actions/actions.ts
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/actions/actions.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Mudita sp. z o.o. All rights reserved.
+ * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
+ */
+
+import { createAction } from "@reduxjs/toolkit"
+import { ActionName } from "generic-view/store"
+
+export const setMscFlashingAbort = createAction<AbortController | undefined>(
+  ActionName.MscFlashingSetAbort
+)

--- a/libs/msc-flash/msc-flash-harmony/src/lib/actions/index.ts
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/actions/index.ts
@@ -5,3 +5,5 @@
 
 export * from "./get-msc-flashing-files-details/get-msc-flashing-files-details.action"
 export * from "./set-flashing-process-state/set-flashing-process-state.action"
+export * from "./abort-msc-flashing"
+export * from "./actions"

--- a/libs/msc-flash/msc-flash-harmony/src/lib/constants/flashing-process-state.enum.ts
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/constants/flashing-process-state.enum.ts
@@ -12,5 +12,6 @@ export enum FlashingProcessState {
   TerminalOpened = "terminal-opened",
   Restarting = "restarting-device",
   Completed = "completed",
+  Canceled = "canceled",
   Failed = "failed",
 }

--- a/libs/msc-flash/msc-flash-harmony/src/lib/reducers/flashing.interface.ts
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/reducers/flashing.interface.ts
@@ -7,6 +7,7 @@ import { FlashingProcessState } from "../constants"
 import { MscFlashDetails } from "../dto"
 
 export interface FlashingState {
+  abortController?: AbortController
   processState: FlashingProcessState
   mscFlashingFilesDetails?: MscFlashDetails
   error: string | undefined

--- a/libs/msc-flash/msc-flash-harmony/src/lib/reducers/flashing.reducer.ts
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/reducers/flashing.reducer.ts
@@ -7,6 +7,7 @@ import { createReducer } from "@reduxjs/toolkit"
 import { FlashingState } from "./flashing.interface"
 import { getMscFlashingFilesDetails, setFlashingProcessState } from "../actions"
 import { FlashingProcessState } from "../constants"
+import { setMscFlashingAbort } from "../actions/actions"
 
 const initialState: FlashingState = {
   processState: FlashingProcessState.Idle,
@@ -23,6 +24,9 @@ export const flashingReducer = createReducer<FlashingState>(
       })
       .addCase(setFlashingProcessState, (state, action) => {
         state.processState = action.payload
+      })
+      .addCase(setMscFlashingAbort, (state, action) => {
+        state.abortController = action.payload
       })
   }
 )

--- a/libs/msc-flash/msc-flash-harmony/src/lib/selectors/flashing-state.selector.ts
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/selectors/flashing-state.selector.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Mudita sp. z o.o. All rights reserved.
+ * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
+ */
+
+import { ReduxRootState } from "Core/__deprecated__/renderer/store"
+import { FlashingState } from "msc-flash-harmony"
+
+export const flashingState = (state: ReduxRootState): FlashingState =>
+  state.flashing

--- a/libs/msc-flash/msc-flash-harmony/src/lib/selectors/index.ts
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/selectors/index.ts
@@ -3,4 +3,4 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-export * from "./msc-flash.selector"
+export * from "./select-flashing-process-state"

--- a/libs/msc-flash/msc-flash-harmony/src/lib/selectors/select-flashing-abort-controller.ts
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/selectors/select-flashing-abort-controller.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Mudita sp. z o.o. All rights reserved.
+ * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
+ */
+
+import { createSelector } from "@reduxjs/toolkit"
+import { flashingState } from "./flashing-state.selector"
+
+export const selectFlashingAbortController = createSelector(
+  flashingState,
+  (flashingState) => flashingState.abortController
+)

--- a/libs/msc-flash/msc-flash-harmony/src/lib/selectors/select-flashing-process-state.ts
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/selectors/select-flashing-process-state.ts
@@ -4,10 +4,9 @@
  */
 
 import { createSelector } from "@reduxjs/toolkit"
-import { ReduxRootState } from "Core/__deprecated__/renderer/store"
-import { FlashingProcessState } from "../constants"
+import { flashingState } from "./flashing-state.selector"
 
 export const selectFlashingProcessState = createSelector(
-  (state: ReduxRootState) => state.flashing.processState,
-  (processState: FlashingProcessState) => processState
+  flashingState,
+  (flashingState) => flashingState.processState
 )

--- a/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/device-flash.factory.ts
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/device-flash.factory.ts
@@ -8,13 +8,13 @@ import LinuxDeviceFlashService from "./linux/linux-device-flash.service"
 import MacDeviceFlashService from "./macos/macos-device-flash-service"
 
 class DeviceFlashFactory {
-  static createDeviceFlashService(): IDeviceFlash {
+  static createDeviceFlashService(temporaryDirectoryPath: string): IDeviceFlash {
     const platform = process.platform
 
     if (platform === "linux") {
       return new LinuxDeviceFlashService()
     } else if (platform === "darwin") {
-      return new MacDeviceFlashService()
+      return new MacDeviceFlashService(temporaryDirectoryPath)
     } else {
       throw new Error(`Unsupported platform: ${platform}`)
     }

--- a/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/device-flash.interface.ts
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/device-flash.interface.ts
@@ -7,6 +7,8 @@ interface IDeviceFlash {
   findDeviceByDeviceName(deviceName?: string): Promise<string>
 
   execute(device: string, imagePath: string, scriptPath: string): Promise<void>
+
+  waitForFlashCompletion(intervalAttemptsLeft?: number, intervalTime?: number): Promise<boolean>;
 }
 
 export default IDeviceFlash

--- a/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/device-flash.interface.ts
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/device-flash.interface.ts
@@ -14,7 +14,7 @@ interface IDeviceFlash {
 
   execute(device: string, imagePath: string, scriptPath: string): Promise<void>
 
-  waitForFlashCompletion(option?: waitForFlashCompletionOption): Promise<boolean>
+  waitForFlashCompletion?(option?: waitForFlashCompletionOption): Promise<boolean>
 }
 
 export default IDeviceFlash

--- a/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/device-flash.interface.ts
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/device-flash.interface.ts
@@ -3,12 +3,18 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
+export interface waitForFlashCompletionOption {
+  intervalAttemptsLeft?: number
+  intervalTime?: number
+  signal?: AbortSignal
+}
+
 interface IDeviceFlash {
   findDeviceByDeviceName(deviceName?: string): Promise<string>
 
   execute(device: string, imagePath: string, scriptPath: string): Promise<void>
 
-  waitForFlashCompletion(intervalAttemptsLeft?: number, intervalTime?: number): Promise<boolean>;
+  waitForFlashCompletion(option?: waitForFlashCompletionOption): Promise<boolean>
 }
 
 export default IDeviceFlash

--- a/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/linux/linux-device-flash.service.ts
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/linux/linux-device-flash.service.ts
@@ -41,10 +41,6 @@ class LinuxDeviceFlashService implements IDeviceFlash {
     console.log("Flash process completed successfully")
   }
 
-  async waitForFlashCompletion(): Promise<boolean>{
-    return true
-  }
-
   private async getUnmountDeviceCommand(device: string): Promise<string> {
     const partitions = await this.getPartitions(device)
     const partitionsString = partitions

--- a/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/linux/linux-device-flash.service.ts
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/linux/linux-device-flash.service.ts
@@ -41,6 +41,10 @@ class LinuxDeviceFlashService implements IDeviceFlash {
     console.log("Flash process completed successfully")
   }
 
+  async waitForFlashCompletion(): Promise<boolean>{
+    return true
+  }
+
   private async getUnmountDeviceCommand(device: string): Promise<string> {
     const partitions = await this.getPartitions(device)
     const partitionsString = partitions

--- a/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/macos/macos-device-flash-service.ts
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/services/device-flash/macos/macos-device-flash-service.ts
@@ -79,14 +79,14 @@ class MacDeviceFlashService implements IDeviceFlash {
       chmod +x "${scriptPath}"
     `)
     await execPromise(
-      `osascript -e 'tell application "Terminal" to do script "\\"${scriptPath}\\" -t \\"${this.flashStatusTempFilePath}\\" -i \\"${imagePath}\\" -d \\"${device}\\""'`
+      `osascript -e 'tell application "Terminal" to do script "\\"${scriptPath}\\" -i \\"${imagePath}\\" -d \\"${device}\\" -s \\"${this.flashStatusTempFilePath}\\""'`
     )
   }
 
   async waitForFlashCompletion(
     option: waitForFlashCompletionOption = {}
   ): Promise<boolean> {
-    const { intervalAttemptsLeft = 20, intervalTime = 1000, signal } = option
+    const { intervalAttemptsLeft = 60, intervalTime = 5000, signal } = option
 
     if (intervalAttemptsLeft <= 0 || signal?.aborted) {
       throw new Error()

--- a/libs/msc-flash/msc-flash-harmony/src/lib/services/flash-msc-device.service.ts
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/services/flash-msc-device.service.ts
@@ -16,6 +16,7 @@ import getAppSettingsMain from "Core/__deprecated__/main/functions/get-app-setti
 
 const IMAGE_FILE_NAME = "BellHybrid.img"
 import { RELEASE_SPACE } from "Core/update/constants/release-space.constant"
+import MacDeviceFlashService from "./device-flash/macos/macos-device-flash-service"
 import { removeDownloadedMscFiles } from "./remove-downloaded-msc-files.service"
 import { setMscFlashingAbort } from "../actions/actions"
 import { selectFlashingProcessState } from "../selectors"
@@ -122,11 +123,15 @@ const startFlashingProcess = async (
     await deviceFlash.execute(device, imageFilePath, scriptFilePath)
     dispatch(setFlashingProcessState(FlashingProcessState.TerminalOpened))
 
-    const abortController = new AbortController()
+    if (deviceFlash instanceof MacDeviceFlashService) {
+      const abortController = new AbortController()
 
-    dispatch(setMscFlashingAbort(abortController))
+      dispatch(setMscFlashingAbort(abortController))
 
-    await deviceFlash.waitForFlashCompletion({ signal: abortController.signal })
+      await deviceFlash.waitForFlashCompletion({
+        signal: abortController.signal,
+      })
+    }
 
     dispatch(setFlashingProcessState(FlashingProcessState.Restarting))
 

--- a/libs/msc-flash/msc-flash-harmony/src/lib/ui/mac-terminal-info-modal/mac-terminal-info-modal.component.tsx
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/ui/mac-terminal-info-modal/mac-terminal-info-modal.component.tsx
@@ -57,7 +57,6 @@ export const MacTerminalInfoModal: FunctionComponent<
         closeable={true}
         closeButton={false}
         closeModal={onClose}
-        onClose={onClose}
       >
         <ModalContent>
           <RoundIconWrapper>

--- a/libs/msc-flash/msc-flash-harmony/src/lib/ui/recovery-mode.tsx
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/ui/recovery-mode.tsx
@@ -27,7 +27,7 @@ import { FlashingProcessState } from "../constants"
 import theme from "Core/core/styles/theming/theme"
 import { RestartingDeviceModal } from "./restarting-device-modal/restarting-device-modal.component"
 import { ErrorHandlingModal } from "./error-handling-modal/error-handling-modal.component"
-import { setFlashingProcessState } from "../actions"
+import { abortMscFlashing, setFlashingProcessState } from "../actions"
 import { MacTerminalInfoModal } from "./mac-terminal-info-modal/mac-terminal-info-modal.component"
 
 const messages = defineMessages({
@@ -145,7 +145,7 @@ const RecoveryModeUI: FunctionComponent = () => {
   }
 
   const macTerminalInfoCloseHandler = (): void => {
-    dispatch(setFlashingProcessState(FlashingProcessState.Completed))
+    dispatch(abortMscFlashing({ reason: FlashingProcessState.Canceled }))
   }
 
   return (


### PR DESCRIPTION
JIRA Reference: [CP-3128]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-3128]: https://appnroll.atlassian.net/browse/CP-3128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ