### PR TITLE
[CP-3180] [API Device][Multidevice] Kompakt Backup - Connection error…

### DIFF
--- a/apps/mudita-center-e2e/src/page-objects/modal-backup-kompakt.page.ts
+++ b/apps/mudita-center-e2e/src/page-objects/modal-backup-kompakt.page.ts
@@ -125,5 +125,25 @@ class ModalBackupKompaktPage extends OverviewPage {
   public get backupCanceledSubTitle() {
     return $('//p[text()="No changes were made."]')
   }
+
+  public get backupFailureIcon() {
+    return $('//*[@data-testid="icon-failure"]')
+  }
+
+  public get backupFailedModal() {
+    return $('//*[@data-testid="modal-content-backup-error-modal"]')
+  }
+
+  public get backupFailedTitle() {
+    return $('//h1[text()="Backup failed"]')
+  }
+
+  public get backupDisconnectedSubTitle() {
+    return $('//p[text()="The backup process was interrupted."]')
+  }
+
+  public get backupFailedModalCloseButton() {
+    return $('//*[@data-testid="primary-button-undefined"]')
+  }
 }
 export default new ModalBackupKompaktPage()

--- a/apps/mudita-center-e2e/src/page-objects/modal-backup-kompakt.page.ts
+++ b/apps/mudita-center-e2e/src/page-objects/modal-backup-kompakt.page.ts
@@ -113,5 +113,17 @@ class ModalBackupKompaktPage extends OverviewPage {
   public get creatingBackupProgressBarDetails() {
     return $(`//*[@data-testid="${ProgressBarTestIds.Details}"]`)
   }
+
+  public get backupInProgressModalCancelled() {
+    return $('//*[@data-testid="modal-content-backupbackup-create"]')
+  }
+
+  public get backupCanceledTitle() {
+    return $('//h1[text()="Backup canceled"]')
+  }
+
+  public get backupCanceledSubTitle() {
+    return $('//p[text()="No changes were made."]')
+  }
 }
 export default new ModalBackupKompaktPage()

--- a/apps/mudita-center-e2e/src/specs/overview/kompakt-backup-error-cancel.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/kompakt-backup-error-cancel.ts
@@ -1,0 +1,101 @@
+import { E2EMockClient } from "../../../../../libs/e2e-mock/client/src"
+import {
+  overviewConfigForBackup,
+  overviewDataWithOneSimCard,
+} from "../../../../../libs/e2e-mock/responses/src"
+import ModalBackupKompaktPage from "../../page-objects/modal-backup-kompakt.page"
+import { mockPreBackupResponses } from "../../helpers/mock-prebackup"
+import OverviewKompaktPage from "../../page-objects/overview-kompakt.page"
+
+describe("Backup error - cancel", () => {
+  before(async () => {
+    E2EMockClient.connect()
+    //wait for a connection to be established
+    await browser.waitUntil(() => {
+      return E2EMockClient.checkConnection()
+    })
+  })
+
+  after(() => {
+    E2EMockClient.stopServer()
+    E2EMockClient.disconnect()
+  })
+
+  it("Connect device", async () => {
+    E2EMockClient.mockResponses([
+      {
+        path: "path-1",
+        body: overviewConfigForBackup,
+        endpoint: "FEATURE_CONFIGURATION",
+        method: "GET",
+        status: 200,
+      },
+      {
+        path: "path-1",
+        body: overviewDataWithOneSimCard,
+        endpoint: "FEATURE_DATA",
+        method: "GET",
+        status: 200,
+      },
+    ])
+    E2EMockClient.addDevice({
+      path: "path-1",
+      serialNumber: "first-serial-number",
+    })
+
+    await browser.pause(6000)
+    const menuItem = await $(`//a[@href="#/generic/mc-overview"]`)
+
+    await menuItem.waitForDisplayed({ timeout: 10000 })
+    await expect(menuItem).toBeDisplayed()
+  })
+
+  it("Mock prebackup, wait for Overview Page and click Create Backup", async () => {
+    mockPreBackupResponses("path-1")
+    const createBackupButton = await ModalBackupKompaktPage.createBackupButton
+    await expect(createBackupButton).toBeDisplayed()
+    await expect(createBackupButton).toBeClickable()
+    await createBackupButton.click()
+  })
+
+  it("Click Create backup and click skip password to start backup and cancel it", async () => {
+    const createBackupProceedNext =
+      await ModalBackupKompaktPage.createBackupProceedNext
+    await expect(createBackupProceedNext).toBeClickable()
+    await createBackupProceedNext.click()
+
+    const createBackupPasswordSkip =
+      await ModalBackupKompaktPage.createBackupPasswordSkip
+    await createBackupPasswordSkip.click()
+    await browser.pause(2000) // wait for animation to load from 0% to10%
+
+    const backupModalClose = ModalBackupKompaktPage.backupModalClose
+    await expect(backupModalClose).toBeDisplayed()
+    await backupModalClose.click() //click "X" button to cancel backup popup
+  })
+
+  it("Verify Backup cancelled modal", async () => {
+    const backupInProgressModalCancelled =
+      ModalBackupKompaktPage.backupInProgressModalCancelled
+    await expect(backupInProgressModalCancelled).toBeDisplayed()
+
+    const backupFailureIcon = ModalBackupKompaktPage.backupFailureIcon
+    await expect(backupFailureIcon).toBeDisplayed()
+
+    const backupCanceledTitle = ModalBackupKompaktPage.backupCanceledTitle
+    await expect(backupCanceledTitle).toHaveText("Backup canceled")
+
+    const backupCanceledSubTitle = ModalBackupKompaktPage.backupCanceledSubTitle
+    await expect(backupCanceledSubTitle).toHaveText("No changes were made.")
+  })
+
+  it("Close backup cancelled modal and if overview page is still displayed", async () => {
+    const backupFailedModalCloseButton =
+      ModalBackupKompaktPage.backupFailedModalCloseButton
+    await backupFailedModalCloseButton.click()
+
+    //check if kompakt image is displayed to assure you are on Overview page (the cancelled backup popup is closed)
+    const kompaktImage = await OverviewKompaktPage.kompaktImage
+    await expect(kompaktImage).toBeDisplayed()
+  })
+})

--- a/apps/mudita-center-e2e/src/specs/overview/kompakt-backup-error-disconnect.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/kompakt-backup-error-disconnect.ts
@@ -5,9 +5,9 @@ import {
 } from "../../../../../libs/e2e-mock/responses/src"
 import ModalBackupKompaktPage from "../../page-objects/modal-backup-kompakt.page"
 import { mockPreBackupResponses } from "../../helpers/mock-prebackup"
-import { BrowserRouter } from "react-router-dom"
+import HomePage from "../../page-objects/home.page"
 
-describe("Backup error test", () => {
+describe("Backup error - disconnect", () => {
   before(async () => {
     E2EMockClient.connect()
     //wait for a connection to be established
@@ -58,7 +58,7 @@ describe("Backup error test", () => {
     await createBackupButton.click()
   })
 
-  it("Click Create backup and click skip password to start backup and cancel it", async () => {
+  it("Click Create backup and click skip password to start backup and disconnect the device", async () => {
     const createBackupProceedNext =
       await ModalBackupKompaktPage.createBackupProceedNext
     await expect(createBackupProceedNext).toBeClickable()
@@ -69,42 +69,34 @@ describe("Backup error test", () => {
     await createBackupPasswordSkip.click()
     await browser.pause(2000) // wait for animation to load from 0% to10%
 
-    const backupModalClose = ModalBackupKompaktPage.backupModalClose
-    await expect(backupModalClose).toBeDisplayed()
-    await backupModalClose.click() //click "X" button to cancel backup popup
+    E2EMockClient.removeDevice("path-1") //disconnect the device
   })
 
-  it("Verify Backup cancelled modal", async () => {
-    const backupInProgressModalCancelled =
-      ModalBackupKompaktPage.backupInProgressModalCancelled
-    await expect(backupInProgressModalCancelled).toBeDisplayed()
+  it("Verify Backup failed modal", async () => {
+    const backupFailedModal = ModalBackupKompaktPage.backupFailedModal
+    await expect(backupFailedModal).toBeDisplayed()
 
-    const backupCanceledTitle = ModalBackupKompaktPage.backupCanceledTitle
-    await expect(backupCanceledTitle).toHaveText("Backup canceled")
+    const backupFailureIcon = ModalBackupKompaktPage.backupFailureIcon
+    await expect(backupFailureIcon).toBeDisplayed()
 
-    const backupCanceledSubTitle = ModalBackupKompaktPage.backupCanceledSubTitle
-    await expect(backupCanceledSubTitle).toHaveText("No changes were made.")
+    const backupFailedTitle = ModalBackupKompaktPage.backupFailedTitle
+    await expect(backupFailedTitle).toHaveText("Backup failed")
+
+    const backupDisconnectedSubTitle =
+      ModalBackupKompaktPage.backupDisconnectedSubTitle
+    await expect(backupDisconnectedSubTitle).toHaveText(
+      "The backup process was interrupted."
+    )
   })
 
-  // it("Verify backup creating modal, check if backup is in progress", async () => {
-  //   const backupInProgressModal =
-  //     await ModalBackupKompaktPage.backupInProgressModal
-  //   await expect(backupInProgressModal).toBeDisplayed()
-  //   await expect(ModalBackupKompaktPage.creatingBackupTitle).toHaveText(
-  //     "Creating backup"
-  //   )
-  //   await expect(ModalBackupKompaktPage.creatingBackupDescription).toHaveText(
-  //     "Please wait and do not unplug your device from computer."
-  //   )
-  //   const creatingBackupProgressBar =
-  //     await ModalBackupKompaktPage.creatingBackupProgressBar
+  it("Close backup failed modal and verify if home screen is present", async () => {
+    const backupFailedModalCloseButton =
+      ModalBackupKompaktPage.backupFailedModalCloseButton
+    await backupFailedModalCloseButton.click()
 
-  //   const creatingBackupProgressBarValue =
-  //     await creatingBackupProgressBar.getAttribute("value")
-  //   expect(creatingBackupProgressBarValue).toBe("10")
-
-  //   const creatingBackupProgressBarDetails =
-  //     await ModalBackupKompaktPage.creatingBackupProgressBarDetails
-  //   await expect(creatingBackupProgressBarDetails).toHaveText("10%")
-  // })
+    //check if home page is displayed
+    const homeHeader = await HomePage.homeHeader
+    await homeHeader.waitForDisplayed()
+    await expect(homeHeader).toHaveText("Welcome to Mudita Center")
+  })
 })

--- a/apps/mudita-center-e2e/src/specs/overview/kompakt-backup-error-disconnect.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/kompakt-backup-error-disconnect.ts
@@ -73,15 +73,19 @@ describe("Backup error - disconnect", () => {
   })
 
   it("Verify Backup failed modal", async () => {
+    //check fail modal
     const backupFailedModal = ModalBackupKompaktPage.backupFailedModal
     await expect(backupFailedModal).toBeDisplayed()
 
+    //check failed icon
     const backupFailureIcon = ModalBackupKompaktPage.backupFailureIcon
     await expect(backupFailureIcon).toBeDisplayed()
 
+    //check failed title
     const backupFailedTitle = ModalBackupKompaktPage.backupFailedTitle
     await expect(backupFailedTitle).toHaveText("Backup failed")
 
+    //check failed subtitle
     const backupDisconnectedSubTitle =
       ModalBackupKompaktPage.backupDisconnectedSubTitle
     await expect(backupDisconnectedSubTitle).toHaveText(

--- a/apps/mudita-center-e2e/src/specs/overview/kompakt-backup-error.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/kompakt-backup-error.ts
@@ -7,7 +7,7 @@ import ModalBackupKompaktPage from "../../page-objects/modal-backup-kompakt.page
 import { mockPreBackupResponses } from "../../helpers/mock-prebackup"
 import { BrowserRouter } from "react-router-dom"
 
-describe("E2E mock sample - overview view", () => {
+describe("Backup error test", () => {
   before(async () => {
     E2EMockClient.connect()
     //wait for a connection to be established
@@ -58,7 +58,7 @@ describe("E2E mock sample - overview view", () => {
     await createBackupButton.click()
   })
 
-  it("Click Create backup and click skip password to start backup nd cancel it", async () => {
+  it("Click Create backup and click skip password to start backup and cancel it", async () => {
     const createBackupProceedNext =
       await ModalBackupKompaktPage.createBackupProceedNext
     await expect(createBackupProceedNext).toBeClickable()
@@ -71,7 +71,19 @@ describe("E2E mock sample - overview view", () => {
 
     const backupModalClose = ModalBackupKompaktPage.backupModalClose
     await expect(backupModalClose).toBeDisplayed()
-    await backupModalClose.click()
+    await backupModalClose.click() //click "X" button to cancel backup popup
+  })
+
+  it("Verify Backup cancelled modal", async () => {
+    const backupInProgressModalCancelled =
+      ModalBackupKompaktPage.backupInProgressModalCancelled
+    await expect(backupInProgressModalCancelled).toBeDisplayed()
+
+    const backupCanceledTitle = ModalBackupKompaktPage.backupCanceledTitle
+    await expect(backupCanceledTitle).toHaveText("Backup canceled")
+
+    const backupCanceledSubTitle = ModalBackupKompaktPage.backupCanceledSubTitle
+    await expect(backupCanceledSubTitle).toHaveText("No changes were made.")
   })
 
   // it("Verify backup creating modal, check if backup is in progress", async () => {

--- a/apps/mudita-center-e2e/src/specs/overview/kompakt-backup-error.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/kompakt-backup-error.ts
@@ -1,0 +1,98 @@
+import { E2EMockClient } from "../../../../../libs/e2e-mock/client/src"
+import {
+  overviewConfigForBackup,
+  overviewDataWithOneSimCard,
+} from "../../../../../libs/e2e-mock/responses/src"
+import ModalBackupKompaktPage from "../../page-objects/modal-backup-kompakt.page"
+import { mockPreBackupResponses } from "../../helpers/mock-prebackup"
+import { BrowserRouter } from "react-router-dom"
+
+describe("E2E mock sample - overview view", () => {
+  before(async () => {
+    E2EMockClient.connect()
+    //wait for a connection to be established
+    await browser.waitUntil(() => {
+      return E2EMockClient.checkConnection()
+    })
+  })
+
+  after(() => {
+    E2EMockClient.stopServer()
+    E2EMockClient.disconnect()
+  })
+
+  it("Connect device", async () => {
+    E2EMockClient.mockResponses([
+      {
+        path: "path-1",
+        body: overviewConfigForBackup,
+        endpoint: "FEATURE_CONFIGURATION",
+        method: "GET",
+        status: 200,
+      },
+      {
+        path: "path-1",
+        body: overviewDataWithOneSimCard,
+        endpoint: "FEATURE_DATA",
+        method: "GET",
+        status: 200,
+      },
+    ])
+    E2EMockClient.addDevice({
+      path: "path-1",
+      serialNumber: "first-serial-number",
+    })
+
+    await browser.pause(6000)
+    const menuItem = await $(`//a[@href="#/generic/mc-overview"]`)
+
+    await menuItem.waitForDisplayed({ timeout: 10000 })
+    await expect(menuItem).toBeDisplayed()
+  })
+
+  it("Mock prebackup, wait for Overview Page and click Create Backup", async () => {
+    mockPreBackupResponses("path-1")
+    const createBackupButton = await ModalBackupKompaktPage.createBackupButton
+    await expect(createBackupButton).toBeDisplayed()
+    await expect(createBackupButton).toBeClickable()
+    await createBackupButton.click()
+  })
+
+  it("Click Create backup and click skip password to start backup nd cancel it", async () => {
+    const createBackupProceedNext =
+      await ModalBackupKompaktPage.createBackupProceedNext
+    await expect(createBackupProceedNext).toBeClickable()
+    await createBackupProceedNext.click()
+
+    const createBackupPasswordSkip =
+      await ModalBackupKompaktPage.createBackupPasswordSkip
+    await createBackupPasswordSkip.click()
+    await browser.pause(2000) // wait for animation to load from 0% to10%
+
+    const backupModalClose = ModalBackupKompaktPage.backupModalClose
+    await expect(backupModalClose).toBeDisplayed()
+    await backupModalClose.click()
+  })
+
+  // it("Verify backup creating modal, check if backup is in progress", async () => {
+  //   const backupInProgressModal =
+  //     await ModalBackupKompaktPage.backupInProgressModal
+  //   await expect(backupInProgressModal).toBeDisplayed()
+  //   await expect(ModalBackupKompaktPage.creatingBackupTitle).toHaveText(
+  //     "Creating backup"
+  //   )
+  //   await expect(ModalBackupKompaktPage.creatingBackupDescription).toHaveText(
+  //     "Please wait and do not unplug your device from computer."
+  //   )
+  //   const creatingBackupProgressBar =
+  //     await ModalBackupKompaktPage.creatingBackupProgressBar
+
+  //   const creatingBackupProgressBarValue =
+  //     await creatingBackupProgressBar.getAttribute("value")
+  //   expect(creatingBackupProgressBarValue).toBe("10")
+
+  //   const creatingBackupProgressBarDetails =
+  //     await ModalBackupKompaktPage.creatingBackupProgressBarDetails
+  //   await expect(creatingBackupProgressBarDetails).toHaveText("10%")
+  // })
+})

--- a/apps/mudita-center-e2e/src/test-filenames/consts/test-filenames.const.ts
+++ b/apps/mudita-center-e2e/src/test-filenames/consts/test-filenames.const.ts
@@ -44,5 +44,7 @@ export enum TestFilesPaths {
   kompaktConnectingSecondKompaktWhileInNews = "src/specs/overview/kompakt-connecting-second-kompakt-while-in-news.ts",
   kompaktPasscodeClose = "src/specs/overview/kompakt-passcode-close.ts",
   kompaktDisconnectDuringBackup = "src/specs/overview/kompakt-disconnect-during-backup.ts",
+  kompaktBackupErrorCancel = "src/specs/overview/kompakt-backup-error-cancel.ts",
+  kompaktBackupErrorDisconnect = "src/specs/overview/kompakt-backup-error-disconnect.ts",
 }
 export const toRelativePath = (path: string) => `./${path}`

--- a/apps/mudita-center-e2e/wdio.conf.ts
+++ b/apps/mudita-center-e2e/wdio.conf.ts
@@ -93,6 +93,8 @@ export const config: Options.Testrunner = {
     toRelativePath(TestFilesPaths.kompaktConnectingSecondKompaktWhileInNews),
     toRelativePath(TestFilesPaths.kompaktPasscodeClose),
     toRelativePath(TestFilesPaths.kompaktDisconnectDuringBackup),
+    toRelativePath(TestFilesPaths.kompaktBackupErrorCancel),
+    toRelativePath(TestFilesPaths.kompaktBackupErrorDisconnect),
   ],
   suites: {
     standalone: [
@@ -135,6 +137,8 @@ export const config: Options.Testrunner = {
       toRelativePath(TestFilesPaths.kompaktConnectingSecondKompaktWhileInNews),
       toRelativePath(TestFilesPaths.kompaktPasscodeClose),
       toRelativePath(TestFilesPaths.kompaktDisconnectDuringBackup),
+      toRelativePath(TestFilesPaths.kompaktBackupErrorCancel),
+      toRelativePath(TestFilesPaths.kompaktBackupErrorDisconnect),
     ],
     multidevicePureHarmony: [],
     multideviceSingleHarmony: [],
@@ -185,6 +189,8 @@ export const config: Options.Testrunner = {
       toRelativePath(TestFilesPaths.kompaktConnectingSecondKompaktWhileInNews),
       toRelativePath(TestFilesPaths.kompaktPasscodeClose),
       toRelativePath(TestFilesPaths.kompaktDisconnectDuringBackup),
+      toRelativePath(TestFilesPaths.kompaktBackupErrorCancel),
+      toRelativePath(TestFilesPaths.kompaktBackupErrorDisconnect),
     ],
   },
   // Patterns to exclude.


### PR DESCRIPTION
…s - Unsuccessful backup - General Error

JIRA Reference: [CP-3180]

### :memo: Description ️

-Mock errors during FILE_TRANSFER (CP-2932: [API Device][Kompakt] Backup - Retrieving backup files - FILE_TRANSFER
W toku
) loop 
Verify Backup Failed modal shows up, verify reason message, click close 

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-3180]: https://appnroll.atlassian.net/browse/CP-3180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ