### PR TITLE
[CP-2922] [API Device][Multidevice] Connecting 2nd Kompakt while in News

### DIFF
--- a/apps/mudita-center-e2e/src/specs/overview/kompakt-connecting-2nd-kompakt-while-in-news.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/kompakt-connecting-2nd-kompakt-while-in-news.ts
@@ -1,0 +1,121 @@
+import { E2EMockClient } from "../../../../../libs/e2e-mock/client/src"
+import {
+  overviewDataWithOneSimCard,
+  overviewDataWithOneSimCard2nd,
+} from "../../../../../libs/e2e-mock/responses/src"
+import OverviewKompaktPage from "../../page-objects/overview-kompakt.page"
+import HomePage from "../../page-objects/home.page"
+import { kompaktImageRegex } from "../../consts/regex-const"
+import overviewPage from "../../page-objects/overview.page"
+import drawerPage from "../../page-objects/drawer.page"
+
+describe("Kompakt switching devices", () => {
+  const firstSerialNumber = "KOM1234567890"
+  const secondSerialNumber = "KOM1234567892"
+
+  before(async () => {
+    E2EMockClient.connect()
+    //wait for a connection to be established
+    await browser.waitUntil(() => {
+      return E2EMockClient.checkConnection()
+    })
+  })
+
+  after(() => {
+    E2EMockClient.stopServer()
+    E2EMockClient.disconnect()
+  })
+
+  it("Connect device", async () => {
+    E2EMockClient.mockResponses([
+      {
+        path: "path-1",
+        body: overviewDataWithOneSimCard,
+        endpoint: "FEATURE_DATA",
+        method: "GET",
+        status: 200,
+      },
+    ])
+    E2EMockClient.addDevice({
+      path: "path-1",
+      serialNumber: firstSerialNumber,
+    })
+
+    await browser.pause(6000)
+    const menuItem = await $(`//a[@href="#/generic/mc-overview"]`)
+
+    await menuItem.waitForDisplayed({ timeout: 10000 })
+    await expect(menuItem).toBeDisplayed()
+  })
+
+  it("Verify Overview Page", async () => {
+    const kompaktImage = await OverviewKompaktPage.kompaktImage
+    await expect(kompaktImage).toBeDisplayed()
+    await expect(kompaktImage).toHaveAttribute("src", kompaktImageRegex)
+
+    const kompaktOsVersion = await OverviewKompaktPage.kompaktOsVersion
+    await expect(kompaktOsVersion).toBeDisplayed()
+
+    const kompaktSimCard1Subtext =
+      await OverviewKompaktPage.kompaktSimCard1Subtext
+    await expect(kompaktSimCard1Subtext).toHaveText("SIM 1")
+
+    const kompaktNetworkName = await OverviewKompaktPage.kompaktNetworkName
+    await expect(kompaktNetworkName).toBeDisplayed()
+    await expect(kompaktNetworkName).toHaveText("T-Mobile")
+
+    const kompaktBatteryLevelValue =
+      await OverviewKompaktPage.kompaktBatteryLevelValue
+    await expect(kompaktBatteryLevelValue).toBeDisplayed()
+    await expect(kompaktBatteryLevelValue).toHaveText("100%")
+  })
+
+  it("Connect 2nd device", async () => {
+    E2EMockClient.mockResponses([
+      {
+        path: "path-2",
+        body: overviewDataWithOneSimCard2nd,
+        endpoint: "FEATURE_DATA",
+        method: "GET",
+        status: 200,
+      },
+    ])
+    E2EMockClient.addDevice({
+      path: "path-2",
+      serialNumber: secondSerialNumber,
+    })
+
+    await browser.pause(6000)
+  })
+
+  it("Switch to 2nd device", async () => {
+    const secondDeviceOnDrawer = await drawerPage.getDeviceOnDrawer(
+      secondSerialNumber
+    )
+    await expect(secondDeviceOnDrawer).toBeDisplayed()
+    await secondDeviceOnDrawer.waitForClickable()
+    await secondDeviceOnDrawer.click()
+  })
+
+  it("Verify Overview Page for 2nd device", async () => {
+    const kompaktImage = await OverviewKompaktPage.kompaktImage
+    await expect(kompaktImage).toBeDisplayed()
+    await expect(kompaktImage).toHaveAttribute("src", kompaktImageRegex)
+
+    const kompaktOsVersion = await OverviewKompaktPage.kompaktOsVersion
+    await expect(kompaktOsVersion).toBeDisplayed()
+
+    const kompaktSimCard1Subtext =
+      await OverviewKompaktPage.kompaktSimCard1Subtext
+    await expect(kompaktSimCard1Subtext).toHaveText("SIM 1")
+
+    const kompaktNetworkName = await OverviewKompaktPage.kompaktNetworkName
+    await expect(kompaktNetworkName).toBeDisplayed()
+    await expect(kompaktNetworkName).toHaveText("Play")
+
+    const kompaktBatteryLevelValue =
+      await OverviewKompaktPage.kompaktBatteryLevelValue
+    await expect(kompaktBatteryLevelValue).toBeDisplayed()
+    await expect(kompaktBatteryLevelValue).toHaveText("40%")
+  })
+})

--- a/apps/mudita-center-e2e/src/specs/overview/kompakt-connecting-second-kompakt-while-in-news.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/kompakt-connecting-second-kompakt-while-in-news.ts
@@ -6,8 +6,8 @@ import {
 import OverviewKompaktPage from "../../page-objects/overview-kompakt.page"
 import HomePage from "../../page-objects/home.page"
 import { kompaktImageRegex } from "../../consts/regex-const"
-import overviewPage from "../../page-objects/overview.page"
 import drawerPage from "../../page-objects/drawer.page"
+import tabsPage from "../../page-objects/tabs.page"
 
 describe("Kompakt switching devices", () => {
   const firstSerialNumber = "KOM1234567890"
@@ -68,6 +68,11 @@ describe("Kompakt switching devices", () => {
       await OverviewKompaktPage.kompaktBatteryLevelValue
     await expect(kompaktBatteryLevelValue).toBeDisplayed()
     await expect(kompaktBatteryLevelValue).toHaveText("100%")
+  })
+
+  it("Open News tab", async () => {
+    const muditaNewsTab = tabsPage.muditaNewsTab
+    await muditaNewsTab.click()
   })
 
   it("Connect 2nd device", async () => {

--- a/apps/mudita-center-e2e/src/specs/overview/kompakt-connecting-second-kompakt-while-in-news.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/kompakt-connecting-second-kompakt-while-in-news.ts
@@ -123,4 +123,13 @@ describe("Kompakt switching devices", () => {
     await expect(kompaktBatteryLevelValue).toBeDisplayed()
     await expect(kompaktBatteryLevelValue).toHaveText("40%")
   })
+
+  it("Disconnect the devices and check if Home page is present", async () => {
+    E2EMockClient.removeDevice("path-1")
+    E2EMockClient.removeDevice("path-2")
+
+    const homeHeader = await HomePage.homeHeader
+    await homeHeader.waitForDisplayed()
+    await expect(homeHeader).toHaveText("Welcome to Mudita Center")
+  })
 })

--- a/apps/mudita-center-e2e/src/test-filenames/consts/test-filenames.const.ts
+++ b/apps/mudita-center-e2e/src/test-filenames/consts/test-filenames.const.ts
@@ -41,5 +41,6 @@ export enum TestFilesPaths {
   kompaktContactsDelete = "src/specs/overview/kompakt-contacts-delete.ts",
   kompaktContactsViewingDetails = "src/specs/overview/kompakt-contacts-viewing-details.ts",
   kompaktContactsSearch = "src/specs/overview/kompakt-contacts-search.ts",
+  kompaktConnectingSecondKompaktWhileInNews = "src/specs/overview/kompakt-connecting-second-kompakt-while-in-news.ts",
 }
 export const toRelativePath = (path: string) => `./${path}`

--- a/apps/mudita-center-e2e/wdio.conf.ts
+++ b/apps/mudita-center-e2e/wdio.conf.ts
@@ -90,6 +90,7 @@ export const config: Options.Testrunner = {
     toRelativePath(TestFilesPaths.kompaktContactsDelete),
     toRelativePath(TestFilesPaths.kompaktContactsViewingDetails),
     toRelativePath(TestFilesPaths.kompaktContactsSearch),
+    toRelativePath(TestFilesPaths.kompaktConnectingSecondKompaktWhileInNews),
   ],
   suites: {
     standalone: [
@@ -129,6 +130,7 @@ export const config: Options.Testrunner = {
       toRelativePath(TestFilesPaths.kompaktContactsDelete),
       toRelativePath(TestFilesPaths.kompaktContactsViewingDetails),
       toRelativePath(TestFilesPaths.kompaktContactsSearch),
+      toRelativePath(TestFilesPaths.kompaktConnectingSecondKompaktWhileInNews),
     ],
     multidevicePureHarmony: [],
     multideviceSingleHarmony: [],
@@ -176,6 +178,7 @@ export const config: Options.Testrunner = {
       toRelativePath(TestFilesPaths.kompaktContactsDelete),
       toRelativePath(TestFilesPaths.kompaktContactsViewingDetails),
       toRelativePath(TestFilesPaths.kompaktContactsSearch),
+      toRelativePath(TestFilesPaths.kompaktConnectingSecondKompaktWhileInNews),
     ],
   },
   // Patterns to exclude.


### PR DESCRIPTION
JIRA Reference: [CP-2922]

### :memo: Description ️

- Open App

Connect 1st Kompakt

Verify Overview Page 

Click News tab

Connect 2nd Kompakt

Click 2nd Kompakt

Overview should show up. Verify

Disconnect any devices

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2922]: https://appnroll.atlassian.net/browse/CP-2922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ