### PR TITLE
[CP-3529] Core fallback to serialport when MTP init access is denied

### DIFF
--- a/libs/generic-view/ui/src/lib/predefined/files-manager-upload/files-manager-upload-progress-warning.tsx
+++ b/libs/generic-view/ui/src/lib/predefined/files-manager-upload/files-manager-upload-progress-warning.tsx
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Mudita sp. z o.o. All rights reserved.
+ * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
+ */
+
+import React, { FunctionComponent } from "react"
+import styled from "styled-components"
+import { Typography } from "../../typography/typography"
+import { typographyConfig } from "../../typography/typography.config"
+
+export const FilesManagerUploadProgressWarning: FunctionComponent = () => {
+  return (
+    <Wrapper>
+      <Typography.P3>
+        Some apps slow down transfer, it’s better <br></br> to close them if you
+        have them open.
+      </Typography.P3>
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled.div`
+  background: ${({ theme }) => theme.color.grey5};
+  padding: 12px;
+  margin: -10px 12px 0 12px;
+
+  p {
+    color: ${({ theme }) => theme.color.black};
+    font-size: ${typographyConfig["typography.p3"].fontSize};
+    line-height: ${typographyConfig["typography.p3"].fontHeight};
+    font-weight: ${typographyConfig["typography.p3"].fontWeight};
+    letter-spacing: ${typographyConfig["typography.p3"].letterSpacing};
+  }
+`

--- a/libs/generic-view/ui/src/lib/predefined/files-manager-upload/files-manager-upload-progress.tsx
+++ b/libs/generic-view/ui/src/lib/predefined/files-manager-upload/files-manager-upload-progress.tsx
@@ -4,24 +4,26 @@
  */
 
 import React from "react"
+import { defineMessages } from "react-intl"
+import { useDispatch, useSelector } from "react-redux"
 import { APIFC, IconType } from "generic-view/utils"
 import {
   ButtonAction,
   McFilesManagerUploadProgressConfig,
 } from "generic-view/models"
-import { Modal } from "../../interactive/modal/modal"
-import { intl } from "Core/__deprecated__/renderer/utils/intl"
-import { defineMessages } from "react-intl"
-import { ProgressBar } from "../../interactive/progress-bar/progress-bar"
 import {
   selectFilesSendingCount,
   selectFilesSendingCurrentFile,
   selectFilesSendingProgress,
   sendFilesAbort,
 } from "generic-view/store"
-import { useDispatch, useSelector } from "react-redux"
 import { Dispatch, ReduxRootState } from "Core/__deprecated__/renderer/store"
+import { intl } from "Core/__deprecated__/renderer/utils/intl"
+import { ProgressBar } from "../../interactive/progress-bar/progress-bar"
+import { Modal } from "../../interactive/modal/modal"
 import { ButtonSecondary } from "../../buttons/button-secondary"
+import { FilesManagerUploadProgressWarning } from "./files-manager-upload-progress-warning"
+import { FilesTransferMode } from "../../../../../store/src/lib/file-transfer/files-transfer-mode.type"
 
 const messages = defineMessages({
   progressModalTitle: {
@@ -45,6 +47,9 @@ export const FilesManagerUploadProgress: APIFC<
   const transferProgress = useSelector((state: ReduxRootState) => {
     return selectFilesSendingProgress(state, selectorsConfig)
   })
+  const filesTransferMode = useSelector((state: ReduxRootState) => {
+    return state.genericFileTransfer.filesTransferMode
+  })
   const currentFile = useSelector((state: ReduxRootState) => {
     return selectFilesSendingCurrentFile(state, selectorsConfig)
   })
@@ -64,6 +69,9 @@ export const FilesManagerUploadProgress: APIFC<
           filesCount,
         })}
       </Modal.Title>
+      {filesTransferMode === FilesTransferMode.SerialPort && (
+        <FilesManagerUploadProgressWarning />
+      )}
       <ProgressBar
         config={{
           maxValue: 100,


### PR DESCRIPTION
JIRA Reference: [CP-3529]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated
