### PR TITLE
[CP-2752] [API Device][Kompakt] Passcode - Close modal without providing a password

### DIFF
--- a/apps/mudita-center-e2e/src/page-objects/locked-page-kompakt.ts
+++ b/apps/mudita-center-e2e/src/page-objects/locked-page-kompakt.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Mudita sp. z o.o. All rights reserved.
+ * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
+ */
+
+import Page from "./page"
+
+export class LockedPageKompakt extends Page {
+  public get passcodeModal() {
+    return $('//div[@data-testid="modal-content-device-initialization"]')
+  }
+
+  public get passcodeModalHeader() {
+    return $('//div[@data-testid="modal-content-device-initialization"]//h1')
+  }
+
+  public get passcodeModalSubtext() {
+    return $('//div[@data-testid="modal-content-device-initialization"]//p')
+  }
+
+  public get closePasscodeModalButton() {
+    return $('//div[@data-testid="icon-close"]')
+  }
+}
+
+export default new LockedPageKompakt()

--- a/apps/mudita-center-e2e/src/specs/overview/kompakt-passcode-close.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/kompakt-passcode-close.ts
@@ -1,0 +1,93 @@
+import { E2EMockClient } from "../../../../../libs/e2e-mock/client/src"
+import { passcodeLockedKompakt } from "../../../../../libs/e2e-mock/responses/src"
+import { overviewDataWithOneSimCard2nd } from "../../../../../libs/e2e-mock/responses/src"
+import LockedPageKompakt from "../../page-objects/locked-page-kompakt"
+import NewsPage from "../../page-objects/news.page"
+import HomePage from "../../page-objects/home.page"
+
+describe("Kompakt passcode close", () => {
+  const firstSerialNumber = "KOM1234567890"
+  const secondSerialNumber = "KOM1234567891"
+
+  before(async () => {
+    E2EMockClient.connect()
+    //wait for a connection to be established
+    await browser.waitUntil(() => {
+      return E2EMockClient.checkConnection()
+    })
+  })
+
+  after(() => {
+    E2EMockClient.stopServer()
+    E2EMockClient.disconnect()
+  })
+
+  it("Connect locked device and check welcome screen", async () => {
+    E2EMockClient.mockResponses([
+      {
+        path: "path-1",
+        body: passcodeLockedKompakt,
+        endpoint: "MENU_CONFIGURATION", //needed for testing locked status
+        method: "GET",
+        status: 423, //needed for testing locked status
+      },
+    ])
+    E2EMockClient.addDevice({
+      path: "path-1",
+      serialNumber: firstSerialNumber,
+    })
+
+    await browser.pause(6000)
+  })
+
+  it("Check passcode locked modal", async () => {
+    const passcodeModal = LockedPageKompakt.passcodeModal
+    await expect(passcodeModal).toBeDisplayed()
+    const passcodeModalHeader = LockedPageKompakt.passcodeModalHeader
+    await expect(passcodeModalHeader).toHaveText("Unlock your phone")
+    const passcodeModalSubtext = LockedPageKompakt.passcodeModalSubtext
+    await expect(passcodeModalSubtext).toHaveText(
+      "Enter your passcode or scan your fingerprint"
+    )
+  })
+
+  it("Close passcode locked modal", async () => {
+    const closePasscodeModalButton = LockedPageKompakt.closePasscodeModalButton
+    await closePasscodeModalButton.click()
+  })
+
+  it("Check if passcode locked modal is gone", async () => {
+    const passcodeModal = LockedPageKompakt.passcodeModal
+    await expect(passcodeModal).not.toBeDisplayed()
+  })
+
+  it("Check if News page is opened", async () => {
+    const newsHeader = await NewsPage.newsHeader
+    await expect(newsHeader).toHaveText("Mudita News")
+  })
+
+  it("Connect 2nd locked device", async () => {
+    E2EMockClient.mockResponses([
+      {
+        path: "path-2",
+        body: overviewDataWithOneSimCard2nd,
+        endpoint: "MENU_CONFIGURATION",
+        method: "GET",
+        status: 423,
+      },
+    ])
+    E2EMockClient.addDevice({
+      path: "path-2",
+      serialNumber: secondSerialNumber,
+    })
+
+    await browser.pause(3000)
+  })
+  it("Disconnect the devices and check if News page is still present", async () => {
+    E2EMockClient.removeDevice("path-1")
+    E2EMockClient.removeDevice("path-2")
+
+    const newsHeader = await NewsPage.newsHeader
+    await expect(newsHeader).toHaveText("Mudita News")
+  })
+})

--- a/apps/mudita-center-e2e/src/test-filenames/consts/test-filenames.const.ts
+++ b/apps/mudita-center-e2e/src/test-filenames/consts/test-filenames.const.ts
@@ -42,5 +42,6 @@ export enum TestFilesPaths {
   kompaktContactsViewingDetails = "src/specs/overview/kompakt-contacts-viewing-details.ts",
   kompaktContactsSearch = "src/specs/overview/kompakt-contacts-search.ts",
   kompaktConnectingSecondKompaktWhileInNews = "src/specs/overview/kompakt-connecting-second-kompakt-while-in-news.ts",
+  kompaktPasscodeClose = "src/specs/overview/kompakt-passcode-close.ts",
 }
 export const toRelativePath = (path: string) => `./${path}`

--- a/apps/mudita-center-e2e/wdio.conf.ts
+++ b/apps/mudita-center-e2e/wdio.conf.ts
@@ -91,6 +91,7 @@ export const config: Options.Testrunner = {
     toRelativePath(TestFilesPaths.kompaktContactsViewingDetails),
     toRelativePath(TestFilesPaths.kompaktContactsSearch),
     toRelativePath(TestFilesPaths.kompaktConnectingSecondKompaktWhileInNews),
+    toRelativePath(TestFilesPaths.kompaktPasscodeClose),
   ],
   suites: {
     standalone: [
@@ -131,6 +132,7 @@ export const config: Options.Testrunner = {
       toRelativePath(TestFilesPaths.kompaktContactsViewingDetails),
       toRelativePath(TestFilesPaths.kompaktContactsSearch),
       toRelativePath(TestFilesPaths.kompaktConnectingSecondKompaktWhileInNews),
+      toRelativePath(TestFilesPaths.kompaktPasscodeClose),
     ],
     multidevicePureHarmony: [],
     multideviceSingleHarmony: [],
@@ -179,6 +181,7 @@ export const config: Options.Testrunner = {
       toRelativePath(TestFilesPaths.kompaktContactsViewingDetails),
       toRelativePath(TestFilesPaths.kompaktContactsSearch),
       toRelativePath(TestFilesPaths.kompaktConnectingSecondKompaktWhileInNews),
+      toRelativePath(TestFilesPaths.kompaktPasscodeClose),
     ],
   },
   // Patterns to exclude.

--- a/libs/e2e-mock/responses/src/lib/overview-responses.ts
+++ b/libs/e2e-mock/responses/src/lib/overview-responses.ts
@@ -41,6 +41,7 @@ export const overviewDataWithoutBadge = {
     },
   },
 }
+export const passcodeLockedKompakt = {}
 
 export const overviewDataWithOneSimCard = {
   summary: {


### PR DESCRIPTION
…cts)

JIRA Reference: [CP-2752]

### :memo: Description ️

- Open App

Homescreen (Onboarding screen) should show up

Wait until Overview screen loads

Popup about password should show up

Close modal without providing a password, Kompakt password screen should “disconnect” (dissapear)

Actual Behavior: NEWS        news page is opened after closing passcode modal, as on mockdevice we need to connect the 2nd device to trigger connection, we add a 2nd device to the test (also passcode locked) and news page is still displayed and 2 devices connected are displayed on the connected devices button    (as user has closed passcode modal, then it suggests MC that user is not interested in viewing device options now so we don’t interrupt with select device modal after connecting second device)*

Previously Expected: Verify you are back on homescreen (onboarding) and screen is not empty  no action in this test*

Expected from [CP-3114](https://appnroll.atlassian.net/browse/CP-3114) - If they have a locked device (Kompakt) -> unlocks go to Overview. Don't unlock and close pop up -> select modal  no action in this test*

Disconnect the device

Verify you are on homescreen

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-2752]: https://appnroll.atlassian.net/browse/CP-2752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-3114]: https://appnroll.atlassian.net/browse/CP-3114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ