### PR TITLE
CP-3174 added test, not completed, removed unused import from contact…

### DIFF
--- a/apps/mudita-center-e2e/src/page-objects/contacts-kompakt.ts
+++ b/apps/mudita-center-e2e/src/page-objects/contacts-kompakt.ts
@@ -37,6 +37,86 @@ class ContactsKompaktPage extends Page {
     return $$('//*[@data-testid="ui-table-row"]')
   }
 
+  public get contactDetailsTitle() {
+    return $('//*[@data-testid="ui-typography-h3"]')
+  }
+
+  public get contactDetailsSubtitleContactInformation() {
+    return $('//*[@data-testid="ui-typography-h4"]')
+  }
+  // TO FILL
+  public get contactDetailsPhoneNumber() {
+    return $('//*[@data-testid=""]')
+  }
+
+  public get contactDetailsPhoneNumberValue() {
+    return $('//*[@data-testid=""]')
+  }
+
+  public get contactDetailsFirstName() {
+    return $('//*[@data-testid=""]')
+  }
+
+  public get contactDetailsFirstNameValue() {
+    return $('//*[@data-testid=""]')
+  }
+
+  public get contactDetailsLastName() {
+    return $('//*[@data-testid=""]')
+  }
+
+  public get contactDetailsLastNameValue() {
+    return $('//*[@data-testid=""]')
+  }
+
+  public get contactDetailsNamePrefix() {
+    return $('//*[@data-testid=""]')
+  }
+
+  public get contactDetailsNamePrefixValue() {
+    return $('//*[@data-testid=""]')
+  }
+
+  public get contactDetailsMiddleName() {
+    return $('//*[@data-testid=""]')
+  }
+
+  public get contactDetailsMiddleNameValue() {
+    return $('//*[@data-testid=""]')
+  }
+
+  public get contactDetailsNameSuffix() {
+    return $('//*[@data-testid=""]')
+  }
+
+  public get contactDetailsNameSuffixValue() {
+    return $('//*[@data-testid=""]')
+  }
+
+  public get contactDetailsEmail() {
+    return $('//*[@data-testid=""]')
+  }
+
+  public get contactDetailsEmailValue() {
+    return $('//*[@data-testid=""]')
+  }
+
+  public get contactDetailsCompany() {
+    return $('//*[@data-testid=""]')
+  }
+
+  public get contactDetailsCompanyValue() {
+    return $('//*[@data-testid=""]')
+  }
+  ///////////////////////////////
+  public get closeContactDetailsButton() {
+    return $('//*[@data-testid="icon-close"]')
+  }
+
+  public get contactPhoneNumberColumn() {
+    return $('//*[@data-testid="="]')
+  }
+
   public get contactsCheckboxesLabels() {
     return $$('//label[contains(@for, "checkbox-")]')
   }

--- a/apps/mudita-center-e2e/src/page-objects/contacts-kompakt.ts
+++ b/apps/mudita-center-e2e/src/page-objects/contacts-kompakt.ts
@@ -37,84 +37,104 @@ class ContactsKompaktPage extends Page {
     return $$('//*[@data-testid="ui-table-row"]')
   }
 
-  public get contactDetailsTitle() {
-    return $('//*[@data-testid="ui-typography-h3"]')
+  public get contactDisplayNameHeader() {
+    return $('//*[@data-testid="ui-typography-h3-contactDisplayNameHeader"]')
   }
 
   public get contactDetailsSubtitleContactInformation() {
-    return $('//*[@data-testid="ui-typography-h4"]')
+    return $('//*[@data-testid="ui-typography-h4-contactInformationText"]')
   }
-  // TO FILL
+
   public get contactDetailsPhoneNumber() {
-    return $('//*[@data-testid=""]')
+    return $(
+      '//*[@data-testid="ui-typography-h5-contactDetailsPhoneNumberLabel"]'
+    )
   }
 
   public get contactDetailsPhoneNumberValue() {
-    return $('//*[@data-testid=""]')
+    return $(
+      '//*[@data-testid="ui-typography-p4-contactDetailsPhoneNumber1Value"]'
+    )
   }
 
   public get contactDetailsFirstName() {
-    return $('//*[@data-testid=""]')
+    return $(
+      '//*[@data-testid="ui-typography-h5-contactDetailsFirstNameLabel"]'
+    )
   }
 
   public get contactDetailsFirstNameValue() {
-    return $('//*[@data-testid=""]')
+    return $(
+      '//*[@data-testid="ui-typography-p4-contactDetailsFirstNameValue"]'
+    )
   }
 
   public get contactDetailsLastName() {
-    return $('//*[@data-testid=""]')
+    return $('//*[@data-testid="ui-typography-h5-contactDetailsLastNameLabel"]')
   }
 
   public get contactDetailsLastNameValue() {
-    return $('//*[@data-testid=""]')
+    return $('//*[@data-testid="ui-typography-p4-contactDetailsLastNameValue"]')
   }
 
   public get contactDetailsNamePrefix() {
-    return $('//*[@data-testid=""]')
+    return $(
+      '//*[@data-testid="ui-typography-h5-contactDetailsNamePrefixLabel"]'
+    )
   }
 
   public get contactDetailsNamePrefixValue() {
-    return $('//*[@data-testid=""]')
+    return $(
+      '//*[@data-testid="ui-typography-p4-contactDetailsNamePrefixValue"]'
+    )
   }
 
   public get contactDetailsMiddleName() {
-    return $('//*[@data-testid=""]')
+    return $(
+      '//*[@data-testid="ui-typography-h5-contactDetailsMiddleNameLabel"]'
+    )
   }
 
   public get contactDetailsMiddleNameValue() {
-    return $('//*[@data-testid=""]')
+    return $(
+      '//*[@data-testid="ui-typography-p4-contactDetailsMiddleNameValue"]'
+    )
   }
 
   public get contactDetailsNameSuffix() {
-    return $('//*[@data-testid=""]')
+    return $(
+      '//*[@data-testid="ui-typography-h5-contactDetailsNameSuffixLabel"]'
+    )
   }
 
   public get contactDetailsNameSuffixValue() {
-    return $('//*[@data-testid=""]')
+    return $(
+      '//*[@data-testid="ui-typography-p4-contactDetailsNameSuffixValue"]'
+    )
   }
 
   public get contactDetailsEmail() {
-    return $('//*[@data-testid=""]')
+    return $('//*[@data-testid="ui-typography-h5-contactDetailsEmailLabel"]')
   }
 
   public get contactDetailsEmailValue() {
-    return $('//*[@data-testid=""]')
+    return $('//*[@data-testid="ui-typography-p4-contactDetailsEmailValue"]')
   }
 
   public get contactDetailsCompany() {
-    return $('//*[@data-testid=""]')
+    return $('//*[@data-testid="ui-typography-h5-contactDetailsCompanyLabel"]')
   }
 
   public get contactDetailsCompanyValue() {
-    return $('//*[@data-testid=""]')
+    return $('//*[@data-testid="ui-typography-p4-contactDetailsCompanyValue"]')
   }
-  ///////////////////////////////
+
   public get closeContactDetailsButton() {
     return $('//*[@data-testid="icon-close"]')
   }
 
   public get contactPhoneNumberColumn() {
-    return $('//*[@data-testid="="]')
+    return $('//*[@data-testid="ui-typography-p1-contactPhoneNumber"]')
   }
 
   public get contactsCheckboxesLabels() {

--- a/apps/mudita-center-e2e/src/specs/overview/kompakt-contacts-viewing-details.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/kompakt-contacts-viewing-details.ts
@@ -135,6 +135,12 @@ describe("E2E mock sample - overview view", () => {
     const closeContactDetailsButton =
       await ContactsKompaktPage.closeContactDetailsButton
     await closeContactDetailsButton.click()
+
+    //check if elements from contacts details bar are not displayed, to assure that Contacts Details panel is closed
+    await expect(closeContactDetailsButton).not.toBeDisplayed()
+    const contactDetailsDeleteButton =
+      ContactsKompaktPage.contactDetailsDeleteButton
+    await expect(contactDetailsDeleteButton).not.toBeDisplayed()
   })
 
   it("Select first contact to open contact details and check if there is ellipsis at the end", async () => {

--- a/apps/mudita-center-e2e/src/specs/overview/kompakt-contacts-viewing-details.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/kompakt-contacts-viewing-details.ts
@@ -52,10 +52,11 @@ describe("E2E mock sample - overview view", () => {
     await contactsList[5].click()
   })
 
-  xit("Check contact's details", async () => {
+  it("Check contact's details", async () => {
     //check contact title in Details view
-    const contactDetailsTitle = await ContactsKompaktPage.contactDetailsTitle
-    await expect(contactDetailsTitle).toHaveText("Dr. Michael Johnson PhD")
+    const contactDisplayNameHeader =
+      await ContactsKompaktPage.contactDisplayNameHeader
+    await expect(contactDisplayNameHeader).toHaveText("Dr. Michael Johnson PhD")
 
     //check contact information subtitle
     const contactDetailsSubtitleContactInformation =
@@ -127,7 +128,7 @@ describe("E2E mock sample - overview view", () => {
     const contactDetailsCompanyValue =
       await ContactsKompaktPage.contactDetailsCompanyValue
     await expect(contactDetailsCompany).toHaveText("Company")
-    await expect(contactDetailsCompanyValue).toHaveText("")
+    await expect(contactDetailsCompanyValue).toHaveText("Research Labs")
   })
 
   it("Close contact details page", async () => {
@@ -140,14 +141,26 @@ describe("E2E mock sample - overview view", () => {
     const contactsList = await ContactsKompaktPage.allContactsTableRows
     await contactsList[0].click()
 
-    const contactDetailsTitle = await ContactsKompaktPage.contactDetailsTitle
-    //await expect(contactDetailsTitle).toHaveTextContaining("...")
-    // const titleText = await contactDetailsTitle.getText()
+    const elementEllipsis = await ContactsKompaktPage.contactDisplayNameHeader
 
-    // await expect(titleText.endsWith("...")).toBe(true)
+    const computedStyle = await browser.execute((el) => {
+      const domElement = el as unknown as HTMLElement // Ensure it's treated correctly
+      const styles = window.getComputedStyle(domElement)
+
+      return {
+        textOverflow: styles.textOverflow,
+        whiteSpace: styles.whiteSpace,
+        overflow: styles.overflow,
+      }
+    }, elementEllipsis)
+
+    // Assertions to verify if ellipsis is actually applied
+    await expect(computedStyle.textOverflow).toBe("ellipsis")
+    await expect(computedStyle.whiteSpace).toBe("nowrap")
+    await expect(computedStyle.overflow).toBe("hidden")
   })
 
-  xit("Check if phone number columns are not visible when Contact Details are opened", async () => {
+  it("Check if phone number columns are not visible when Contact Details are opened", async () => {
     const contactPhoneNumberColumn =
       await ContactsKompaktPage.contactPhoneNumberColumn
     await expect(contactPhoneNumberColumn).not.toBeDisplayed()

--- a/apps/mudita-center-e2e/src/specs/overview/kompakt-contacts-viewing-details.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/kompakt-contacts-viewing-details.ts
@@ -1,0 +1,155 @@
+import { E2EMockClient } from "../../../../../libs/e2e-mock/client/src"
+import tabsPage from "../../page-objects/tabs.page"
+import ContactsKompaktPage from "../../page-objects/contacts-kompakt"
+import { mockEntityDownloadProcess } from "../../helpers"
+import { selectedContactsEntities } from "../../helpers/entity-fixtures"
+
+describe("E2E mock sample - overview view", () => {
+  before(async () => {
+    E2EMockClient.connect()
+    //wait for a connection to be established
+    await browser.waitUntil(() => {
+      return E2EMockClient.checkConnection()
+    })
+  })
+
+  after(() => {
+    E2EMockClient.stopServer()
+    E2EMockClient.disconnect()
+  })
+
+  it("Connect device", async () => {
+    E2EMockClient.addDevice({
+      path: "path-1",
+      serialNumber: "first-serial-number",
+    })
+
+    // mock contacts function for testing/modification purposes
+    mockEntityDownloadProcess({
+      path: "path-1",
+      data: selectedContactsEntities,
+      entityType: "contacts",
+    })
+
+    await browser.pause(6000)
+    const menuItem = await $(`//a[@href="#/generic/mc-overview"]`)
+
+    await menuItem.waitForDisplayed({ timeout: 10000 })
+    await expect(menuItem).toBeDisplayed()
+  })
+
+  it("Click Contacts tab and check contacts counter", async () => {
+    const contactsKompaktTab = tabsPage.contactsKompaktTab
+    await contactsKompaktTab.click()
+
+    const contactsCounter = ContactsKompaktPage.contactsCounter
+    await expect(contactsCounter).toBeDisplayed()
+    await expect(contactsCounter).toHaveText("Contacts (17)")
+  })
+
+  it("Select sixth contact to open contact details", async () => {
+    const contactsList = await ContactsKompaktPage.allContactsTableRows
+    await contactsList[5].click()
+  })
+
+  xit("Check contact's details", async () => {
+    //check contact title in Details view
+    const contactDetailsTitle = await ContactsKompaktPage.contactDetailsTitle
+    await expect(contactDetailsTitle).toHaveText("Dr. Michael Johnson PhD")
+
+    //check contact information subtitle
+    const contactDetailsSubtitleContactInformation =
+      await ContactsKompaktPage.contactDetailsSubtitleContactInformation
+    await expect(contactDetailsSubtitleContactInformation).toHaveText(
+      "Contact information"
+    )
+
+    //check contact information Phone Number
+    const contactDetailsPhoneNumber =
+      await ContactsKompaktPage.contactDetailsPhoneNumber
+    const contactDetailsPhoneNumberValue =
+      await ContactsKompaktPage.contactDetailsPhoneNumberValue
+    await expect(contactDetailsPhoneNumber).toHaveText("Phone number")
+    await expect(contactDetailsPhoneNumberValue).toHaveText("+49876543210")
+
+    //check contact information First Name
+    const contactDetailsFirstName =
+      await ContactsKompaktPage.contactDetailsFirstName
+    const contactDetailsFirstNameValue =
+      await ContactsKompaktPage.contactDetailsFirstNameValue
+    await expect(contactDetailsFirstName).toHaveText("First name")
+    await expect(contactDetailsFirstNameValue).toHaveText("Michael")
+
+    //check contact information Last Name
+    const contactDetailsLastName =
+      await ContactsKompaktPage.contactDetailsLastName
+    const contactDetailsLastNameValue =
+      await ContactsKompaktPage.contactDetailsLastNameValue
+    await expect(contactDetailsLastName).toHaveText("Last name")
+    await expect(contactDetailsLastNameValue).toHaveText("Johnson")
+
+    //check contact information Name Prefix
+    const contactDetailsNamePrefix =
+      await ContactsKompaktPage.contactDetailsNamePrefix
+    const contactDetailsNamePrefixValue =
+      await ContactsKompaktPage.contactDetailsNamePrefixValue
+    await expect(contactDetailsNamePrefix).toHaveText("Name prefix")
+    await expect(contactDetailsNamePrefixValue).toHaveText("Dr.")
+
+    //check contact information Middle Name
+    const contactDetailsMiddleName =
+      await ContactsKompaktPage.contactDetailsMiddleName
+    const contactDetailsMiddleNameValue =
+      await ContactsKompaktPage.contactDetailsMiddleNameValue
+    await expect(contactDetailsMiddleName).toHaveText("Middle name")
+    await expect(contactDetailsMiddleNameValue).toHaveText("David")
+
+    //check contact information Name Suffix
+    const contactDetailsNameSuffix =
+      await ContactsKompaktPage.contactDetailsNameSuffix
+    const contactDetailsNameSuffixValue =
+      await ContactsKompaktPage.contactDetailsNameSuffixValue
+    await expect(contactDetailsNameSuffix).toHaveText("Name suffix")
+    await expect(contactDetailsNameSuffixValue).toHaveText("PhD")
+
+    //check contact information Email
+    const contactDetailsEmail = await ContactsKompaktPage.contactDetailsEmail
+    const contactDetailsEmailValue =
+      await ContactsKompaktPage.contactDetailsEmailValue
+    await expect(contactDetailsEmail).toHaveText("Email")
+    await expect(contactDetailsEmailValue).toHaveText(
+      "michael.j@researchlab.com"
+    )
+
+    //check contact information Company
+    const contactDetailsCompany =
+      await ContactsKompaktPage.contactDetailsCompany
+    const contactDetailsCompanyValue =
+      await ContactsKompaktPage.contactDetailsCompanyValue
+    await expect(contactDetailsCompany).toHaveText("Company")
+    await expect(contactDetailsCompanyValue).toHaveText("")
+  })
+
+  it("Close contact details page", async () => {
+    const closeContactDetailsButton =
+      await ContactsKompaktPage.closeContactDetailsButton
+    await closeContactDetailsButton.click()
+  })
+
+  it("Select first contact to open contact details and check if there is ellipsis at the end", async () => {
+    const contactsList = await ContactsKompaktPage.allContactsTableRows
+    await contactsList[0].click()
+
+    const contactDetailsTitle = await ContactsKompaktPage.contactDetailsTitle
+    //await expect(contactDetailsTitle).toHaveTextContaining("...")
+    // const titleText = await contactDetailsTitle.getText()
+
+    // await expect(titleText.endsWith("...")).toBe(true)
+  })
+
+  xit("Check if phone number columns are not visible when Contact Details are opened", async () => {
+    const contactPhoneNumberColumn =
+      await ContactsKompaktPage.contactPhoneNumberColumn
+    await expect(contactPhoneNumberColumn).not.toBeDisplayed()
+  })
+})

--- a/apps/mudita-center-e2e/src/specs/overview/kompakt-contacts-viewing.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/kompakt-contacts-viewing.ts
@@ -3,7 +3,6 @@ import tabsPage from "../../page-objects/tabs.page"
 import ContactsKompaktPage from "../../page-objects/contacts-kompakt"
 import { mockEntityDownloadProcess } from "../../helpers"
 import { selectedContactsEntities } from "../../helpers/entity-fixtures"
-import { mockEntityDeleteProcess } from "../../helpers/mock-entity-delete-process"
 
 describe("E2E mock sample - overview view", () => {
   before(async () => {

--- a/apps/mudita-center-e2e/src/test-filenames/consts/test-filenames.const.ts
+++ b/apps/mudita-center-e2e/src/test-filenames/consts/test-filenames.const.ts
@@ -39,5 +39,6 @@ export enum TestFilesPaths {
   kompaktContactsViewingEmpty = "src/specs/overview/kompakt-contacts-viewing-empty.ts",
   kompaktContactsDeleteDetails = "src/specs/overview/kompakt-contacts-delete-details.ts",
   kompaktContactsDelete = "src/specs/overview/kompakt-contacts-delete.ts",
+  kompaktContactsViewingDetails = "src/specs/overview/kompakt-contacts-viewing-details.ts.ts",
 }
 export const toRelativePath = (path: string) => `./${path}`

--- a/apps/mudita-center-e2e/src/test-filenames/consts/test-filenames.const.ts
+++ b/apps/mudita-center-e2e/src/test-filenames/consts/test-filenames.const.ts
@@ -39,6 +39,6 @@ export enum TestFilesPaths {
   kompaktContactsViewingEmpty = "src/specs/overview/kompakt-contacts-viewing-empty.ts",
   kompaktContactsDeleteDetails = "src/specs/overview/kompakt-contacts-delete-details.ts",
   kompaktContactsDelete = "src/specs/overview/kompakt-contacts-delete.ts",
-  kompaktContactsViewingDetails = "src/specs/overview/kompakt-contacts-viewing-details.ts.ts",
+  kompaktContactsViewingDetails = "src/specs/overview/kompakt-contacts-viewing-details.ts",
 }
 export const toRelativePath = (path: string) => `./${path}`

--- a/apps/mudita-center-e2e/wdio.conf.ts
+++ b/apps/mudita-center-e2e/wdio.conf.ts
@@ -88,6 +88,7 @@ export const config: Options.Testrunner = {
     toRelativePath(TestFilesPaths.kompaktContactsViewingEmpty),
     toRelativePath(TestFilesPaths.kompaktContactsDeleteDetails),
     toRelativePath(TestFilesPaths.kompaktContactsDelete),
+    toRelativePath(TestFilesPaths.kompaktContactsViewingDetails),
   ],
   suites: {
     standalone: [
@@ -125,6 +126,7 @@ export const config: Options.Testrunner = {
       toRelativePath(TestFilesPaths.kompaktContactsViewingEmpty),
       toRelativePath(TestFilesPaths.kompaktContactsDeleteDetails),
       toRelativePath(TestFilesPaths.kompaktContactsDelete),
+      toRelativePath(TestFilesPaths.kompaktContactsViewingDetails),
     ],
     multidevicePureHarmony: [],
     multideviceSingleHarmony: [],
@@ -170,6 +172,7 @@ export const config: Options.Testrunner = {
       toRelativePath(TestFilesPaths.kompaktContactsViewingEmpty),
       toRelativePath(TestFilesPaths.kompaktContactsDeleteDetails),
       toRelativePath(TestFilesPaths.kompaktContactsDelete),
+      toRelativePath(TestFilesPaths.kompaktContactsViewingDetails),
     ],
   },
   // Patterns to exclude.


### PR DESCRIPTION
…s-viewing.ts test, added few selectors to fill

JIRA Reference: [CP-3174]

### :memo: Description ️

-Mock and Connect Kompakt with 10 contacts

Open One of the contacts on the Contacts Tab list

Check completed contact details

Close contact details page

Long contact names end with elipsis

If the contact details are expanded, the phone number columns are not visible.

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-3174]: https://appnroll.atlassian.net/browse/CP-3174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ