### PR TITLE
[CP-2976] Extension of the mocking mechanism from per item to per list to avoid race conditions.

### DIFF
--- a/apps/mudita-center-e2e/src/helpers/mock-entity-delete-process.ts
+++ b/apps/mudita-center-e2e/src/helpers/mock-entity-delete-process.ts
@@ -11,25 +11,29 @@ interface mockEntityDeleteProcessOptions {
   entityType: string
 }
 
-export const mockEntityDeleteProcess = ({ totalEntities, entityType }: mockEntityDeleteProcessOptions) => {
-  E2EMockClient.mockResponseOnce({
-    path: "path-1",
-    body: { totalEntities, uniqueKey: `${uuid()}` },
-    match: {
-      expected: {
-        entityType: entityType,
+export const mockEntityDeleteProcess = ({
+  totalEntities,
+  entityType,
+}: mockEntityDeleteProcessOptions) => {
+  E2EMockClient.mockResponsesOnce([
+    {
+      path: "path-1",
+      body: { totalEntities, uniqueKey: `${uuid()}` },
+      match: {
+        expected: {
+          entityType: entityType,
+        },
       },
+      endpoint: "ENTITIES_METADATA",
+      method: "GET",
+      status: 200,
     },
-    endpoint: "ENTITIES_METADATA",
-    method: "GET",
-    status: 200,
-  })
-
-  E2EMockClient.mockResponseOnce({
-    path: "path-1",
-    endpoint: "ENTITIES_DATA",
-    method: "DELETE",
-    status: 200,
-    body: {}
-  })
+    {
+      path: "path-1",
+      endpoint: "ENTITIES_DATA",
+      method: "DELETE",
+      status: 200,
+      body: {},
+    },
+  ])
 }

--- a/apps/mudita-center-e2e/src/helpers/mock-entity-download-process.helper.ts
+++ b/apps/mudita-center-e2e/src/helpers/mock-entity-download-process.helper.ts
@@ -22,69 +22,68 @@ export const mockEntityDownloadProcess = ({
   const totalEntities = data.length
   const transferId = generateUniqueNumber()
 
-  E2EMockClient.mockResponse({
-    path,
-    body: { totalEntities, uniqueKey: "1733750368390" },
-    match: {
-      expected: {
-        entityType: entityType,
+  E2EMockClient.mockResponses([
+    {
+      path,
+      body: { totalEntities, uniqueKey: "1733750368390" },
+      match: {
+        expected: {
+          entityType: entityType,
+        },
       },
+      endpoint: "ENTITIES_METADATA",
+      method: "GET",
+      status: 200,
     },
-    endpoint: "ENTITIES_METADATA",
-    method: "GET",
-    status: 200,
-  })
-
-  E2EMockClient.mockResponse({
-    path,
-    body: {
-      filePath: `../${entityType}_entities.json`,
-      progress: 100,
-    },
-    match: {
-      expected: {
-        entityType: entityType,
-        responseType: "file",
-      },
-    },
-    endpoint: "ENTITIES_DATA",
-    method: "GET",
-    status: 200,
-  })
-
-  E2EMockClient.mockResponse({
-    path,
-    body: {
-      transferId,
-      chunkSize: sizeInBytes,
-      fileSize: sizeInBytes,
-      crc32: crc32Hex,
-    },
-    match: {
-      expected: {
+    {
+      path,
+      body: {
         filePath: `../${entityType}_entities.json`,
+        progress: 100,
       },
+      match: {
+        expected: {
+          entityType: entityType,
+          responseType: "file",
+        },
+      },
+      endpoint: "ENTITIES_DATA",
+      method: "GET",
+      status: 200,
     },
-    endpoint: "PRE_FILE_TRANSFER",
-    method: "GET",
-    status: 200,
-  })
-
-  E2EMockClient.mockResponse({
-    path,
-    body: {
-      transferId,
-      chunkNumber: 1,
-      data: base64,
+    {
+      path,
+      body: {
+        transferId,
+        chunkSize: sizeInBytes,
+        fileSize: sizeInBytes,
+        crc32: crc32Hex,
+      },
+      match: {
+        expected: {
+          filePath: `../${entityType}_entities.json`,
+        },
+      },
+      endpoint: "PRE_FILE_TRANSFER",
+      method: "GET",
+      status: 200,
     },
-    match: {
-      expected: {
+    {
+      path,
+      body: {
         transferId,
         chunkNumber: 1,
+        data: base64,
       },
+      match: {
+        expected: {
+          transferId,
+          chunkNumber: 1,
+        },
+      },
+      endpoint: "FILE_TRANSFER",
+      method: "GET",
+      status: 200,
     },
-    endpoint: "FILE_TRANSFER",
-    method: "GET",
-    status: 200,
-  })
+  ])
 }

--- a/apps/mudita-center-e2e/src/helpers/mock-prebackup.ts
+++ b/apps/mudita-center-e2e/src/helpers/mock-prebackup.ts
@@ -3,13 +3,15 @@ import { E2EMockClient } from "../../../../libs/e2e-mock/client/src"
 // Helper function to mock PRE_BACKUP responses
 export function mockPreBackupResponses(path: string) {
   // Mock initial PRE_BACKUP response with status 202 (processing)
-  E2EMockClient.mockResponse({
-    path,
-    endpoint: "PRE_BACKUP",
-    method: "POST",
-    status: 202,
-    body: {},
-  })
+  E2EMockClient.mockResponses([
+    {
+      path,
+      endpoint: "PRE_BACKUP",
+      method: "POST",
+      status: 202,
+      body: {},
+    },
+  ])
 
   // After 10 seconds, update the response to status 200 (completed)
   //   setTimeout(() => {

--- a/apps/mudita-center-e2e/src/specs/overview/e2e-mock-lock-sample.e2e.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/e2e-mock-lock-sample.e2e.ts
@@ -25,35 +25,36 @@ describe("E2E mock lock sample", () => {
   })
 
   it.only("Connect locked device", async () => {
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: {},
-      endpoint: "FEATURE_DATA",
-      method: "GET",
-      status: 423,
-    })
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: {},
-      endpoint: "FEATURE_CONFIGURATION",
-      method: "GET",
-      status: 423,
-    })
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: {},
-      endpoint: "MENU_CONFIGURATION",
-      method: "GET",
-      status: 423,
-    })
-
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: {},
-      endpoint: "OUTBOX",
-      method: "GET",
-      status: 423,
-    })
+    E2EMockClient.mockResponses([
+      {
+        path: "path-1",
+        body: {},
+        endpoint: "FEATURE_DATA",
+        method: "GET",
+        status: 423,
+      },
+      {
+        path: "path-1",
+        body: {},
+        endpoint: "FEATURE_CONFIGURATION",
+        method: "GET",
+        status: 423,
+      },
+      {
+        path: "path-1",
+        body: {},
+        endpoint: "MENU_CONFIGURATION",
+        method: "GET",
+        status: 423,
+      },
+      {
+        path: "path-1",
+        body: {},
+        endpoint: "OUTBOX",
+        method: "GET",
+        status: 423,
+      },
+    ])
 
     E2EMockClient.addDevice({
       path: "path-1",
@@ -67,145 +68,146 @@ describe("E2E mock lock sample", () => {
     await expect(lockScreen).toBeDisplayed()
     await browser.pause(2000)
 
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: getBodyAsRecord(
-        DEFAULT_RESPONSES.API_CONFIGURATION?.GET?.[0]?.body
-      ),
-      endpoint: "API_CONFIGURATION",
-      method: "GET",
-      status: 200,
-    })
+    E2EMockClient.mockResponses([
+      {
+        path: "path-1",
+        body: getBodyAsRecord(
+          DEFAULT_RESPONSES.API_CONFIGURATION?.GET?.[0]?.body
+        ),
+        endpoint: "API_CONFIGURATION",
+        method: "GET",
+        status: 200,
+      },
+    ])
 
     await browser.pause(2000)
 
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: getBodyAsRecord(DEFAULT_RESPONSES.FEATURE_DATA?.GET?.[0]?.body),
-      match: {
-        expected: {
-          feature: "mc-overview",
-          lang: "en-US",
+    E2EMockClient.mockResponses([
+      {
+        path: "path-1",
+        body: getBodyAsRecord(DEFAULT_RESPONSES.FEATURE_DATA?.GET?.[0]?.body),
+        match: {
+          expected: {
+            feature: "mc-overview",
+            lang: "en-US",
+          },
         },
+        endpoint: "FEATURE_DATA",
+        method: "GET",
+        status: 200,
       },
-      endpoint: "FEATURE_DATA",
-      method: "GET",
-      status: 200,
-    })
-
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: getBodyAsRecord(DEFAULT_RESPONSES.FEATURE_DATA?.GET?.[1]?.body),
-      match: {
-        expected: {
-          feature: "fileManager",
-          lang: "en-US",
+      {
+        path: "path-1",
+        body: getBodyAsRecord(DEFAULT_RESPONSES.FEATURE_DATA?.GET?.[1]?.body),
+        match: {
+          expected: {
+            feature: "fileManager",
+            lang: "en-US",
+          },
         },
+        endpoint: "FEATURE_DATA",
+        method: "GET",
+        status: 200,
       },
-      endpoint: "FEATURE_DATA",
-      method: "GET",
-      status: 200,
-    })
+    ])
 
     await browser.pause(2000)
 
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: getBodyAsRecord(
-        DEFAULT_RESPONSES.FEATURE_CONFIGURATION?.GET?.[0]?.body
-      ),
-      match: {
-        expected: {
-          feature: "contacts",
-          lang: "en-US",
+    E2EMockClient.mockResponses([
+      {
+        path: "path-1",
+        body: getBodyAsRecord(
+          DEFAULT_RESPONSES.FEATURE_CONFIGURATION?.GET?.[0]?.body
+        ),
+        match: {
+          expected: {
+            feature: "contacts",
+            lang: "en-US",
+          },
         },
+        endpoint: "FEATURE_CONFIGURATION",
+        method: "GET",
+        status: 200,
       },
-      endpoint: "FEATURE_CONFIGURATION",
-      method: "GET",
-      status: 200,
-    })
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: getBodyAsRecord(
-        DEFAULT_RESPONSES.FEATURE_CONFIGURATION?.GET?.[1]?.body
-      ),
-      match: {
-        expected: {
-          feature: "mc-overview",
-          lang: "en-US",
+      {
+        path: "path-1",
+        body: getBodyAsRecord(
+          DEFAULT_RESPONSES.FEATURE_CONFIGURATION?.GET?.[1]?.body
+        ),
+        match: {
+          expected: {
+            feature: "mc-overview",
+            lang: "en-US",
+          },
         },
+        endpoint: "FEATURE_CONFIGURATION",
+        method: "GET",
+        status: 200,
       },
-      endpoint: "FEATURE_CONFIGURATION",
-      method: "GET",
-      status: 200,
-    })
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: getBodyAsRecord(
-        DEFAULT_RESPONSES.FEATURE_CONFIGURATION?.GET?.[2]?.body
-      ),
-      match: {
-        expected: {
-          feature: "fileManager",
-          lang: "en-US",
+      {
+        path: "path-1",
+        body: getBodyAsRecord(
+          DEFAULT_RESPONSES.FEATURE_CONFIGURATION?.GET?.[2]?.body
+        ),
+        match: {
+          expected: {
+            feature: "fileManager",
+            lang: "en-US",
+          },
         },
+        endpoint: "FEATURE_CONFIGURATION",
+        method: "GET",
+        status: 200,
       },
-      endpoint: "FEATURE_CONFIGURATION",
-      method: "GET",
-      status: 200,
-    })
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: getBodyAsRecord(
-        DEFAULT_RESPONSES.MENU_CONFIGURATION?.GET?.[0]?.body
-      ),
-      endpoint: "MENU_CONFIGURATION",
-      method: "GET",
-      status: 200,
-    })
-
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: getBodyAsRecord(
-        DEFAULT_RESPONSES.ENTITIES_METADATA?.GET?.[0]?.body
-      ),
-      endpoint: "ENTITIES_METADATA",
-      method: "GET",
-      status: 200,
-    })
-
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: {
-        features: [],
-        data: [],
+      {
+        path: "path-1",
+        body: getBodyAsRecord(
+          DEFAULT_RESPONSES.MENU_CONFIGURATION?.GET?.[0]?.body
+        ),
+        endpoint: "MENU_CONFIGURATION",
+        method: "GET",
+        status: 200,
       },
-      endpoint: "OUTBOX",
-      method: "GET",
-      status: 200,
-    })
-
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: getBodyAsRecord(
-        DEFAULT_RESPONSES.ENTITIES_CONFIGURATION?.GET?.[0]?.body
-      ),
-      match: { expected: { entityType: "contacts" } },
-      endpoint: "ENTITIES_CONFIGURATION",
-      method: "GET",
-      status: 200,
-    })
-
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: getBodyAsRecord(
-        DEFAULT_RESPONSES.ENTITIES_CONFIGURATION?.GET?.[1]?.body
-      ),
-      match: { expected: { entityType: "audioFiles" } },
-      endpoint: "ENTITIES_CONFIGURATION",
-      method: "GET",
-      status: 200,
-    })
+      {
+        path: "path-1",
+        body: getBodyAsRecord(
+          DEFAULT_RESPONSES.ENTITIES_METADATA?.GET?.[0]?.body
+        ),
+        endpoint: "ENTITIES_METADATA",
+        method: "GET",
+        status: 200,
+      },
+      {
+        path: "path-1",
+        body: {
+          features: [],
+          data: [],
+        },
+        endpoint: "OUTBOX",
+        method: "GET",
+        status: 200,
+      },
+      {
+        path: "path-1",
+        body: getBodyAsRecord(
+          DEFAULT_RESPONSES.ENTITIES_CONFIGURATION?.GET?.[0]?.body
+        ),
+        match: { expected: { entityType: "contacts" } },
+        endpoint: "ENTITIES_CONFIGURATION",
+        method: "GET",
+        status: 200,
+      },
+      {
+        path: "path-1",
+        body: getBodyAsRecord(
+          DEFAULT_RESPONSES.ENTITIES_CONFIGURATION?.GET?.[1]?.body
+        ),
+        match: { expected: { entityType: "audioFiles" } },
+        endpoint: "ENTITIES_CONFIGURATION",
+        method: "GET",
+        status: 200,
+      },
+    ])
 
     mockEntityDownloadProcess({
       path: "path-1",

--- a/apps/mudita-center-e2e/src/specs/overview/e2e-mock-match.e2e.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/e2e-mock-match.e2e.ts
@@ -23,42 +23,44 @@ describe("E2E mock match sample", () => {
   it.only("Connect device with two different responses for one endpoint", async () => {
     // if body of FEATURE_CONFIGURATION request is equal to { feature: "contacts", lang: "en-US" } then return body: contactsConfig.
     // in other cases return response without match filed
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: contactsConfig,
-      endpoint: "FEATURE_CONFIGURATION",
-      method: "GET",
-      status: 200,
-      match: {
-        expected: { feature: "contacts", lang: "en-US" },
+    E2EMockClient.mockResponses([
+      {
+        path: "path-1",
+        body: contactsConfig,
+        endpoint: "FEATURE_CONFIGURATION",
+        method: "GET",
+        status: 200,
+        match: {
+          expected: { feature: "contacts", lang: "en-US" },
+        },
       },
-    })
-    // if body of FEATURE_DATA request is equal to { feature: "contacts", lang: "en-US" } then return body: contactsConfig.
-    // in other cases return response without match filed
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: contactsData,
-      endpoint: "FEATURE_DATA",
-      method: "GET",
-      status: 200,
-      match: {
-        expected: { feature: "contacts", lang: "en-US" },
+      // if body of FEATURE_DATA request is equal to { feature: "contacts", lang: "en-US" } then return body: contactsConfig.
+      // in other cases return response without match filed
+      {
+        path: "path-1",
+        body: contactsData,
+        endpoint: "FEATURE_DATA",
+        method: "GET",
+        status: 200,
+        match: {
+          expected: { feature: "contacts", lang: "en-US" },
+        },
       },
-    })
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: apiConfigWithContacts,
-      endpoint: "API_CONFIGURATION",
-      method: "GET",
-      status: 200,
-    })
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: menuWithContacts,
-      endpoint: "MENU_CONFIGURATION",
-      method: "GET",
-      status: 200,
-    })
+      {
+        path: "path-1",
+        body: apiConfigWithContacts,
+        endpoint: "API_CONFIGURATION",
+        method: "GET",
+        status: 200,
+      },
+      {
+        path: "path-1",
+        body: menuWithContacts,
+        endpoint: "MENU_CONFIGURATION",
+        method: "GET",
+        status: 200,
+      },
+    ])
 
     E2EMockClient.addDevice({
       path: "path-1",

--- a/apps/mudita-center-e2e/src/specs/overview/e2e-mock-sample.e2e.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/e2e-mock-sample.e2e.ts
@@ -39,22 +39,26 @@ describe("E2E mock sample - overview view", () => {
     await expect(badge).toBeDisplayed()
 
     // overwrite default response for given device
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: overviewDataWithoutBadge,
-      endpoint: "FEATURE_DATA",
-      method: "GET",
-      status: 200,
-    })
+    E2EMockClient.mockResponses([
+      {
+        path: "path-1",
+        body: overviewDataWithoutBadge,
+        endpoint: "FEATURE_DATA",
+        method: "GET",
+        status: 200,
+      },
+    ])
 
     // overwrite newest response for given device
-    E2EMockClient.mockResponseOnce({
-      path: "path-1",
-      body: outboxReloadOverview,
-      endpoint: "OUTBOX",
-      method: "GET",
-      status: 200,
-    })
+    E2EMockClient.mockResponsesOnce([
+      {
+        path: "path-1",
+        body: outboxReloadOverview,
+        endpoint: "OUTBOX",
+        method: "GET",
+        status: 200,
+      },
+    ])
 
     await badge.waitForDisplayed({ reverse: true })
     screenshotHelper.makeViewScreenshot()

--- a/apps/mudita-center-e2e/src/specs/overview/e2e-reset-mock-overview.e2e.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/e2e-reset-mock-overview.e2e.ts
@@ -1,9 +1,8 @@
 import { E2EMockClient } from "../../../../../libs/e2e-mock/client/src"
 import {
   outboxReloadOverview,
-  overviewDataWithOneSimCard
+  overviewDataWithOneSimCard,
 } from "../../../../../libs/e2e-mock/responses/src"
-import screenshotHelper from "../../helpers/screenshot.helper"
 
 describe("E2E reset mock sample - overview view", () => {
   before(async () => {
@@ -33,24 +32,26 @@ describe("E2E reset mock sample - overview view", () => {
   })
 
   it("Overwrite device response", async () => {
-
     // overwrite default response for given device
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: overviewDataWithOneSimCard,
-      endpoint: "FEATURE_DATA",
-      method: "GET",
-      status: 200,
-    })
+    E2EMockClient.mockResponses([
+      {
+        path: "path-1",
+        body: overviewDataWithOneSimCard,
+        endpoint: "FEATURE_DATA",
+        method: "GET",
+        status: 200,
+      },
+    ])
     // overwrite newest response for given device
-    E2EMockClient.mockResponseOnce({
-      path: "path-1",
-      body: outboxReloadOverview,
-      endpoint: "OUTBOX",
-      method: "GET",
-      status: 200,
-    })
-    
+    E2EMockClient.mockResponsesOnce([
+      {
+        path: "path-1",
+        body: outboxReloadOverview,
+        endpoint: "OUTBOX",
+        method: "GET",
+        status: 200,
+      },
+    ])
 
     await browser.pause(30000)
   })
@@ -74,7 +75,6 @@ describe("E2E reset mock sample - overview view", () => {
         },
       ],
     })
-
 
     await browser.pause(30000)
   })

--- a/apps/mudita-center-e2e/src/specs/overview/e2e-reset-mock-sample.e2e.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/e2e-reset-mock-sample.e2e.ts
@@ -1,9 +1,4 @@
 import { E2EMockClient } from "../../../../../libs/e2e-mock/client/src"
-import {
-  outboxReloadOverview,
-  overviewDataWithoutBadge,
-} from "../../../../../libs/e2e-mock/responses/src"
-import screenshotHelper from "../../helpers/screenshot.helper"
 
 describe("E2E reset mock sample", () => {
   before(async () => {
@@ -20,35 +15,36 @@ describe("E2E reset mock sample", () => {
   })
 
   it("Connect locked device", async () => {
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: {},
-      endpoint: "FEATURE_DATA",
-      method: "GET",
-      status: 423,
-    })
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: {},
-      endpoint: "FEATURE_CONFIGURATION",
-      method: "GET",
-      status: 423,
-    })
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: {},
-      endpoint: "MENU_CONFIGURATION",
-      method: "GET",
-      status: 423,
-    })
-
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: {},
-      endpoint: "OUTBOX",
-      method: "GET",
-      status: 423,
-    })
+    E2EMockClient.mockResponses([
+      {
+        path: "path-1",
+        body: {},
+        endpoint: "FEATURE_DATA",
+        method: "GET",
+        status: 423,
+      },
+      {
+        path: "path-1",
+        body: {},
+        endpoint: "FEATURE_CONFIGURATION",
+        method: "GET",
+        status: 423,
+      },
+      {
+        path: "path-1",
+        body: {},
+        endpoint: "MENU_CONFIGURATION",
+        method: "GET",
+        status: 423,
+      },
+      {
+        path: "path-1",
+        body: {},
+        endpoint: "OUTBOX",
+        method: "GET",
+        status: 423,
+      },
+    ])
 
     E2EMockClient.addDevice({
       path: "path-1",

--- a/apps/mudita-center-e2e/src/specs/overview/kompakt-about.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/kompakt-about.ts
@@ -17,13 +17,15 @@ describe("Checking About your Kompakt", () => {
   })
 
   it("Connect device", async () => {
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: overviewDataWithOneSimCard,
-      endpoint: "FEATURE_DATA",
-      method: "GET",
-      status: 200,
-    })
+    E2EMockClient.mockResponses([
+      {
+        path: "path-1",
+        body: overviewDataWithOneSimCard,
+        endpoint: "FEATURE_DATA",
+        method: "GET",
+        status: 200,
+      },
+    ])
 
     E2EMockClient.addDevice({
       path: "path-1",

--- a/apps/mudita-center-e2e/src/specs/overview/kompakt-backup-getting-initial-info.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/kompakt-backup-getting-initial-info.ts
@@ -20,20 +20,22 @@ describe("E2E mock sample - overview view", () => {
   })
 
   it("Connect device", async () => {
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: overviewConfigForBackup,
-      endpoint: "FEATURE_CONFIGURATION",
-      method: "GET",
-      status: 200,
-    })
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: overviewDataWithOneSimCard,
-      endpoint: "FEATURE_DATA",
-      method: "GET",
-      status: 200,
-    })
+    E2EMockClient.mockResponses([
+      {
+        path: "path-1",
+        body: overviewConfigForBackup,
+        endpoint: "FEATURE_CONFIGURATION",
+        method: "GET",
+        status: 200,
+      },
+      {
+        path: "path-1",
+        body: overviewDataWithOneSimCard,
+        endpoint: "FEATURE_DATA",
+        method: "GET",
+        status: 200,
+      },
+    ])
     E2EMockClient.addDevice({
       path: "path-1",
       serialNumber: "first-serial-number",

--- a/apps/mudita-center-e2e/src/specs/overview/kompakt-overview.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/kompakt-overview.ts
@@ -21,13 +21,15 @@ describe("E2E mock sample - overview view", () => {
   })
 
   it("Connect device", async () => {
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: overviewDataWithOneSimCard,
-      endpoint: "FEATURE_DATA",
-      method: "GET",
-      status: 200,
-    })
+    E2EMockClient.mockResponses([
+      {
+        path: "path-1",
+        body: overviewDataWithOneSimCard,
+        endpoint: "FEATURE_DATA",
+        method: "GET",
+        status: 200,
+      },
+    ])
     E2EMockClient.addDevice({
       path: "path-1",
       serialNumber: "first-serial-number",

--- a/apps/mudita-center-e2e/src/specs/overview/kompakt-prebackup-api.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/kompakt-prebackup-api.ts
@@ -21,20 +21,22 @@ describe("E2E mock sample - overview view", () => {
   })
 
   it("Connect device", async () => {
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: overviewConfigForBackup,
-      endpoint: "FEATURE_CONFIGURATION",
-      method: "GET",
-      status: 200,
-    })
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: overviewDataWithOneSimCard,
-      endpoint: "FEATURE_DATA",
-      method: "GET",
-      status: 200,
-    })
+    E2EMockClient.mockResponses([
+      {
+        path: "path-1",
+        body: overviewConfigForBackup,
+        endpoint: "FEATURE_CONFIGURATION",
+        method: "GET",
+        status: 200,
+      },
+      {
+        path: "path-1",
+        body: overviewDataWithOneSimCard,
+        endpoint: "FEATURE_DATA",
+        method: "GET",
+        status: 200,
+      },
+    ])
     E2EMockClient.addDevice({
       path: "path-1",
       serialNumber: "first-serial-number",

--- a/apps/mudita-center-e2e/src/specs/overview/kompakt-switching-devices.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/kompakt-switching-devices.ts
@@ -27,13 +27,15 @@ describe("Kompakt switching devices", () => {
   })
 
   it("Connect device", async () => {
-    E2EMockClient.mockResponse({
-      path: "path-1",
-      body: overviewDataWithOneSimCard,
-      endpoint: "FEATURE_DATA",
-      method: "GET",
-      status: 200,
-    })
+    E2EMockClient.mockResponses([
+      {
+        path: "path-1",
+        body: overviewDataWithOneSimCard,
+        endpoint: "FEATURE_DATA",
+        method: "GET",
+        status: 200,
+      },
+    ])
     E2EMockClient.addDevice({
       path: "path-1",
       serialNumber: firstSerialNumber,
@@ -69,13 +71,15 @@ describe("Kompakt switching devices", () => {
   })
 
   it("Connect 2nd device", async () => {
-    E2EMockClient.mockResponse({
-      path: "path-2",
-      body: overviewDataWithOneSimCard2nd,
-      endpoint: "FEATURE_DATA",
-      method: "GET",
-      status: 200,
-    })
+    E2EMockClient.mockResponses([
+      {
+        path: "path-2",
+        body: overviewDataWithOneSimCard2nd,
+        endpoint: "FEATURE_DATA",
+        method: "GET",
+        status: 200,
+      },
+    ])
     E2EMockClient.addDevice({
       path: "path-2",
       serialNumber: secondSerialNumber,

--- a/apps/mudita-center-e2e/src/specs/stress-tests/connected-devices-stress-test.ts
+++ b/apps/mudita-center-e2e/src/specs/stress-tests/connected-devices-stress-test.ts
@@ -47,13 +47,15 @@ describe("Kompakt switching devices", () => {
     ]
 
     const mockResponses = devices.map((device) => {
-      E2EMockClient.mockResponse({
-        path: device.path,
-        body: device.body,
-        endpoint: "FEATURE_DATA",
-        method: "GET",
-        status: 200,
-      })
+      E2EMockClient.mockResponses([
+        {
+          path: device.path,
+          body: device.body,
+          endpoint: "FEATURE_DATA",
+          method: "GET",
+          status: 200,
+        },
+      ])
       return E2EMockClient.addDevice({
         path: device.path,
         serialNumber: device.serialNumber,
@@ -73,7 +75,7 @@ describe("Kompakt switching devices", () => {
     const availableDevices = await selectDevicePage.availableDevices
 
     for (const device of availableDevices) {
-      await expect(device).toBeDisplayed();
+      await expect(device).toBeDisplayed()
     }
 
     const firstDeviceOnSelectModal =
@@ -126,13 +128,15 @@ describe("Kompakt switching devices", () => {
     ]
 
     for (const device of devices) {
-      E2EMockClient.mockResponse({
-        path: device.path,
-        body: device.body,
-        endpoint: "FEATURE_DATA",
-        method: "GET",
-        status: 200,
-      })
+      E2EMockClient.mockResponses([
+        {
+          path: device.path,
+          body: device.body,
+          endpoint: "FEATURE_DATA",
+          method: "GET",
+          status: 200,
+        },
+      ])
       E2EMockClient.addDevice({
         path: device.path,
         serialNumber: device.serialNumber,

--- a/apps/mudita-center-e2e/src/specs/stress-tests/device-drawer-stress-test.ts
+++ b/apps/mudita-center-e2e/src/specs/stress-tests/device-drawer-stress-test.ts
@@ -48,13 +48,15 @@ describe("Kompakt switching devices", () => {
 
     for (let i = 0; i < devices.length; i++) {
       const device = devices[i]
-      E2EMockClient.mockResponse({
-        path: device.path,
-        body: device.body,
-        endpoint: "FEATURE_DATA",
-        method: "GET",
-        status: 200,
-      })
+      E2EMockClient.mockResponses([
+        {
+          path: device.path,
+          body: device.body,
+          endpoint: "FEATURE_DATA",
+          method: "GET",
+          status: 200,
+        },
+      ])
       E2EMockClient.addDevice({
         path: device.path,
         serialNumber: device.serialNumber,
@@ -101,13 +103,15 @@ describe("Kompakt switching devices", () => {
   })
 
   it("Connect 3rd Kompakt device", async () => {
-    E2EMockClient.mockResponse({
-      path: "path-3",
-      body: overviewDataWithOneSimCard3rd,
-      endpoint: "FEATURE_DATA",
-      method: "GET",
-      status: 200,
-    })
+    E2EMockClient.mockResponses([
+      {
+        path: "path-3",
+        body: overviewDataWithOneSimCard3rd,
+        endpoint: "FEATURE_DATA",
+        method: "GET",
+        status: 200,
+      },
+    ])
     E2EMockClient.addDevice({
       path: "path-3",
       serialNumber: thirdSerialNumber,
@@ -159,13 +163,15 @@ describe("Kompakt switching devices", () => {
     ]
 
     for (const device of devices) {
-      E2EMockClient.mockResponse({
-        path: device.path,
-        body: device.body,
-        endpoint: "FEATURE_DATA",
-        method: "GET",
-        status: 200,
-      })
+      E2EMockClient.mockResponses([
+        {
+          path: device.path,
+          body: device.body,
+          endpoint: "FEATURE_DATA",
+          method: "GET",
+          status: 200,
+        },
+      ])
       E2EMockClient.addDevice({
         path: device.path,
         serialNumber: device.serialNumber,

--- a/libs/e2e-mock/client/src/lib/e2e-mock-client.ts
+++ b/libs/e2e-mock/client/src/lib/e2e-mock-client.ts
@@ -31,11 +31,11 @@ export const E2EMockClient = {
   mockReset: (param: RestoreDefaultResponses) => {
     getClientEmiter()?.("mock.response.reset", param)
   },
-  mockResponse: (param: AddKompaktResponse) => {
-    getClientEmiter()?.("mock.response.every", param)
+  mockResponses: (param: AddKompaktResponse[]) => {
+    getClientEmiter()?.("mock.responses.every", param)
   },
-  mockResponseOnce: (param: AddKompaktResponse) => {
-    getClientEmiter()?.("mock.response.once", param)
+  mockResponsesOnce: (param: AddKompaktResponse[]) => {
+    getClientEmiter()?.("mock.responses.once", param)
   },
   connect: () => {
     connect()

--- a/libs/e2e-mock/server/src/lib/mock-descriptor/mock-descriptor-validators.ts
+++ b/libs/e2e-mock/server/src/lib/mock-descriptor/mock-descriptor-validators.ts
@@ -36,6 +36,8 @@ export const addKompaktResponseValidator = z.object({
 
 export type AddKompaktResponse = z.infer<typeof addKompaktResponseValidator>
 
+export const addKompaktResponsesValidator = z.array(addKompaktResponseValidator)
+
 export const restoreDefaultResponsesValidator = z.object({
   path: z.string().min(1),
   requests: z

--- a/libs/e2e-mock/server/src/lib/mock-descriptor/mock-descriptor.test.ts
+++ b/libs/e2e-mock/server/src/lib/mock-descriptor/mock-descriptor.test.ts
@@ -5,7 +5,7 @@
 
 import { DEFAULT_RESPONSES } from "e2e-mock-responses"
 import { APIEndpoints } from "device/models"
-import { mockDescriptor, getMockedDevices } from "./mock-descriptor"
+import { getMockedDevices, mockDescriptor } from "./mock-descriptor"
 import { AddKompaktResponse } from "./mock-descriptor-validators"
 
 const path = "/dev/ttyUSB0"
@@ -64,7 +64,7 @@ describe("MockDescriptor", () => {
         status: 200,
         body: { key: "value" },
       }
-      mockDescriptor.addResponse(response)
+      mockDescriptor.addResponses([response])
 
       const result = mockDescriptor.getResponse(path, endpoint, method, {})
       expect(result).toEqual({ status: 200, body: { key: "value" } })
@@ -79,7 +79,7 @@ describe("MockDescriptor", () => {
         body: { key: "value" },
         match: { expected: { key: "value" } },
       }
-      mockDescriptor.addResponse(response)
+      mockDescriptor.addResponses([response])
 
       const result = mockDescriptor.getResponse(path, endpoint, method, {
         key: "value",
@@ -96,7 +96,7 @@ describe("MockDescriptor", () => {
         body: { key: "firstValue" },
         match: undefined,
       }
-      mockDescriptor.addResponse(firstResponse)
+      mockDescriptor.addResponses([firstResponse])
 
       const secondResponse: AddKompaktResponse = {
         path,
@@ -106,7 +106,7 @@ describe("MockDescriptor", () => {
         body: { key: "secondValue" },
         match: { expected: { key: "secondValue" } },
       }
-      mockDescriptor.addResponse(secondResponse)
+      mockDescriptor.addResponses([secondResponse])
 
       const result = mockDescriptor.getResponse(path, endpoint, method, {
         key: "secondValue",
@@ -123,7 +123,7 @@ describe("MockDescriptor", () => {
         body: { key: "value" },
         match: { expected: { key: "notValue" } },
       }
-      mockDescriptor.addResponse(response)
+      mockDescriptor.addResponses([response])
 
       const result = mockDescriptor.getResponse(path, endpoint, method, {
         key: "otherValue",
@@ -140,7 +140,7 @@ describe("MockDescriptor", () => {
         body: { key: "firstValue" },
         match: undefined,
       }
-      mockDescriptor.addResponse(firstResponse)
+      mockDescriptor.addResponses([firstResponse])
 
       const secondResponse: AddKompaktResponse = {
         path,
@@ -150,7 +150,7 @@ describe("MockDescriptor", () => {
         body: { key: "secondValue" },
         match: undefined,
       }
-      mockDescriptor.addResponse(secondResponse)
+      mockDescriptor.addResponses([secondResponse])
 
       const result = mockDescriptor.getResponse(path, endpoint, method, {
         key: "secondValue",
@@ -254,7 +254,7 @@ describe("MockDescriptor", () => {
         body: { key: "firstValue" },
         match: undefined,
       }
-      mockDescriptor.addResponse(firstResponse)
+      mockDescriptor.addResponses([firstResponse])
 
       const secondResponse: AddKompaktResponse = {
         path,
@@ -264,7 +264,7 @@ describe("MockDescriptor", () => {
         body: { key: "secondValue" },
         match: undefined,
       }
-      mockDescriptor.addResponse(secondResponse)
+      mockDescriptor.addResponses([secondResponse])
 
       const filteredResponses = mockDescriptor.getResponse(
         path,
@@ -287,7 +287,7 @@ describe("MockDescriptor", () => {
         body: { key: "value" },
         match: { expected: { key: "value" } },
       }
-      mockDescriptor.addResponse(firstResponse)
+      mockDescriptor.addResponses([firstResponse])
 
       const secondResponse: AddKompaktResponse = {
         path,
@@ -297,7 +297,7 @@ describe("MockDescriptor", () => {
         body: { key: "value" },
         match: { expected: { key: "value" } },
       }
-      mockDescriptor.addResponse(secondResponse)
+      mockDescriptor.addResponses([secondResponse])
 
       const filteredResponses = mockDescriptor.getResponse(
         path,

--- a/libs/e2e-mock/server/src/lib/server.tsx
+++ b/libs/e2e-mock/server/src/lib/server.tsx
@@ -6,7 +6,7 @@
 import ipc from "node-ipc"
 import logger from "Core/__deprecated__/main/utils/logger"
 import {
-  addKompaktResponseValidator,
+  addKompaktResponsesValidator,
   addKompaktValidator,
   restoreDefaultResponsesValidator,
 } from "./mock-descriptor/mock-descriptor-validators"
@@ -26,37 +26,37 @@ ipc.config.retry = 15
 const instanceID = Math.floor(Math.random() * 10000)
 
 ipc.serve(function () {
-  ipc.server.on("mock.add.device", function (data, socket) {
+  ipc.server.on("mock.add.device", function (data) {
     logger.info(`mock.add.device fro instanceID: ${instanceID}`)
     const params = addKompaktValidator.safeParse(data)
     if (params.success) {
       mockDescriptor.addKompakt(params.data)
     }
   })
-  ipc.server.on("mock.remove.device", function (data, socket) {
+  ipc.server.on("mock.remove.device", function (data) {
     if (typeof data === "string") {
       mockDescriptor.removeDevice(data)
     }
   })
-  ipc.server.on("mock.response.every", function (data, socket) {
-    const params = addKompaktResponseValidator.safeParse(data)
+  ipc.server.on("mock.responses.every", function (data) {
+    const params = addKompaktResponsesValidator.safeParse(data)
     if (params.success) {
-      mockDescriptor.addResponse(params.data)
+      mockDescriptor.addResponses(params.data)
     }
   })
-  ipc.server.on("mock.response.once", function (data, socket) {
-    const params = addKompaktResponseValidator.safeParse(data)
+  ipc.server.on("mock.responses.once", function (data) {
+    const params = addKompaktResponsesValidator.safeParse(data)
     if (params.success) {
-      mockDescriptor.addResponseOnce(params.data)
+      mockDescriptor.addResponsesOnce(params.data)
     }
   })
-  ipc.server.on("mock.response.reset", function (data, socket) {
+  ipc.server.on("mock.response.reset", function (data) {
     const params = restoreDefaultResponsesValidator.safeParse(data)
     if (params.success) {
       mockDescriptor.removeResponses(params.data)
     }
   })
-  ipc.server.on("server.stop", function (data, socket) {
+  ipc.server.on("server.stop", function () {
     stopServer()
   })
   ipc.server.on("set.mock.update.state", function (data: UpdateState) {

--- a/libs/e2e-mock/server/src/lib/server.tsx
+++ b/libs/e2e-mock/server/src/lib/server.tsx
@@ -26,37 +26,37 @@ ipc.config.retry = 15
 const instanceID = Math.floor(Math.random() * 10000)
 
 ipc.serve(function () {
-  ipc.server.on("mock.add.device", function (data) {
+  ipc.server.on("mock.add.device", function (data, socket) {
     logger.info(`mock.add.device fro instanceID: ${instanceID}`)
     const params = addKompaktValidator.safeParse(data)
     if (params.success) {
       mockDescriptor.addKompakt(params.data)
     }
   })
-  ipc.server.on("mock.remove.device", function (data) {
+  ipc.server.on("mock.remove.device", function (data, socket) {
     if (typeof data === "string") {
       mockDescriptor.removeDevice(data)
     }
   })
-  ipc.server.on("mock.responses.every", function (data) {
+  ipc.server.on("mock.responses.every", function (data, socket) {
     const params = addKompaktResponsesValidator.safeParse(data)
     if (params.success) {
       mockDescriptor.addResponses(params.data)
     }
   })
-  ipc.server.on("mock.responses.once", function (data) {
+  ipc.server.on("mock.responses.once", function (data, socket) {
     const params = addKompaktResponsesValidator.safeParse(data)
     if (params.success) {
       mockDescriptor.addResponsesOnce(params.data)
     }
   })
-  ipc.server.on("mock.response.reset", function (data) {
+  ipc.server.on("mock.response.reset", function (data, socket) {
     const params = restoreDefaultResponsesValidator.safeParse(data)
     if (params.success) {
       mockDescriptor.removeResponses(params.data)
     }
   })
-  ipc.server.on("server.stop", function () {
+  ipc.server.on("server.stop", function (data, socket) {
     stopServer()
   })
   ipc.server.on("set.mock.update.state", function (data: UpdateState) {


### PR DESCRIPTION
JIRA Reference: [CP-2976]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2976]: https://appnroll.atlassian.net/browse/CP-2976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ