### PR TITLE
[CP-3297] When user cancel adding sounds to Harmony, the uploading failed modal is displayed

### DIFF
--- a/libs/core/files-manager/actions/upload-file.action.ts
+++ b/libs/core/files-manager/actions/upload-file.action.ts
@@ -58,7 +58,7 @@ export const uploadFile = createAsyncThunk<
 
     if (!openFileResult.ok || !openFileResult.data) {
       dispatch(setUploadBlocked(false))
-      return rejectWithValue("no files to upload")
+      return
     }
 
     const filePaths = openFileResult.data


### PR DESCRIPTION
JIRA Reference: [CP-3297]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated
