### PR TITLE
[CP-3277] Disable Code Signing for Applications on Non-Production Environments in Windows - vol.2

### DIFF
--- a/.github/workflows/nexus-mock-pre-production.yml
+++ b/.github/workflows/nexus-mock-pre-production.yml
@@ -125,6 +125,24 @@ jobs:
         if: matrix.os == 'macOS'
         run: |
           codesign -v -v apps/mudita-center/release/mac/Mudita\ Center.app
+      - name: Signing via Digicert
+        if: matrix.os == 'Windows'
+        env:
+          SM_HOST: ${{ secrets.SM_HOST }}
+          SM_API_KEY: ${{ secrets.SM_API_KEY }}
+          SM_CLIENT_CERT_FILE: "C:\\actions-runner\\certs\\Certificate_pkcs12.p12"
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+          SM_CODE_SIGNING_CERT_SHA1_HASH: ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}
+        run: |
+          SET SM_HOST=%SM_HOST%
+          SET SM_API_KEY=%SM_API_KEY%
+          SET SM_CLIENT_CERT_FILE=%SM_CLIENT_CERT_FILE%
+          SET SM_CLIENT_CERT_PASSWORD=%SM_CLIENT_CERT_PASSWORD%
+          SET SM_CODE_SIGNING_CERT_SHA1_HASH=%SM_CODE_SIGNING_CERT_SHA1_HASH%
+          SET PATH=%PATH%;"C:\Program Files\DigiCert\DigiCert One Signing Manager Tools"
+          SET PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
+          signtool.exe sign /sha1 %SM_CODE_SIGNING_CERT_SHA1_HASH% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/mudita-center/release/Mudita-Center.exe
+        shell: cmd
       - name: Push artifacts to nexus registry from Windows
         if: matrix.os == 'Windows'
         env:

--- a/.github/workflows/nexus-pre-production-latest.yml
+++ b/.github/workflows/nexus-pre-production-latest.yml
@@ -176,6 +176,24 @@ jobs:
         if: matrix.os == 'macOS'
         run: |
           codesign -v -v apps/mudita-center/release/mac/Mudita\ Center.app
+      - name: Signing via Digicert
+        if: matrix.os == 'Windows'
+        env:
+          SM_HOST: ${{ secrets.SM_HOST }}
+          SM_API_KEY: ${{ secrets.SM_API_KEY }}
+          SM_CLIENT_CERT_FILE: "C:\\actions-runner\\certs\\Certificate_pkcs12.p12"
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+          SM_CODE_SIGNING_CERT_SHA1_HASH: ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}
+        run: |
+          SET SM_HOST=%SM_HOST%
+          SET SM_API_KEY=%SM_API_KEY%
+          SET SM_CLIENT_CERT_FILE=%SM_CLIENT_CERT_FILE%
+          SET SM_CLIENT_CERT_PASSWORD=%SM_CLIENT_CERT_PASSWORD%
+          SET SM_CODE_SIGNING_CERT_SHA1_HASH=%SM_CODE_SIGNING_CERT_SHA1_HASH%
+          SET PATH=%PATH%;"C:\Program Files\DigiCert\DigiCert One Signing Manager Tools"
+          SET PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
+          signtool.exe sign /sha1 %SM_CODE_SIGNING_CERT_SHA1_HASH% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/mudita-center/release/Mudita-Center.exe
+        shell: cmd
       - name: Push artifacts to nexus registry from Windows
         if: matrix.os == 'Windows'
         env:

--- a/.github/workflows/nexus-pre-production.yml
+++ b/.github/workflows/nexus-pre-production.yml
@@ -101,6 +101,24 @@ jobs:
         if: matrix.os == 'macOS'
         run: |
           codesign -v -v apps/mudita-center/release/mac/Mudita\ Center.app
+      - name: Signing via Digicert
+        if: matrix.os == 'Windows'
+        env:
+          SM_HOST: ${{ secrets.SM_HOST }}
+          SM_API_KEY: ${{ secrets.SM_API_KEY }}
+          SM_CLIENT_CERT_FILE: "C:\\actions-runner\\certs\\Certificate_pkcs12.p12"
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+          SM_CODE_SIGNING_CERT_SHA1_HASH: ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}
+        run: |
+          SET SM_HOST=%SM_HOST%
+          SET SM_API_KEY=%SM_API_KEY%
+          SET SM_CLIENT_CERT_FILE=%SM_CLIENT_CERT_FILE%
+          SET SM_CLIENT_CERT_PASSWORD=%SM_CLIENT_CERT_PASSWORD%
+          SET SM_CODE_SIGNING_CERT_SHA1_HASH=%SM_CODE_SIGNING_CERT_SHA1_HASH%
+          SET PATH=%PATH%;"C:\Program Files\DigiCert\DigiCert One Signing Manager Tools"
+          SET PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
+          signtool.exe sign /sha1 %SM_CODE_SIGNING_CERT_SHA1_HASH% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/mudita-center/release/Mudita-Center.exe
+        shell: cmd
       - name: Push artifacts to nexus registry from Windows
         if: matrix.os == 'Windows'
         env:


### PR DESCRIPTION
JIRA Reference: [CP-3277]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-3277]: https://appnroll.atlassian.net/browse/CP-3277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ