### PR TITLE
API configuration testing - test case to check if the response data i…

### DIFF
--- a/libs/api-devices-testing/src/lib/api-configuration.spec.tsx
+++ b/libs/api-devices-testing/src/lib/api-configuration.spec.tsx
@@ -6,6 +6,11 @@
 import { DeviceProtocol } from "device-protocol/feature"
 import { setKompaktConnection } from "./helpers/set-connection"
 import { APIConfigService } from "device/feature"
+import {
+  ApiConfig,
+  GeneralError
+} from "device/models"
+import exp from "constants"
 
 jest.mock("shared/utils", () => {
   return { callRenderer: () => {} }
@@ -32,7 +37,7 @@ describe("API configuration", () => {
     await deviceProtocol?.activeDevice?.disconnect()
   }, 10000)
 
-  it("should receive API configuration", async () => {
+  it("should receive API configuration success on default device id", async () => {
     expect(deviceProtocol?.devices).toHaveLength(1)
 
     if (deviceProtocol === undefined) {
@@ -47,4 +52,48 @@ describe("API configuration", () => {
 
     expect(result.ok).toBeTruthy()
   })
+
+  it("should receive API configuration error on invalid deviceId", async () => {
+    expect(deviceProtocol?.devices).toHaveLength(1)
+
+    if (deviceProtocol === undefined) {
+      return
+    }
+
+    deviceProtocol.setActiveDevice(deviceProtocol.devices[0].id)
+
+    const apiConfigService = new APIConfigService(deviceProtocol)
+
+    const result = await apiConfigService.getAPIConfig("dummyID")
+    expect(result.ok).toBeFalsy()
+    expect(result.error?.type).toBe(GeneralError.NoDevice)
+  })
+  
+  it("should receive valid API configuration response", async () => {
+    expect(deviceProtocol?.devices).toHaveLength(1)
+
+    if (deviceProtocol === undefined) {
+      return
+    }
+
+    deviceProtocol.setActiveDevice(deviceProtocol.devices[0].id)
+
+    const apiConfigService = new APIConfigService(deviceProtocol)
+
+    const result = await apiConfigService.getAPIConfig()
+    const apiConfig = result.data as ApiConfig
+
+    expect(apiConfig.apiVersion).toMatch(/^\d+\.\d+\.\d+$/)
+    expect(apiConfig.osVersion).toMatch(/^MuditaOS K/)
+    expect(apiConfig.lang).toMatch(/^[a-z]{2}-[A-Z]{2}$/)
+    expect(apiConfig.variant?.length).toBeGreaterThan(0)
+    expect(apiConfig.features.sort()).toEqual(["mc-overview","contacts","mc-data-migration","fileManager"].sort())
+    expect(apiConfig.entityTypes?.sort()).toEqual(["contacts","audioFiles","imageFiles","ebookFiles"].sort())
+    expect(apiConfig.productId).toEqual("2006")
+    expect(apiConfig.vendorId).toEqual("0e8d")
+    expect(apiConfig.serialNumber).toMatch(/^[A-Z0-9]{13}$/)
+    expect(apiConfig.otaApiConfig?.otaApiKey.length).toEqual(15)
+    expect(apiConfig.otaApiConfig?.osVersionTimestamp.toString().length).toEqual(10)
+  })
+
 })

--- a/libs/api-devices-testing/src/lib/api-configuration.spec.tsx
+++ b/libs/api-devices-testing/src/lib/api-configuration.spec.tsx
@@ -10,7 +10,6 @@ import {
   ApiConfig,
   GeneralError
 } from "device/models"
-import exp from "constants"
 
 jest.mock("shared/utils", () => {
   return { callRenderer: () => {} }

--- a/libs/api-devices-testing/src/lib/api-configuration.spec.tsx
+++ b/libs/api-devices-testing/src/lib/api-configuration.spec.tsx
@@ -27,6 +27,9 @@ jest.mock("electron-better-ipc", () => {
 
 describe("API configuration", () => {
   let deviceProtocol: DeviceProtocol | undefined = undefined
+  const testFeatures = ["mc-overview","contacts","mc-data-migration","fileManager"].sort()
+  const testEntityTypes = ["contacts","audioFiles","imageFiles","ebookFiles"].sort()
+  const productId = 
 
   beforeEach(async () => {
     deviceProtocol = await setKompaktConnection()
@@ -86,8 +89,8 @@ describe("API configuration", () => {
     expect(apiConfig.osVersion).toMatch(/^MuditaOS K/)
     expect(apiConfig.lang).toMatch(/^[a-z]{2}-[A-Z]{2}$/)
     expect(apiConfig.variant?.length).toBeGreaterThan(0)
-    expect(apiConfig.features.sort()).toEqual(["mc-overview","contacts","mc-data-migration","fileManager"].sort())
-    expect(apiConfig.entityTypes?.sort()).toEqual(["contacts","audioFiles","imageFiles","ebookFiles"].sort())
+    expect(apiConfig.features.sort()).toEqual(testFeatures)
+    expect(apiConfig.entityTypes?.sort()).toEqual(testEntityTypes)
     expect(apiConfig.productId).toEqual("2006")
     expect(apiConfig.vendorId).toEqual("0e8d")
     expect(apiConfig.serialNumber).toMatch(/^[A-Z0-9]{13}$/)

--- a/libs/api-devices-testing/src/lib/connection.spec.tsx
+++ b/libs/api-devices-testing/src/lib/connection.spec.tsx
@@ -31,7 +31,7 @@ describe("Connection", () => {
       expect(deviceProtocol.devices).toHaveLength(0)
       const attachedDevice = (await deviceProtocol.getAttachedDevices()).find(
         (port) => {
-          return port.vendorId === vendorId && port.productId === productId
+          return port.vendorId?.toLowerCase() === vendorId.toLowerCase() && port.productId?.toLowerCase() === productId.toLowerCase()
         }
       )
 

--- a/libs/api-devices-testing/src/lib/helpers/set-connection.ts
+++ b/libs/api-devices-testing/src/lib/helpers/set-connection.ts
@@ -20,7 +20,7 @@ export const setConnection = async (vendorId: string, productId: string) => {
   )
   const attachedDevice = (await deviceProtocol.getAttachedDevices()).find(
     (port) => {
-      return port.vendorId === vendorId && port.productId === productId
+      return port.vendorId?.toLowerCase() === vendorId.toLowerCase() && port.productId?.toLowerCase() === productId.toLowerCase()
     }
   )
 


### PR DESCRIPTION
JIRA Reference: [CP-3421]

### :memo: Description ️

- API configuration testing - test case to check if the response data is valid, 
- Fixed a bug where Mudita Center couldn't connect to the Kompakt in API testing



### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-3421]: https://appnroll.atlassian.net/browse/CP-3421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ