### PR TITLE
[CP-XXX] Added `getCurrentDevices` method to app-serialport

### DIFF
--- a/libs/app-serialport/devices/src/lib/serial-port-device.ts
+++ b/libs/app-serialport/devices/src/lib/serial-port-device.ts
@@ -118,7 +118,7 @@ export class SerialPortDevice extends SerialPort {
   }
 
   private createRequest({ options, ...data }: SerialPortRequest) {
-    const id = parseInt(uniqueId())
+    const id = parseInt(uniqueId()) % 99999999 || 1
     return new Promise<SerialPortResponse>((resolve, reject) => {
       void this.#queue.add(async () => {
         try {

--- a/libs/app-serialport/main/src/lib/app-serial-port.preload.ts
+++ b/libs/app-serialport/main/src/lib/app-serial-port.preload.ts
@@ -19,6 +19,9 @@ export const serialPort = {
       }
     )
   },
+  getCurrentDevices: () => {
+    return electronAPI.ipcRenderer.invoke(SerialPortIpcEvents.GetCurrentDevices)
+  },
   request: (path: string, data: SerialPortRequest) => {
     return electronAPI.ipcRenderer.invoke(
       SerialPortIpcEvents.Request,

--- a/libs/app-serialport/main/src/lib/app-serial-port.ts
+++ b/libs/app-serialport/main/src/lib/app-serial-port.ts
@@ -31,7 +31,7 @@ export class AppSerialPort {
     void this.detectChanges()
     setInterval(() => {
       void this.detectChanges()
-    }, 3000)
+    }, 250)
   }
 
   private getDeviceSerialPortInstance({
@@ -165,6 +165,10 @@ export class AppSerialPort {
         callback(changes)
       }
     )
+  }
+
+  getCurrentDevices(): Promise<SerialPortDeviceInfo[]> {
+    return this.listDevices()
   }
 
   request(path: SerialPortDevicePath, data: SerialPortRequest) {

--- a/libs/app-serialport/main/src/lib/init-serialport.ts
+++ b/libs/app-serialport/main/src/lib/init-serialport.ts
@@ -29,6 +29,9 @@ export const initSerialPort = (ipcMain: IpcMain, webContents: WebContents) => {
     serialport.onDevicesChange((data) => {
       webContents.send(SerialPortIpcEvents.DevicesChanged, data)
     })
+    ipcMain.handle(SerialPortIpcEvents.GetCurrentDevices, () => {
+      return (serialport as AppSerialPort).getCurrentDevices()
+    })
     ipcMain.removeHandler(SerialPortIpcEvents.Request)
     ipcMain.handle(
       SerialPortIpcEvents.Request,

--- a/libs/app-serialport/models/src/lib/serial-port-ipc-events.ts
+++ b/libs/app-serialport/models/src/lib/serial-port-ipc-events.ts
@@ -5,6 +5,7 @@
 
 export enum SerialPortIpcEvents {
   DevicesChanged = "serialport:devices-changed",
+  GetCurrentDevices = "serialport:get-current-devices",
   Request = "serialport:request",
   ChangeBaudRate = "serialport:change-baud-rate",
 }

--- a/libs/app-serialport/renderer/src/lib/app-serial-port.ts
+++ b/libs/app-serialport/renderer/src/lib/app-serial-port.ts
@@ -21,12 +21,16 @@ export class AppSerialPort {
     window.api.serialPort.onDevicesChanged(callback)
   }
 
+  static getCurrentDevices(): Promise<SerialPortDeviceInfo[]> {
+    return window.api.serialPort.getCurrentDevices()
+  }
+
   static async changeBaudRate(path: SerialPortDevicePath, baudRate: number) {
     await window.api.serialPort.changeBaudRate(path, baudRate)
   }
 
   static isCompatible(
-    device: SerialPortDeviceInfo
+    device: Pick<SerialPortDeviceInfo, "deviceType">
   ): device is SerialPortDeviceInfo {
     if (!Object.values(SerialPortDeviceType).includes(device.deviceType)) {
       throw new Error("Device type is not supported")
@@ -35,7 +39,7 @@ export class AppSerialPort {
   }
 
   static async request(
-    device: SerialPortDeviceInfo,
+    device: Pick<SerialPortDeviceInfo, "deviceType" | "path">,
     data: SerialPortRequest
   ): Promise<SerialPortResponse> {
     try {

--- a/libs/devices/api-device/adapters/src/lib/api-device-serial-port.ts
+++ b/libs/devices/api-device/adapters/src/lib/api-device-serial-port.ts
@@ -20,7 +20,10 @@ import {
   ApiDeviceResponseBody,
 } from "devices/api-device/models"
 
-type Response<E extends ApiDeviceEndpoint, M extends ApiDeviceMethod<E>> =
+export type Response<
+  E extends ApiDeviceEndpoint,
+  M extends ApiDeviceMethod<E>,
+> =
   | {
       ok: true
       endpoint: E
@@ -36,7 +39,9 @@ type Response<E extends ApiDeviceEndpoint, M extends ApiDeviceMethod<E>> =
     }
 
 export class ApiDeviceSerialPort {
-  static isCompatible(device?: SerialPortDeviceInfo): device is ApiDevice {
+  static isCompatible(
+    device?: Pick<SerialPortDeviceInfo, "deviceType"> | null
+  ): device is ApiDevice {
     if (!device) {
       return true
     }

--- a/libs/devices/api-device/models/src/lib/api-device.ts
+++ b/libs/devices/api-device/models/src/lib/api-device.ts
@@ -8,4 +8,8 @@ import {
   SerialPortDeviceType,
 } from "app-serialport/models"
 
-export type ApiDevice = SerialPortDeviceInfo<SerialPortDeviceType.ApiDevice>
+export type ApiDevice = Pick<
+  SerialPortDeviceInfo<SerialPortDeviceType.ApiDevice>,
+  "deviceType" | "path"
+> &
+  Partial<Omit<SerialPortDeviceInfo, "deviceType" | "path">>


### PR DESCRIPTION
JIRA Reference: [CP-XXX]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated
