### PR TITLE
[CP-3135] Infinite loop after flashing - MC not aware that flashed device is actually ready to use

### DIFF
--- a/libs/msc-flash/msc-flash-harmony/src/lib/ui/restarting-device-modal/restarting-device-modal.component.tsx
+++ b/libs/msc-flash/msc-flash-harmony/src/lib/ui/restarting-device-modal/restarting-device-modal.component.tsx
@@ -3,11 +3,15 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { FunctionComponent } from "Core/core/types/function-component.interface"
-import { intl } from "Core/__deprecated__/renderer/utils/intl"
-import React from "react"
+import React, { useEffect } from "react"
 import { defineMessages } from "react-intl"
+import { useDispatch } from "react-redux"
+import { intl } from "Core/__deprecated__/renderer/utils/intl"
+import { Dispatch } from "Core/__deprecated__/renderer/store"
+import { FunctionComponent } from "Core/core/types/function-component.interface"
 import LoaderModal from "Core/ui/components/loader-modal/loader-modal.component"
+import { setFlashingProcessState } from "../../actions"
+import { FlashingProcessState } from "../../constants"
 
 interface RestartingDeviceModalProps {
   open: boolean
@@ -28,6 +32,16 @@ const messages = defineMessages({
 export const RestartingDeviceModal: FunctionComponent<
   RestartingDeviceModalProps
 > = ({ open }) => {
+  const dispatch = useDispatch<Dispatch>()
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      dispatch(setFlashingProcessState(FlashingProcessState.Failed))
+    }, 2 * 60 * 1000)
+
+    return () => clearTimeout(timer)
+  }, [dispatch])
+
   return (
     <LoaderModal
       open={open}


### PR DESCRIPTION
JIRA Reference: [CP-3135]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-3135]: https://appnroll.atlassian.net/browse/CP-3135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ