### PR TITLE
[CP-3372] Create selectors based on existing data-testid attributes for contacts preview

### DIFF
--- a/apps/mudita-center-e2e/src/page-objects/contacts-kompakt.ts
+++ b/apps/mudita-center-e2e/src/page-objects/contacts-kompakt.ts
@@ -36,5 +36,25 @@ class ContactsKompaktPage extends Page {
   public get allContactsTableRows() {
     return $$('//*[@data-testid="ui-table-row"]')
   }
+
+  public get checkboxByRowIndex() {
+    return (rowIndex: number) => $(`(//*[@data-testid="ui-table-row"])[${rowIndex + 1}]//td[1]//input[@type="checkbox"]`);
+  }
+
+  public get displayNameByRowIndex() {
+    return (rowIndex: number) => $(`(//*[@data-testid="ui-table-row"])[${rowIndex + 1}]//td[2]//p[@data-testid="ui-typography-p1"]`);
+  }
+
+  public get emptyCellByRowIndex() {
+    return (rowIndex: number) => $(`(//*[@data-testid="ui-table-row"])[${rowIndex + 1}]//td[3]`);
+  }
+
+  public get phoneNumberByRowIndex() {
+    return (rowIndex: number) => $(`(//*[@data-testid="ui-table-row"])[${rowIndex + 1}]//td[4]`);
+  }
+
+  public get phoneNumberCounterByRowIndex() {
+    return (rowIndex: number) => $(`(//*[@data-testid="ui-table-row"])[${rowIndex + 1}]//td[5]`);
+  }
 }
 export default new ContactsKompaktPage()

--- a/apps/mudita-center-e2e/src/specs/overview/kompakt-contacts-viewing.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/kompakt-contacts-viewing.ts
@@ -59,9 +59,54 @@ describe("E2E mock sample - overview view", () => {
     const importContactsButton = ContactsKompaktPage.importContactsButton
     await expect(importContactsButton).toBeDisplayed()
     await expect(importContactsButton).toBeClickable()
+
   })
 
-  xit("Verify different contacts", async () => {})
+  it("Verify different contacts", async () => {
+
+    // first row -> Long Display Name...
+    const checkbox = await ContactsKompaktPage.checkboxByRowIndex(0);
+    const isChecked = await checkbox.isSelected();
+    console.log(`Checkbox is selected: ${isChecked}`);
+    expect(isChecked).toBe(false);
+
+    const displayName = await ContactsKompaktPage.displayNameByRowIndex(0);
+    const displayNameText = await displayName.getText();
+    console.log(`Display Name: ${displayNameText}`);
+    expect(displayNameText).toBe('Long Display Name (last name is long) Anna Maria Katarzyna Nowak-Wielka-Zabłocka-Długosz-Ostrowska-Mickiewicz-Piękna-Sobieska-Kowalewska-Jagiellońska-Słowacka-Krzyżanowska-Kordecka-Kościuszkowska');
+
+    const lastCell = await ContactsKompaktPage.emptyCellByRowIndex(0);
+    const lastCellText = await lastCell.getText();
+    console.log(`Empty Cell Content: ${lastCellText}`);
+    expect(lastCellText).toBe('');
+
+    const phoneNumber = await ContactsKompaktPage.phoneNumberByRowIndex(0);
+    const phoneNumberText = await phoneNumber.getText();
+    console.log(`Phone Number: ${phoneNumberText}`);
+    expect(phoneNumberText).toBe('+48123456786');
+
+    const phoneNumberCounter = await ContactsKompaktPage.phoneNumberCounterByRowIndex(0);
+    const phoneNumberCounterText = await phoneNumberCounter.getText();
+    console.log(`Phone Number Counter: ${phoneNumberCounterText}`);
+    expect(phoneNumberCounterText).toBe('');
+
+
+    // Dr. Michael Johnson PhD
+    const displayName5 = await ContactsKompaktPage.displayNameByRowIndex(5);
+    const displayNameText5 = await displayName5.getText();
+    console.log(`Display Name: ${displayNameText5}`);
+
+    // prefix
+    expect(displayNameText5).toContain('Dr.');
+
+    // suffix
+    expect(displayNameText5).toContain('PhD');
+
+    const phoneNumberCounter5 = await ContactsKompaktPage.phoneNumberCounterByRowIndex(5);
+    const phoneNumberCounterText5 = await phoneNumberCounter5.getText();
+    console.log(`Phone Number Counter: ${phoneNumberCounterText5}`);
+    expect(phoneNumberCounterText5).toBe('+1');
+  })
 
   it("Verify contacts array", async () => {
     //scroll down

--- a/apps/mudita-center-e2e/src/specs/overview/kompakt-contacts-viewing.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/kompakt-contacts-viewing.ts
@@ -2,6 +2,8 @@ import { E2EMockClient } from "../../../../../libs/e2e-mock/client/src"
 import tabsPage from "../../page-objects/tabs.page"
 import ContactsKompaktPage from "../../page-objects/contacts-kompakt"
 import exp from "constants"
+import { mockEntityDownloadProcess } from "../../helpers"
+import { selectedContactsEntities } from "../../helpers/entity-fixtures"
 
 describe("E2E mock sample - overview view", () => {
   before(async () => {
@@ -23,6 +25,13 @@ describe("E2E mock sample - overview view", () => {
       serialNumber: "first-serial-number",
     })
 
+    // mock contacts function for testing/modification purposes
+    mockEntityDownloadProcess({
+      path: "path-1",
+      data: selectedContactsEntities,
+      entityType: "contacts",
+    })
+
     await browser.pause(6000)
     const menuItem = await $(`//a[@href="#/generic/mc-overview"]`)
 
@@ -31,18 +40,12 @@ describe("E2E mock sample - overview view", () => {
   })
 
   it("Click Contacts tab and check contacts counter", async () => {
-    // mock contacts function for testing/modification purposes
-    // mockEntityDownloadProcess({
-    //   path: "path-1",
-    //   data: selectedContactsEntities,
-    //   entityType: "contacts",
-    // })
     const contactsKompaktTab = tabsPage.contactsKompaktTab
     await contactsKompaktTab.click()
 
     const contactsCounter = ContactsKompaktPage.contactsCounter
     await expect(contactsCounter).toBeDisplayed()
-    await expect(contactsCounter).toHaveText("Contacts (1)")
+    await expect(contactsCounter).toHaveText("Contacts (17)")
   })
 
   it("Verify Page elements ", async () => {


### PR DESCRIPTION
JIRA Reference: [CP-3372]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-3372]: https://appnroll.atlassian.net/browse/CP-3372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ