### PR TITLE
[CP-3178] - [API Device][Kompakt] Disconnecting the device during cre…

### DIFF
--- a/apps/mudita-center-e2e/src/specs/overview/kompakt-disconnect-during-backup.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/kompakt-disconnect-during-backup.ts
@@ -1,0 +1,75 @@
+import { E2EMockClient } from "../../../../../libs/e2e-mock/client/src"
+import {
+  overviewConfigForBackup,
+  overviewDataWithOneSimCard,
+} from "../../../../../libs/e2e-mock/responses/src"
+import ModalBackupKompaktPage from "../../page-objects/modal-backup-kompakt.page"
+import { mockPreBackupResponses } from "../../helpers/mock-prebackup"
+
+describe("Disconnect during backup", () => {
+  before(async () => {
+    E2EMockClient.connect()
+    //wait for a connection to be established
+    await browser.waitUntil(() => {
+      return E2EMockClient.checkConnection()
+    })
+  })
+
+  after(() => {
+    E2EMockClient.stopServer()
+    E2EMockClient.disconnect()
+  })
+
+  it("Connect device", async () => {
+    E2EMockClient.mockResponses([
+      {
+        path: "path-1",
+        body: overviewConfigForBackup,
+        endpoint: "FEATURE_CONFIGURATION",
+        method: "GET",
+        status: 200,
+      },
+      {
+        path: "path-1",
+        body: overviewDataWithOneSimCard,
+        endpoint: "FEATURE_DATA",
+        method: "GET",
+        status: 200,
+      },
+    ])
+    E2EMockClient.addDevice({
+      path: "path-1",
+      serialNumber: "first-serial-number",
+    })
+
+    await browser.pause(6000)
+    const menuItem = await $(`//a[@href="#/generic/mc-overview"]`)
+
+    await menuItem.waitForDisplayed({ timeout: 10000 })
+    await expect(menuItem).toBeDisplayed()
+  })
+
+  it("Mock prebackup, wait for Overview Page and click Create Backup", async () => {
+    mockPreBackupResponses("path-1")
+    const createBackupButton = await ModalBackupKompaktPage.createBackupButton
+    await expect(createBackupButton).toBeDisplayed()
+    await expect(createBackupButton).toBeClickable()
+    await createBackupButton.click()
+  })
+
+  it("Click Create backup and click skip password to start backup", async () => {
+    const createBackupProceedNext =
+      await ModalBackupKompaktPage.createBackupProceedNext
+    await expect(createBackupProceedNext).toBeClickable()
+    await createBackupProceedNext.click()
+
+    const createBackupPasswordSkip =
+      await ModalBackupKompaktPage.createBackupPasswordSkip
+    await createBackupPasswordSkip.click()
+    await browser.pause(2000) // wait for animation to load from 0% to10%
+  })
+
+  it("Disconnect the device while backup is in progress", async () => {
+    E2EMockClient.removeDevice("path-1")
+  })
+})

--- a/apps/mudita-center-e2e/src/specs/overview/kompakt-disconnect-during-backup.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/kompakt-disconnect-during-backup.ts
@@ -78,5 +78,6 @@ describe("Disconnect during backup", () => {
     const homeHeader = await HomePage.homeHeader
     await homeHeader.waitForDisplayed()
     await expect(homeHeader).toHaveText("Welcome to Mudita Center")
+    await browser.pause(500)
   })
 })

--- a/apps/mudita-center-e2e/src/specs/overview/kompakt-disconnect-during-backup.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/kompakt-disconnect-during-backup.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../../../libs/e2e-mock/responses/src"
 import ModalBackupKompaktPage from "../../page-objects/modal-backup-kompakt.page"
 import { mockPreBackupResponses } from "../../helpers/mock-prebackup"
+import HomePage from "../../page-objects/home.page"
 
 describe("Disconnect during backup", () => {
   before(async () => {
@@ -71,5 +72,11 @@ describe("Disconnect during backup", () => {
 
   it("Disconnect the device while backup is in progress", async () => {
     E2EMockClient.removeDevice("path-1")
+  })
+
+  it("Check if Home page is present", async () => {
+    const homeHeader = await HomePage.homeHeader
+    await homeHeader.waitForDisplayed()
+    await expect(homeHeader).toHaveText("Welcome to Mudita Center")
   })
 })

--- a/apps/mudita-center-e2e/src/specs/overview/kompakt-passcode-close.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/kompakt-passcode-close.ts
@@ -3,7 +3,6 @@ import { passcodeLockedKompakt } from "../../../../../libs/e2e-mock/responses/sr
 import { overviewDataWithOneSimCard2nd } from "../../../../../libs/e2e-mock/responses/src"
 import LockedPageKompakt from "../../page-objects/locked-page-kompakt"
 import NewsPage from "../../page-objects/news.page"
-import HomePage from "../../page-objects/home.page"
 
 describe("Kompakt passcode close", () => {
   const firstSerialNumber = "KOM1234567890"

--- a/apps/mudita-center-e2e/src/test-filenames/consts/test-filenames.const.ts
+++ b/apps/mudita-center-e2e/src/test-filenames/consts/test-filenames.const.ts
@@ -43,5 +43,6 @@ export enum TestFilesPaths {
   kompaktContactsSearch = "src/specs/overview/kompakt-contacts-search.ts",
   kompaktConnectingSecondKompaktWhileInNews = "src/specs/overview/kompakt-connecting-second-kompakt-while-in-news.ts",
   kompaktPasscodeClose = "src/specs/overview/kompakt-passcode-close.ts",
+  kompaktDisconnectDuringBackup = "src/specs/overview/kompakt-disconnect-during-backup.ts",
 }
 export const toRelativePath = (path: string) => `./${path}`

--- a/apps/mudita-center-e2e/wdio.conf.ts
+++ b/apps/mudita-center-e2e/wdio.conf.ts
@@ -92,6 +92,7 @@ export const config: Options.Testrunner = {
     toRelativePath(TestFilesPaths.kompaktContactsSearch),
     toRelativePath(TestFilesPaths.kompaktConnectingSecondKompaktWhileInNews),
     toRelativePath(TestFilesPaths.kompaktPasscodeClose),
+    toRelativePath(TestFilesPaths.kompaktDisconnectDuringBackup),
   ],
   suites: {
     standalone: [
@@ -133,6 +134,7 @@ export const config: Options.Testrunner = {
       toRelativePath(TestFilesPaths.kompaktContactsSearch),
       toRelativePath(TestFilesPaths.kompaktConnectingSecondKompaktWhileInNews),
       toRelativePath(TestFilesPaths.kompaktPasscodeClose),
+      toRelativePath(TestFilesPaths.kompaktDisconnectDuringBackup),
     ],
     multidevicePureHarmony: [],
     multideviceSingleHarmony: [],
@@ -182,6 +184,7 @@ export const config: Options.Testrunner = {
       toRelativePath(TestFilesPaths.kompaktContactsSearch),
       toRelativePath(TestFilesPaths.kompaktConnectingSecondKompaktWhileInNews),
       toRelativePath(TestFilesPaths.kompaktPasscodeClose),
+      toRelativePath(TestFilesPaths.kompaktDisconnectDuringBackup),
     ],
   },
   // Patterns to exclude.


### PR DESCRIPTION
…ating backup

JIRA Reference: [CP-3178]

### :memo: Description ️

-Scenario
Mock disconnecting Kompakt while backup process is after PRE_BACKUP (CP-2931: [API Device][Kompakt] Backup - PRE_BACKUP API
Gotowe
) or during FILE_TRANSFER (CP-2932: [API Device][Kompakt] Backup - Retrieving backup files - FILE_TRANSFER
W toku
)
HomePage should show up, verify that

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-3178]: https://appnroll.atlassian.net/browse/CP-3178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ