### PR TITLE
CP-3480 fixed the locators for failing tests

### DIFF
--- a/apps/mudita-center-e2e/src/page-objects/contacts-kompakt.ts
+++ b/apps/mudita-center-e2e/src/page-objects/contacts-kompakt.ts
@@ -11,7 +11,7 @@ class ContactsKompaktPage extends Page {
   }
 
   public get importContactsSubtext() {
-    return $('//p[@data-testid="ui-typography-p1"]')
+    return $('//p[@data-testid="ui-typography-p1-emptyStateDetailText"]')
   }
 
   public get importContactsButton() {
@@ -42,7 +42,7 @@ class ContactsKompaktPage extends Page {
   }
 
   public get contactSelectedBar() {
-    return $('//*[@data-testid="ui-typography-p4"]')
+    return $('//*[@data-testid="ui-typography-p4-selectedContactsCounter"]')
   }
 
   public get contactSelectedDeleteButton() {
@@ -70,7 +70,13 @@ class ContactsKompaktPage extends Page {
 
   public get contactDeleteModalText() {
     return $(
-      '//p[@data-testid="ui-typography-p1" and text()="This can\'t be undone so please make a copy of any important information first."]'
+      '//p[@data-testid="ui-typography-p1-globalDeleteModalContent" and text()="This can\'t be undone so please make a copy of any important information first."]'
+    )
+  }
+
+  public get contactDeleteDetailsModalText() {
+    return $(
+      '//p[@data-testid="ui-typography-p1-detailsDeleteModalContent" and text()="This can\'t be undone so please make a copy of any important information first."]'
     )
   }
 
@@ -108,7 +114,7 @@ class ContactsKompaktPage extends Page {
       $(
         `(//*[@data-testid="ui-table-row"])[${
           rowIndex + 1
-        }]//td[2]//p[@data-testid="ui-typography-p1"]`
+        }]//td[2]//p[@data-testid="ui-typography-p1-contactDisplayName"]`
       )
   }
 

--- a/apps/mudita-center-e2e/src/specs/overview/kompakt-contacts-delete-details.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/kompakt-contacts-delete-details.ts
@@ -68,8 +68,9 @@ describe("E2E mock sample - overview view", () => {
     const contactDeleteModalTitle = ContactsKompaktPage.contactDeleteModalTitle
     await expect(contactDeleteModalTitle).toHaveText("Delete contact?")
 
-    const contactDeleteModalText = ContactsKompaktPage.contactDeleteModalText
-    await expect(contactDeleteModalText).toHaveText(
+    const contactDeleteDetailsModalText =
+      ContactsKompaktPage.contactDeleteDetailsModalText
+    await expect(contactDeleteDetailsModalText).toHaveText(
       "This can't be undone so please make a copy of any important information first."
     )
   })


### PR DESCRIPTION
JIRA Reference: [CP-3480]

### :memo: Description ️

-fix locator for contacts details, contacts list, contacts delete, contacts details delete 

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated
