### PR TITLE
CP-3172, added a new test, also added a little text updated for delet…

### DIFF
--- a/apps/mudita-center-e2e/src/page-objects/contacts-kompakt.ts
+++ b/apps/mudita-center-e2e/src/page-objects/contacts-kompakt.ts
@@ -37,6 +37,18 @@ class ContactsKompaktPage extends Page {
     return $$('//*[@data-testid="ui-table-row"]')
   }
 
+  public get contactsCheckboxesLabels() {
+    return $$('//label[contains(@for, "checkbox-")]')
+  }
+
+  public get contactSelectedBar() {
+    return $('//*[@data-testid="ui-typography-p4"]')
+  }
+
+  public get contactSelectedDeleteButton() {
+    return $('//*[@data-testid="button-text_deleteButton"]')
+  }
+
   public get contactDetailsDeleteButton() {
     return $('//*[@data-testid="icon-delete"]')
   }
@@ -45,11 +57,15 @@ class ContactsKompaktPage extends Page {
     return $('//*[@data-testid="modal-content-detailsDeleteModal"]')
   }
 
+  public get contactDeleteModalFromList() {
+    return $('//*[@data-testid="modal-content-globalDeleteModal"]')
+  }
+
   public get contactDeleteModalIcon() {
     return $('//*[@data-testid="icon-exclamation"]')
   }
   public get contactDeleteModalTitle() {
-    return $('//h1[text()="Delete contact"]')
+    return $('//h1[text()="Delete contact?"]')
   }
 
   public get contactDeleteModalText() {
@@ -68,6 +84,16 @@ class ContactsKompaktPage extends Page {
       '//*[@data-testid="primary-button-detailsDeleteModalCancelButton"]'
     )
   }
+
+  public get deleteContactConfirmButtonFromList() {
+    return $(
+      '//*[@data-testid="primary-button-globalDeleteModalConfirmButton"]'
+    )
+  }
+  public get deleteContactCancelButtonFromList() {
+    return $('//*[@data-testid="primary-button-globalDeleteModalCancelButton"]')
+  }
+
   public get checkboxByRowIndex() {
     return (rowIndex: number) =>
       $(

--- a/apps/mudita-center-e2e/src/specs/overview/kompakt-contacts-delete.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/kompakt-contacts-delete.ts
@@ -48,19 +48,25 @@ describe("E2E mock sample - overview view", () => {
     await expect(contactsCounter).toHaveText("Contacts (17)")
   })
 
-  it("Select first contact to open contact details", async () => {
-    const contactsList = await ContactsKompaktPage.allContactsTableRows
-    await contactsList[0].click()
+  it("Select first contact's checkbox", async () => {
+    const checkboxesLabels = await ContactsKompaktPage.contactsCheckboxesLabels
+    await checkboxesLabels[0].click()
+  })
+
+  it("Check contact selected bar", async () => {
+    const contactSelectedBar = ContactsKompaktPage.contactSelectedBar
+    await expect(contactSelectedBar).toHaveText("1 contact selected")
+
+    const contactSelectedDeleteButton =
+      ContactsKompaktPage.contactSelectedDeleteButton
+    await expect(contactSelectedDeleteButton).toBeClickable()
+    await contactSelectedDeleteButton.click()
   })
   it("Check delete modal", async () => {
-    const contactDetailsDeleteButton =
-      ContactsKompaktPage.contactDetailsDeleteButton
-    await expect(contactDetailsDeleteButton).toBeClickable()
-    await contactDetailsDeleteButton.click()
-
     //check delete modal
-    const contactDeleteModal = ContactsKompaktPage.contactDeleteModal
-    await expect(contactDeleteModal).toBeDisplayed()
+    const contactDeleteModalFromList =
+      ContactsKompaktPage.contactDeleteModalFromList
+    await expect(contactDeleteModalFromList).toBeDisplayed()
 
     const contactDeleteModalIcon = ContactsKompaktPage.contactDeleteModalIcon
     await expect(contactDeleteModalIcon).toBeDisplayed()
@@ -80,10 +86,10 @@ describe("E2E mock sample - overview view", () => {
     expect(isClickable).toBe(false)
 
     //check modal cancellation
-    const deleteContactCancelButton =
-      ContactsKompaktPage.deleteContactCancelButton
-    await expect(deleteContactCancelButton).toBeClickable()
-    await deleteContactCancelButton.click()
+    const deleteContactCancelButtonFromList =
+      ContactsKompaktPage.deleteContactCancelButtonFromList
+    await expect(deleteContactCancelButtonFromList).toBeClickable()
+    await deleteContactCancelButtonFromList.click()
   })
   it("Check contact deletion and counter update", async () => {
     //click again to open modal again
@@ -96,10 +102,10 @@ describe("E2E mock sample - overview view", () => {
       entityType: "contacts",
       totalEntities: selectedContactsEntities.length - 1,
     })
-    const deleteContactConfirmButton =
-      ContactsKompaktPage.deleteContactConfirmButton
-    await expect(deleteContactConfirmButton).toBeClickable()
-    await deleteContactConfirmButton.click()
+    const deleteContactConfirmButtonFromList =
+      ContactsKompaktPage.deleteContactConfirmButtonFromList
+    await expect(deleteContactConfirmButtonFromList).toBeClickable()
+    await deleteContactConfirmButtonFromList.click()
 
     //verify if counter is updated after deleting (number should be deducted by 1)
     const contactsCounter = ContactsKompaktPage.contactsCounter

--- a/apps/mudita-center-e2e/src/test-filenames/consts/test-filenames.const.ts
+++ b/apps/mudita-center-e2e/src/test-filenames/consts/test-filenames.const.ts
@@ -38,5 +38,6 @@ export enum TestFilesPaths {
   kompaktContactsViewing = "src/specs/overview/kompakt-contacts-viewing.ts",
   kompaktContactsViewingEmpty = "src/specs/overview/kompakt-contacts-viewing-empty.ts",
   kompaktContactsDeleteDetails = "src/specs/overview/kompakt-contacts-delete-details.ts",
+  kompaktContactsDelete = "src/specs/overview/kompakt-contacts-delete.ts",
 }
 export const toRelativePath = (path: string) => `./${path}`

--- a/apps/mudita-center-e2e/wdio.conf.ts
+++ b/apps/mudita-center-e2e/wdio.conf.ts
@@ -87,6 +87,7 @@ export const config: Options.Testrunner = {
     toRelativePath(TestFilesPaths.kompaktContactsViewing),
     toRelativePath(TestFilesPaths.kompaktContactsViewingEmpty),
     toRelativePath(TestFilesPaths.kompaktContactsDeleteDetails),
+    toRelativePath(TestFilesPaths.kompaktContactsDelete),
   ],
   suites: {
     standalone: [
@@ -123,6 +124,7 @@ export const config: Options.Testrunner = {
       toRelativePath(TestFilesPaths.kompaktContactsViewing),
       toRelativePath(TestFilesPaths.kompaktContactsViewingEmpty),
       toRelativePath(TestFilesPaths.kompaktContactsDeleteDetails),
+      toRelativePath(TestFilesPaths.kompaktContactsDelete),
     ],
     multidevicePureHarmony: [],
     multideviceSingleHarmony: [],
@@ -167,6 +169,7 @@ export const config: Options.Testrunner = {
       toRelativePath(TestFilesPaths.kompaktContactsViewing),
       toRelativePath(TestFilesPaths.kompaktContactsViewingEmpty),
       toRelativePath(TestFilesPaths.kompaktContactsDeleteDetails),
+      toRelativePath(TestFilesPaths.kompaktContactsDelete),
     ],
   },
   // Patterns to exclude.


### PR DESCRIPTION
…e-details test due to CP-3461 text fix

JIRA Reference: [CP-3172]

### :memo: Description ️
Mock and Connect Kompakt with 10 contacts.

Test deleting contact from contacts list. 

Select contact you want to delete

Verify delete menu bar

Verify delete button and modal

Verify the rest of screen is blocked when confirmation modal shows up. Check if any element below is not clickable.

Cancel deletion

Delete again - verify contact is removed

After successfully deleting a contact, the total number of contacts is updated accordingly (Verify count).

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-3172]: https://appnroll.atlassian.net/browse/CP-3172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ