### PR TITLE
[CP-2752] Added tests ids to api device unlock modal

### DIFF
--- a/libs/core/device-initialization/components/devices-initialization-modal-flows/api-device-initialization-modal-flow.tsx
+++ b/libs/core/device-initialization/components/devices-initialization-modal-flows/api-device-initialization-modal-flow.tsx
@@ -37,6 +37,7 @@ import {
 import { setDeviceInitializationStatus } from "Core/device-initialization/actions/base.action"
 import { DeviceInitializationStatus } from "Core/device-initialization/reducers/device-initialization.interface"
 import { ButtonAction } from "generic-view/models"
+import { ApiDeviceLockedModalTestIds } from "e2e-test-ids"
 
 const messages = defineMessages({
   lockedModalHeadline: {
@@ -82,7 +83,12 @@ export const APIDeviceInitializationModalFlow: FunctionComponent = () => {
       return "/generic/mc-data-migration"
     }
     return firstMenuItemUrl
-  }, [dataMigrationSourceDevice, dataMigrationTargetDevice, menuElements, pathToGoBack])
+  }, [
+    dataMigrationSourceDevice,
+    dataMigrationTargetDevice,
+    menuElements,
+    pathToGoBack,
+  ])
 
   const onModalClose = useCallback(async () => {
     if (pathToGoBack === URL_MAIN.dataMigration && dataMigrationSourceDevice) {
@@ -138,10 +144,14 @@ export const APIDeviceInitializationModalFlow: FunctionComponent = () => {
           }}
         >
           <Modal.TitleIcon config={{ type: IconType.Mudita }} />
-          <Modal.Title>
+          <Modal.Title
+            data-testid={ApiDeviceLockedModalTestIds.LockedModalHeadline}
+          >
             {intl.formatMessage(messages.lockedModalHeadline)}
           </Modal.Title>
-          <p>{intl.formatMessage(messages.lockedModalParagraph)}</p>
+          <p data-testid={ApiDeviceLockedModalTestIds.LockedModalParagraph}>
+            {intl.formatMessage(messages.lockedModalParagraph)}
+          </p>
         </Modal>
       </Wrapper>
     </GenericThemeProvider>

--- a/libs/e2e-test-ids/src/e2e-test-ids.ts
+++ b/libs/e2e-test-ids/src/e2e-test-ids.ts
@@ -99,3 +99,8 @@ export enum NewContactSupportModalTestIds {
   AttachedFilesLabel = "attached-files-label",
   AttachedFilesSubtext = "attached-files-subtext",
 }
+
+export enum ApiDeviceLockedModalTestIds {
+  LockedModalHeadline = "device-locked-modal-headline",
+  LockedModalParagraph = "device-locked-modal-paragraph",
+}


### PR DESCRIPTION
JIRA Reference: [CP-2752]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2752]: https://appnroll.atlassian.net/browse/CP-2752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ