### PR TITLE
[CP-3211][Mudita Center] Process Messages from Pure to Kompakt

### DIFF
--- a/libs/device/models/src/lib/data-transfer/data-transfer.test.ts
+++ b/libs/device/models/src/lib/data-transfer/data-transfer.test.ts
@@ -15,6 +15,7 @@ const minimumPreDataTransfer: PreDataTransfer = {
   domains: {
     ["contacts-v1"]: "dummy-text",
     ["callLog-v1"]: "dummy-text",
+    ["messages-v1"]: "dummy-text",
   },
 }
 

--- a/libs/device/models/src/lib/data-transfer/data-transfer.ts
+++ b/libs/device/models/src/lib/data-transfer/data-transfer.ts
@@ -5,7 +5,7 @@
 
 import { z } from "zod"
 
-export type DataTransferDomain = "contacts-v1" | "callLog-v1"
+export type DataTransferDomain = "contacts-v1" | "callLog-v1" | "messages-v1"
 
 export const PreDataTransferValidator = (domains: DataTransferDomain[]) => {
   const featuresValidator = domains.reduce((acc, key) => {

--- a/libs/device/models/src/lib/unified-entities/index.ts
+++ b/libs/device/models/src/lib/unified-entities/index.ts
@@ -5,3 +5,4 @@
 
 export * from "./unified-call-log"
 export * from "./unified-contact"
+export * from "./unified-message"

--- a/libs/device/models/src/lib/unified-entities/unified-message.ts
+++ b/libs/device/models/src/lib/unified-entities/unified-message.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Mudita sp. z o.o. All rights reserved.
+ * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
+ */
+
+export interface UnifiedMessageAddress {
+  address: string
+}
+
+export type UnifiedMessageType = "SMS" | "MMS"
+
+export type UnifiedMessageStatus = "RECEIVED" | "SENT"
+
+export type UnifiedMessageDeliveryStatus =
+  | "PENDING"
+  | "FAILED"
+  | "DELIVERED"
+  | "NONE"
+
+export interface UnifiedMessage {
+  id: string
+  body: string
+  date: number
+  read: boolean
+  type: UnifiedMessageType
+  address: [UnifiedMessageAddress, UnifiedMessageAddress?]
+  status: UnifiedMessageStatus
+  deliveryStatus: UnifiedMessageDeliveryStatus
+}

--- a/libs/generic-view/store/src/lib/data-migration/data-migration-mappers/pure-to-unified-contact.ts
+++ b/libs/generic-view/store/src/lib/data-migration/data-migration-mappers/pure-to-unified-contact.ts
@@ -5,9 +5,9 @@
 
 import { UnifiedContact } from "device/models"
 import { Contact } from "Core/contacts/reducers"
-import { getDisplayName } from "../helpers"
+import { getDisplayName } from "../../imports/contacts-mappers/helpers"
 
-export const mapPureApi = (contacts: Contact[]): UnifiedContact[] => {
+export const pureToUnifiedContact = (contacts: Contact[]): UnifiedContact[] => {
   return contacts.map((contact) => {
     const unifiedContact: Omit<UnifiedContact, "displayName"> = {
       id: contact.id,

--- a/libs/generic-view/store/src/lib/data-migration/data-migration-mappers/pure-to-unified-message.test.ts
+++ b/libs/generic-view/store/src/lib/data-migration/data-migration-mappers/pure-to-unified-message.test.ts
@@ -847,4 +847,85 @@ describe("`pureToUnifiedMessage`", () => {
       ])
     })
   })
+
+  describe("`pureToUnifiedMessage` - Filtering Messages Without Threads", () => {
+    test("excludes messages without a matching thread", () => {
+      const mockOptions: PureToUnifiedMessageOptions = {
+        threads: {
+          "2": {
+            contactId: "5",
+            contactName: "Leia Organa",
+            id: "2",
+            lastUpdatedAt: new Date("1970-01-01T00:06:32.000Z"),
+            messageSnippet: "Message without thread",
+            messageType: MessageType.INBOX,
+            phoneNumber: "+123456789",
+            unread: false,
+          },
+        },
+        messages: {
+          "1": {
+            content: "Message without a thread",
+            date: new Date("1970-01-01T00:06:31.000Z"),
+            id: "1",
+            messageType: MessageType.INBOX,
+            phoneNumber: "+123456789",
+            threadId: "3",
+          },
+        },
+      }
+
+      const unifiedMessages = pureToUnifiedMessage(mockOptions)
+      expect(unifiedMessages).toEqual([])
+    })
+
+    test("includes only messages with matching threads among multiple messages", () => {
+      const mockOptions: PureToUnifiedMessageOptions = {
+        threads: {
+          "1": {
+            contactId: "4",
+            contactName: "Luke Skywalker",
+            id: "1",
+            lastUpdatedAt: new Date("1970-01-01T00:06:31.000Z"),
+            messageSnippet: "Test Message",
+            messageType: MessageType.INBOX,
+            phoneNumber: "+91898402777",
+            unread: true,
+          },
+        },
+        messages: {
+          "1": {
+            content: "Test Message #1",
+            date: new Date("1970-01-01T00:06:31.000Z"),
+            id: "1",
+            messageType: MessageType.INBOX,
+            phoneNumber: "+91898402777",
+            threadId: "1",
+          },
+          "2": {
+            content: "Unmatched Message",
+            date: new Date("1970-01-01T00:06:32.000Z"),
+            id: "2",
+            messageType: MessageType.INBOX,
+            phoneNumber: "+91898405555",
+            threadId: "2",
+          },
+        },
+      }
+
+      const unifiedMessages = pureToUnifiedMessage(mockOptions)
+      expect(unifiedMessages).toEqual([
+        {
+          id: "1",
+          body: "Test Message #1",
+          date: 391000,
+          read: false,
+          type: "SMS",
+          address: [{ address: "+91898402777" }],
+          status: "SENT",
+          deliveryStatus: "DELIVERED",
+        },
+      ])
+    })
+  })
 })

--- a/libs/generic-view/store/src/lib/data-migration/data-migration-mappers/pure-to-unified-message.test.ts
+++ b/libs/generic-view/store/src/lib/data-migration/data-migration-mappers/pure-to-unified-message.test.ts
@@ -1,0 +1,850 @@
+/**
+ * Copyright (c) Mudita sp. z o.o. All rights reserved.
+ * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
+ */
+
+import {
+  pureToUnifiedMessage,
+  PureToUnifiedMessageOptions,
+} from "./pure-to-unified-message"
+import { MessageType } from "Core/messages/constants"
+
+describe("`pureToUnifiedMessage`", () => {
+  describe("`pureToUnifiedMessage` - Basic Mapping", () => {
+    test("maps a single basic message correctly", () => {
+      const mockOptions: PureToUnifiedMessageOptions = {
+        threads: {
+          "1": {
+            contactId: "4",
+            contactName: "Luke Skywalker",
+            id: "1",
+            lastUpdatedAt: new Date("1970-01-01T00:06:31.000Z"),
+            messageSnippet: "Hello",
+            messageType: MessageType.INBOX,
+            phoneNumber: "+123456789",
+            unread: true,
+          },
+        },
+        messages: {
+          "1": {
+            content: "Hello",
+            date: new Date("1970-01-01T00:06:31.000Z"),
+            id: "1",
+            messageType: MessageType.INBOX,
+            phoneNumber: "+123456789",
+            threadId: "1",
+          },
+        },
+      }
+
+      const unifiedMessages = pureToUnifiedMessage(mockOptions)
+      expect(unifiedMessages).toEqual([
+        {
+          id: "1",
+          body: "Hello",
+          date: 391000,
+          read: false,
+          type: "SMS",
+          address: [{ address: "+123456789" }],
+          status: "SENT",
+          deliveryStatus: "DELIVERED",
+        },
+      ])
+    })
+
+    test("maps two messages from different senders correctly", () => {
+      const mockOptionsMultiple: PureToUnifiedMessageOptions = {
+        threads: {
+          "1": {
+            contactId: "4",
+            contactName: "Skywalker Luke",
+            id: "1",
+            lastUpdatedAt: new Date("1970-01-01T00:06:31.000Z"),
+            messageSnippet: "Test Message from Luke",
+            messageType: MessageType.INBOX,
+            phoneNumber: "+91898402777",
+            unread: true,
+          },
+          "2": {
+            contactId: "5",
+            contactName: "Leia Organa",
+            id: "2",
+            lastUpdatedAt: new Date("1970-01-01T00:06:32.000Z"),
+            messageSnippet: "Test Message from Leia",
+            messageType: MessageType.INBOX,
+            phoneNumber: "+91898405555",
+            unread: false,
+          },
+        },
+        messages: {
+          "1": {
+            content: "Hello from Luke",
+            date: new Date("1970-01-01T00:06:31.000Z"),
+            id: "1",
+            messageType: MessageType.INBOX,
+            phoneNumber: "+91898402777",
+            threadId: "1",
+          },
+          "2": {
+            content: "Hello from Leia",
+            date: new Date("1970-01-01T00:06:32.000Z"),
+            id: "2",
+            messageType: MessageType.INBOX,
+            phoneNumber: "+91898405555",
+            threadId: "2",
+          },
+        },
+      }
+
+      const unifiedMessages = pureToUnifiedMessage(mockOptionsMultiple)
+      expect(unifiedMessages).toEqual([
+        {
+          id: "1",
+          body: "Hello from Luke",
+          date: 391000,
+          read: false,
+          type: "SMS",
+          address: [{ address: "+91898402777" }],
+          status: "SENT",
+          deliveryStatus: "DELIVERED",
+        },
+        {
+          id: "2",
+          body: "Hello from Leia",
+          date: 392000,
+          read: true,
+          type: "SMS",
+          address: [{ address: "+91898405555" }],
+          status: "SENT",
+          deliveryStatus: "DELIVERED",
+        },
+      ])
+    })
+  })
+
+  describe("`pureToUnifiedMessage` - Message Type Mapping", () => {
+    test("maps INBOX message type to SENT and DELIVERED", () => {
+      const mockOptions: PureToUnifiedMessageOptions = {
+        threads: {
+          "1": {
+            contactId: "4",
+            contactName: "Skywalker Luke",
+            id: "1",
+            lastUpdatedAt: new Date("1970-01-01T00:06:31.000Z"),
+            messageSnippet: "Test Message",
+            messageType: MessageType.INBOX,
+            phoneNumber: "+91898402777",
+            unread: true,
+          },
+        },
+        messages: {
+          "1": {
+            content: "Test Message #1",
+            date: new Date("1970-01-01T00:06:31.000Z"),
+            id: "1",
+            messageType: MessageType.INBOX,
+            phoneNumber: "+91898402777",
+            threadId: "1",
+          },
+        },
+      }
+      const unifiedMessages = pureToUnifiedMessage(mockOptions)
+      expect(unifiedMessages).toEqual([
+        {
+          id: "1",
+          body: "Test Message #1",
+          date: 391000,
+          read: false,
+          type: "SMS",
+          address: [{ address: "+91898402777" }],
+          status: "SENT",
+          deliveryStatus: "DELIVERED",
+        },
+      ])
+    })
+
+    test("maps FAILED message type to SENT and FAILED", () => {
+      const mockOptions: PureToUnifiedMessageOptions = {
+        threads: {
+          "1": {
+            contactId: "4",
+            contactName: "Skywalker Luke",
+            id: "1",
+            lastUpdatedAt: new Date("1970-01-01T00:06:31.000Z"),
+            messageSnippet: "Test Message",
+            messageType: MessageType.FAILED,
+            phoneNumber: "+91898402777",
+            unread: true,
+          },
+        },
+        messages: {
+          "1": {
+            content: "Test Message #2",
+            date: new Date("1970-01-01T00:06:31.000Z"),
+            id: "1",
+            messageType: MessageType.FAILED,
+            phoneNumber: "+91898402777",
+            threadId: "1",
+          },
+        },
+      }
+      const unifiedMessages = pureToUnifiedMessage(mockOptions)
+      expect(unifiedMessages).toEqual([
+        {
+          id: "1",
+          body: "Test Message #2",
+          date: 391000,
+          read: false,
+          type: "SMS",
+          address: [{ address: "+91898402777" }],
+          status: "SENT",
+          deliveryStatus: "FAILED",
+        },
+      ])
+    })
+
+    test("ignores DRAFT message type", () => {
+      const mockOptions: PureToUnifiedMessageOptions = {
+        threads: {
+          "1": {
+            contactId: "4",
+            contactName: "Skywalker Luke",
+            id: "1",
+            lastUpdatedAt: new Date("1970-01-01T00:06:31.000Z"),
+            messageSnippet: "Draft Message",
+            messageType: MessageType.DRAFT,
+            phoneNumber: "+91898402777",
+            unread: true,
+          },
+        },
+        messages: {
+          "1": {
+            content: "Draft Message #1",
+            date: new Date("1970-01-01T00:06:31.000Z"),
+            id: "1",
+            messageType: MessageType.DRAFT,
+            phoneNumber: "+91898402777",
+            threadId: "1",
+          },
+        },
+      }
+      const unifiedMessages = pureToUnifiedMessage(mockOptions)
+      expect(unifiedMessages).toEqual([]) // DRAFT messages should be ignored
+    })
+
+    test("maps QUEUED message type to SENT and PENDING", () => {
+      const mockOptions: PureToUnifiedMessageOptions = {
+        threads: {
+          "1": {
+            contactId: "4",
+            contactName: "Skywalker Luke",
+            id: "1",
+            lastUpdatedAt: new Date("1970-01-01T00:06:31.000Z"),
+            messageSnippet: "Test Message",
+            messageType: MessageType.QUEUED,
+            phoneNumber: "+91898402777",
+            unread: true,
+          },
+        },
+        messages: {
+          "1": {
+            content: "Test Message #3",
+            date: new Date("1970-01-01T00:06:31.000Z"),
+            id: "1",
+            messageType: MessageType.QUEUED,
+            phoneNumber: "+91898402777",
+            threadId: "1",
+          },
+        },
+      }
+      const unifiedMessages = pureToUnifiedMessage(mockOptions)
+      expect(unifiedMessages).toEqual([
+        {
+          id: "1",
+          body: "Test Message #3",
+          date: 391000,
+          read: false,
+          type: "SMS",
+          address: [{ address: "+91898402777" }],
+          status: "SENT",
+          deliveryStatus: "PENDING",
+        },
+      ])
+    })
+
+    test("maps OUTBOX message type to RECEIVED and NONE", () => {
+      const mockOptions: PureToUnifiedMessageOptions = {
+        threads: {
+          "1": {
+            contactId: "4",
+            contactName: "Skywalker Luke",
+            id: "1",
+            lastUpdatedAt: new Date("1970-01-01T00:06:31.000Z"),
+            messageSnippet: "Sent Message",
+            messageType: MessageType.OUTBOX,
+            phoneNumber: "+91898402777",
+            unread: true,
+          },
+        },
+        messages: {
+          "1": {
+            content: "Sent Message #1",
+            date: new Date("1970-01-01T00:06:31.000Z"),
+            id: "1",
+            messageType: MessageType.OUTBOX,
+            phoneNumber: "+91898402777",
+            threadId: "1",
+          },
+        },
+      }
+      const unifiedMessages = pureToUnifiedMessage(mockOptions)
+      expect(unifiedMessages).toEqual([
+        {
+          id: "1",
+          body: "Sent Message #1",
+          date: 391000,
+          read: false,
+          type: "SMS",
+          address: [{ address: "+91898402777" }],
+          status: "RECEIVED",
+          deliveryStatus: "NONE",
+        },
+      ])
+    })
+  })
+
+  describe("`pureToUnifiedMessage` - Read Flag Mapping", () => {
+    test("should mark all messages as read when thread unread is false", () => {
+      const mockOptions: PureToUnifiedMessageOptions = {
+        threads: {
+          "1": {
+            contactId: "4",
+            contactName: "Skywalker Luke",
+            id: "1",
+            lastUpdatedAt: new Date("1970-01-01T00:06:33.000Z"),
+            messageSnippet: "Latest Message",
+            messageType: MessageType.OUTBOX,
+            phoneNumber: "+91898402777",
+            unread: false,
+          },
+        },
+        messages: {
+          "1": {
+            content: "Old Message #1",
+            date: new Date("1970-01-01T00:06:31.000Z"),
+            id: "1",
+            messageType: MessageType.OUTBOX,
+            phoneNumber: "+91898402777",
+            threadId: "1",
+          },
+          "2": {
+            content: "Old Message #2",
+            date: new Date("1970-01-01T00:06:32.000Z"),
+            id: "2",
+            messageType: MessageType.OUTBOX,
+            phoneNumber: "+91898402777",
+            threadId: "1",
+          },
+          "3": {
+            content: "Latest Message",
+            date: new Date("1970-01-01T00:06:33.000Z"),
+            id: "3",
+            messageType: MessageType.OUTBOX,
+            phoneNumber: "+91898402777",
+            threadId: "1",
+          },
+        },
+      }
+      const unifiedMessages = pureToUnifiedMessage(mockOptions)
+      expect(unifiedMessages).toEqual([
+        {
+          id: "1",
+          body: "Old Message #1",
+          date: 391000,
+          read: true,
+          type: "SMS",
+          address: [{ address: "+91898402777" }],
+          status: "RECEIVED",
+          deliveryStatus: "NONE",
+        },
+        {
+          id: "2",
+          body: "Old Message #2",
+          date: 392000,
+          read: true,
+          type: "SMS",
+          address: [{ address: "+91898402777" }],
+          status: "RECEIVED",
+          deliveryStatus: "NONE",
+        },
+        {
+          id: "3",
+          body: "Latest Message",
+          date: 393000,
+          read: true,
+          type: "SMS",
+          address: [{ address: "+91898402777" }],
+          status: "RECEIVED",
+          deliveryStatus: "NONE",
+        },
+      ])
+    })
+
+    test("should mark only the latest message as unread when thread unread is true", () => {
+      const mockOptions: PureToUnifiedMessageOptions = {
+        threads: {
+          "1": {
+            contactId: "4",
+            contactName: "Skywalker Luke",
+            id: "1",
+            lastUpdatedAt: new Date("1970-01-01T00:06:33.000Z"),
+            messageSnippet: "Latest Message",
+            messageType: MessageType.OUTBOX,
+            phoneNumber: "+91898402777",
+            unread: true,
+          },
+        },
+        messages: {
+          "1": {
+            content: "Old Message #1",
+            date: new Date("1970-01-01T00:06:31.000Z"),
+            id: "1",
+            messageType: MessageType.OUTBOX,
+            phoneNumber: "+91898402777",
+            threadId: "1",
+          },
+          "2": {
+            content: "Old Message #2",
+            date: new Date("1970-01-01T00:06:32.000Z"),
+            id: "2",
+            messageType: MessageType.OUTBOX,
+            phoneNumber: "+91898402777",
+            threadId: "1",
+          },
+          "3": {
+            content: "Latest Message",
+            date: new Date("1970-01-01T00:06:33.000Z"),
+            id: "3",
+            messageType: MessageType.OUTBOX,
+            phoneNumber: "+91898402777",
+            threadId: "1",
+          },
+        },
+      }
+      const unifiedMessages = pureToUnifiedMessage(mockOptions)
+      expect(unifiedMessages).toEqual([
+        {
+          id: "1",
+          body: "Old Message #1",
+          date: 391000,
+          read: true,
+          type: "SMS",
+          address: [{ address: "+91898402777" }],
+          status: "RECEIVED",
+          deliveryStatus: "NONE",
+        },
+        {
+          id: "2",
+          body: "Old Message #2",
+          date: 392000,
+          read: true,
+          type: "SMS",
+          address: [{ address: "+91898402777" }],
+          status: "RECEIVED",
+          deliveryStatus: "NONE",
+        },
+        {
+          id: "3",
+          body: "Latest Message",
+          date: 393000,
+          read: false,
+          type: "SMS",
+          address: [{ address: "+91898402777" }],
+          status: "RECEIVED",
+          deliveryStatus: "NONE",
+        },
+      ])
+    })
+
+    test("should correctly map read flags across two threads with different unread states", () => {
+      const mockOptions: PureToUnifiedMessageOptions = {
+        threads: {
+          "1": {
+            contactId: "4",
+            contactName: "Skywalker Luke",
+            id: "1",
+            lastUpdatedAt: new Date("1970-01-01T00:06:32.000Z"),
+            messageSnippet: "Message in first thread",
+            messageType: MessageType.OUTBOX,
+            phoneNumber: "+91898402777",
+            unread: false,
+          },
+          "2": {
+            contactId: "5",
+            contactName: "Leia Organa",
+            id: "2",
+            lastUpdatedAt: new Date("1970-01-01T00:06:33.000Z"),
+            messageSnippet: "Latest in second thread",
+            messageType: MessageType.OUTBOX,
+            phoneNumber: "+91898405555",
+            unread: true,
+          },
+        },
+        messages: {
+          "1": {
+            content: "Old Message in Thread 1",
+            date: new Date("1970-01-01T00:06:31.000Z"),
+            id: "1",
+            messageType: MessageType.OUTBOX,
+            phoneNumber: "+91898402777",
+            threadId: "1",
+          },
+          "2": {
+            content: "Message in Thread 2",
+            date: new Date("1970-01-01T00:06:32.000Z"),
+            id: "2",
+            messageType: MessageType.OUTBOX,
+            phoneNumber: "+91898402777",
+            threadId: "1",
+          },
+          "3": {
+            content: "Latest in Thread 2",
+            date: new Date("1970-01-01T00:06:33.000Z"),
+            id: "3",
+            messageType: MessageType.OUTBOX,
+            phoneNumber: "+91898405555",
+            threadId: "2",
+          },
+        },
+      }
+      const unifiedMessages = pureToUnifiedMessage(mockOptions)
+      expect(unifiedMessages).toEqual([
+        {
+          id: "1",
+          body: "Old Message in Thread 1",
+          date: 391000,
+          read: true,
+          type: "SMS",
+          address: [{ address: "+91898402777" }],
+          status: "RECEIVED",
+          deliveryStatus: "NONE",
+        },
+        {
+          id: "2",
+          body: "Message in Thread 2",
+          date: 392000,
+          read: true,
+          type: "SMS",
+          address: [{ address: "+91898402777" }],
+          status: "RECEIVED",
+          deliveryStatus: "NONE",
+        },
+        {
+          id: "3",
+          body: "Latest in Thread 2",
+          date: 393000,
+          read: false,
+          type: "SMS",
+          address: [{ address: "+91898405555" }],
+          status: "RECEIVED",
+          deliveryStatus: "NONE",
+        },
+      ])
+    })
+
+    test("should ignore DRAFT messages and set read flag as true for latest message when thread unread is false", () => {
+      const mockOptions: PureToUnifiedMessageOptions = {
+        threads: {
+          "1": {
+            contactId: "4",
+            contactName: "Skywalker Luke",
+            id: "1",
+            lastUpdatedAt: new Date("1970-01-01T00:06:34.000Z"), // Czas ostatniej wiadomości jako `DRAFT`
+            messageSnippet: "Draft Message",
+            messageType: MessageType.OUTBOX,
+            phoneNumber: "+91898402777",
+            unread: false,
+          },
+        },
+        messages: {
+          "1": {
+            content: "Old Message #1",
+            date: new Date("1970-01-01T00:06:31.000Z"),
+            id: "1",
+            messageType: MessageType.OUTBOX,
+            phoneNumber: "+91898402777",
+            threadId: "1",
+          },
+          "2": {
+            content: "Another OUTBOX Message",
+            date: new Date("1970-01-01T00:06:32.000Z"),
+            id: "2",
+            messageType: MessageType.OUTBOX,
+            phoneNumber: "+91898402777",
+            threadId: "1",
+          },
+          "3": {
+            content: "Draft Message",
+            date: new Date("1970-01-01T00:06:34.000Z"),
+            id: "3",
+            messageType: MessageType.DRAFT,
+            phoneNumber: "+91898402777",
+            threadId: "1",
+          },
+        },
+      }
+      const unifiedMessages = pureToUnifiedMessage(mockOptions)
+      expect(unifiedMessages).toEqual([
+        {
+          id: "1",
+          body: "Old Message #1",
+          date: 391000,
+          read: true,
+          type: "SMS",
+          address: [{ address: "+91898402777" }],
+          status: "RECEIVED",
+          deliveryStatus: "NONE",
+        },
+        {
+          id: "2",
+          body: "Another OUTBOX Message",
+          date: 392000,
+          read: true,
+          type: "SMS",
+          address: [{ address: "+91898402777" }],
+          status: "RECEIVED",
+          deliveryStatus: "NONE",
+        },
+      ])
+    })
+
+    // If the last message is `DRAFT` and `thread.unread` is `true`, we ignore the `DRAFT` and mark the previous message as `read: true`.
+    test("should ignore the last DRAFT message and mark the latest message as read to true when thread unread is true", () => {
+      const mockOptions: PureToUnifiedMessageOptions = {
+        threads: {
+          "1": {
+            contactId: "4",
+            contactName: "Skywalker Luke",
+            id: "1",
+            lastUpdatedAt: new Date("1970-01-01T00:06:34.000Z"),
+            messageSnippet: "Draft Message",
+            messageType: MessageType.OUTBOX,
+            phoneNumber: "+91898402777",
+            unread: true,
+          },
+        },
+        messages: {
+          "1": {
+            content: "Old Message #1",
+            date: new Date("1970-01-01T00:06:31.000Z"),
+            id: "1",
+            messageType: MessageType.OUTBOX,
+            phoneNumber: "+91898402777",
+            threadId: "1",
+          },
+          "2": {
+            content: "Another OUTBOX Message",
+            date: new Date("1970-01-01T00:06:32.000Z"),
+            id: "2",
+            messageType: MessageType.OUTBOX,
+            phoneNumber: "+91898402777",
+            threadId: "1",
+          },
+          "3": {
+            content: "Draft Message",
+            date: new Date("1970-01-01T00:06:34.000Z"),
+            id: "3",
+            messageType: MessageType.DRAFT,
+            phoneNumber: "+91898402777",
+            threadId: "1",
+          },
+        },
+      }
+      const unifiedMessages = pureToUnifiedMessage(mockOptions)
+      expect(unifiedMessages).toEqual([
+        {
+          id: "1",
+          body: "Old Message #1",
+          date: 391000,
+          read: true,
+          type: "SMS",
+          address: [{ address: "+91898402777" }],
+          status: "RECEIVED",
+          deliveryStatus: "NONE",
+        },
+        {
+          id: "2",
+          body: "Another OUTBOX Message",
+          date: 392000,
+          read: true,
+          type: "SMS",
+          address: [{ address: "+91898402777" }],
+          status: "RECEIVED",
+          deliveryStatus: "NONE",
+        },
+      ])
+    })
+  })
+
+  describe("`pureToUnifiedMessage` - Handling Incomplete or Empty Data", () => {
+    test("should handle undefined contactId and contactName in Thread", () => {
+      const mockOptions: PureToUnifiedMessageOptions = {
+        threads: {
+          "1": {
+            contactId: undefined,
+            contactName: undefined,
+            id: "1",
+            lastUpdatedAt: new Date("1970-01-01T00:06:31.000Z"),
+            messageSnippet: "Test Message",
+            messageType: MessageType.INBOX,
+            phoneNumber: "+91898402777",
+            unread: true,
+          },
+        },
+        messages: {
+          "1": {
+            content: "Test Message #1",
+            date: new Date("1970-01-01T00:06:31.000Z"),
+            id: "1",
+            messageType: MessageType.INBOX,
+            phoneNumber: "+91898402777",
+            threadId: "1",
+          },
+        },
+      }
+      const unifiedMessages = pureToUnifiedMessage(mockOptions)
+      expect(unifiedMessages).toEqual([
+        {
+          id: "1",
+          body: "Test Message #1",
+          date: 391000,
+          read: false,
+          type: "SMS",
+          address: [{ address: "+91898402777" }],
+          status: "SENT",
+          deliveryStatus: "DELIVERED",
+        },
+      ])
+    })
+
+    test("should handle empty phoneNumber in Thread and Message", () => {
+      const mockOptions: PureToUnifiedMessageOptions = {
+        threads: {
+          "1": {
+            contactId: "4",
+            contactName: "Luke Skywalker",
+            id: "1",
+            lastUpdatedAt: new Date("1970-01-01T00:06:31.000Z"),
+            messageSnippet: "Test Message",
+            messageType: MessageType.INBOX,
+            phoneNumber: "",
+            unread: true,
+          },
+        },
+        messages: {
+          "1": {
+            content: "Test Message #1",
+            date: new Date("1970-01-01T00:06:31.000Z"),
+            id: "1",
+            messageType: MessageType.INBOX,
+            phoneNumber: "",
+            threadId: "1",
+          },
+        },
+      }
+      const unifiedMessages = pureToUnifiedMessage(mockOptions)
+      expect(unifiedMessages).toEqual([
+        {
+          id: "1",
+          body: "Test Message #1",
+          date: 391000,
+          read: false,
+          type: "SMS",
+          address: [{ address: "" }], // Pusty adres
+          status: "SENT",
+          deliveryStatus: "DELIVERED",
+        },
+      ])
+    })
+
+    test("should handle undefined content in Message", () => {
+      const mockOptions: PureToUnifiedMessageOptions = {
+        threads: {
+          "1": {
+            contactId: "4",
+            contactName: "Luke Skywalker",
+            id: "1",
+            lastUpdatedAt: new Date("1970-01-01T00:06:31.000Z"),
+            messageSnippet: "Test Message",
+            messageType: MessageType.INBOX,
+            phoneNumber: "+91898402777",
+            unread: true,
+          },
+        },
+        messages: {
+          "1": {
+            content: "",
+            date: new Date("1970-01-01T00:06:31.000Z"),
+            id: "1",
+            messageType: MessageType.INBOX,
+            phoneNumber: "+91898402777",
+            threadId: "1",
+          },
+        },
+      }
+      const unifiedMessages = pureToUnifiedMessage(mockOptions)
+      expect(unifiedMessages).toEqual([
+        {
+          id: "1",
+          body: "",
+          date: 391000,
+          read: false,
+          type: "SMS",
+          address: [{ address: "+91898402777" }],
+          status: "SENT",
+          deliveryStatus: "DELIVERED",
+        },
+      ])
+    })
+
+    test("should handle minimal date for date in Message", () => {
+      const mockOptions: PureToUnifiedMessageOptions = {
+        threads: {
+          "1": {
+            contactId: "4",
+            contactName: "Luke Skywalker",
+            id: "1",
+            lastUpdatedAt: new Date(0),
+            messageSnippet: "Test Message",
+            messageType: MessageType.INBOX,
+            phoneNumber: "+91898402777",
+            unread: true,
+          },
+        },
+        messages: {
+          "1": {
+            content: "Test Message #1",
+            date: new Date(0),
+            id: "1",
+            messageType: MessageType.INBOX,
+            phoneNumber: "+91898402777",
+            threadId: "1",
+          },
+        },
+      }
+      const unifiedMessages = pureToUnifiedMessage(mockOptions)
+      expect(unifiedMessages).toEqual([
+        {
+          id: "1",
+          body: "Test Message #1",
+          date: 0,
+          read: false,
+          type: "SMS",
+          address: [{ address: "+91898402777" }],
+          status: "SENT",
+          deliveryStatus: "DELIVERED",
+        },
+      ])
+    })
+  })
+})

--- a/libs/generic-view/store/src/lib/data-migration/data-migration-mappers/pure-to-unified-message.ts
+++ b/libs/generic-view/store/src/lib/data-migration/data-migration-mappers/pure-to-unified-message.ts
@@ -21,10 +21,11 @@ export const pureToUnifiedMessage = ({
   threads,
 }: PureToUnifiedMessageOptions): UnifiedMessage[] => {
   return Object.values(messages)
-    .filter((message) => message.messageType !== MessageType.DRAFT)
+    .filter((message) =>
+      message.messageType !== MessageType.DRAFT && threads[message.threadId]
+    )
     .map((message) => {
       const thread = threads[message.threadId]
-      if (!thread) return null
 
       let status: UnifiedMessageStatus
       let deliveryStatus: UnifiedMessageDeliveryStatus
@@ -70,5 +71,4 @@ export const pureToUnifiedMessage = ({
         deliveryStatus,
       }
     })
-    .filter((message): message is UnifiedMessage => message !== null)
 }

--- a/libs/generic-view/store/src/lib/data-migration/data-migration-mappers/pure-to-unified-message.ts
+++ b/libs/generic-view/store/src/lib/data-migration/data-migration-mappers/pure-to-unified-message.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Mudita sp. z o.o. All rights reserved.
+ * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
+ */
+
+import { UnifiedMessage } from "device/models"
+import { MessageObject, ThreadObject } from "Core/data-sync/types"
+
+export interface PureToUnifiedMessageOptions {
+  threads: Record<string, ThreadObject>
+  messages: Record<string, MessageObject>
+}
+
+export const pureToUnifiedMessage = ({
+  messages,
+  threads,
+}: PureToUnifiedMessageOptions): UnifiedMessage[] => {
+  // TODO
+}

--- a/libs/generic-view/store/src/lib/data-migration/transfer-migration-data.ts
+++ b/libs/generic-view/store/src/lib/data-migration/transfer-migration-data.ts
@@ -25,6 +25,7 @@ import { delay } from "shared/utils"
 import { removeDirectory } from "system-utils/feature"
 import { DataMigrationStatus } from "./reducer"
 import { clearMigrationData } from "./clear-migration-data"
+import { pureToUnifiedMessage } from "./data-migration-mappers/pure-to-unified-message"
 
 export const transferMigrationData = createAsyncThunk<
   void,
@@ -106,6 +107,19 @@ export const transferMigrationData = createAsyncThunk<
             if (!isEmpty(transformedData)) {
               domainsData.push({
                 domain: "callLog-v1", // FIXME: The domain should be returned from Data Migration configuration
+                data: transformedData,
+              })
+            }
+            break
+          }
+          case DataMigrationFeature.Messages: {
+            const transformedData = pureToUnifiedMessage(
+              databaseResponse.payload as AllIndexes
+            )
+
+            if (!isEmpty(transformedData)) {
+              domainsData.push({
+                domain: "messages-v1", // FIXME: The domain should be returned from Data Migration configuration
                 data: transformedData,
               })
             }

--- a/libs/generic-view/store/src/lib/data-migration/transfer-migration-data.ts
+++ b/libs/generic-view/store/src/lib/data-migration/transfer-migration-data.ts
@@ -14,7 +14,7 @@ import {
 import { readAllIndexes } from "Core/data-sync/actions"
 import { isEmpty } from "lodash"
 import { AllIndexes } from "Core/data-sync/types"
-import { mapPureApi } from "../imports/contacts-mappers/pure/map-pure-api"
+import { pureToUnifiedContact } from "./data-migration-mappers/pure-to-unified-contact"
 import {
   DomainData,
   transferDataToDevice,
@@ -90,7 +90,7 @@ export const transferMigrationData = createAsyncThunk<
         switch (feature) {
           case DataMigrationFeature.Contacts: {
             const { contacts } = databaseResponse.payload as AllIndexes
-            const transformedData = mapPureApi(Object.values(contacts))
+            const transformedData = pureToUnifiedContact(Object.values(contacts))
 
             if (!isEmpty(transformedData)) {
               domainsData.push({

--- a/libs/generic-view/store/src/lib/data-transfer/transfer-data-to-device.action.ts
+++ b/libs/generic-view/store/src/lib/data-transfer/transfer-data-to-device.action.ts
@@ -11,6 +11,7 @@ import {
   DataTransferDomain,
   UnifiedCallLog,
   UnifiedContact,
+  UnifiedMessage,
 } from "device/models"
 import {
   cancelDataTransferRequest,
@@ -34,6 +35,7 @@ import { selectActiveApiDeviceId } from "../selectors/select-active-api-device-i
 type DomainDataMapping = {
   "contacts-v1": UnifiedContact[]
   "callLog-v1": UnifiedCallLog[]
+  "messages-v1": UnifiedMessage[]
 }
 
 export type DomainData = {


### PR DESCRIPTION
JIRA Reference: [CP-3211]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-3211]: https://appnroll.atlassian.net/browse/CP-3211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ