### PR TITLE
[CP-3805] [API Device][Kompakt] Overview - Check Device TYPE: GLOBAL/…

### DIFF
--- a/apps/mudita-center-e2e/src/page-objects/overview-kompakt.page.ts
+++ b/apps/mudita-center-e2e/src/page-objects/overview-kompakt.page.ts
@@ -79,5 +79,17 @@ class OverviewKompaktPage extends OverviewPage {
   public get kompaktOsVersionLabel() {
     return $("//*[@data-testid='version-label']")
   }
+
+  public get kompaktDeviceTypeLabel() {
+    return $("//p[contains(text(), 'Device type:')]")
+  }
+
+  public get kompaktDeviceTypeLabelValue1st() {
+    return $("//p[contains(text(), 'GLOBAL')]")
+  }
+
+  public get kompaktDeviceTypeLabelValue2nd() {
+    return $("//p[contains(text(), 'US')]")
+  }
 }
 export default new OverviewKompaktPage()

--- a/apps/mudita-center-e2e/src/specs/overview/kompakt-check-device-type.ts
+++ b/apps/mudita-center-e2e/src/specs/overview/kompakt-check-device-type.ts
@@ -1,0 +1,98 @@
+import { E2EMockClient } from "../../../../../libs/e2e-mock/client/src"
+import {
+  overviewDataWithOneSimCard,
+  overviewDataWithOneSimCard2nd,
+} from "../../../../../libs/e2e-mock/responses/src"
+import OverviewKompaktPage from "../../page-objects/overview-kompakt.page"
+import drawerPage from "../../page-objects/drawer.page"
+
+describe("Check Device type", () => {
+  const firstSerialNumber = "KOM1234567890"
+  const secondSerialNumber = "KOM1234567892"
+  before(async () => {
+    E2EMockClient.connect()
+    //wait for a connection to be established
+    await browser.waitUntil(() => {
+      return E2EMockClient.checkConnection()
+    })
+  })
+
+  after(() => {
+    E2EMockClient.stopServer()
+    E2EMockClient.disconnect()
+  })
+
+  it("Connect device 1st - GLOBAL", async () => {
+    E2EMockClient.mockResponses([
+      {
+        path: "path-1",
+        body: overviewDataWithOneSimCard,
+        endpoint: "FEATURE_DATA",
+        method: "GET",
+        status: 200,
+      },
+    ])
+    E2EMockClient.addDevice({
+      path: "path-1",
+      serialNumber: firstSerialNumber,
+    })
+
+    await browser.pause(6000)
+    const menuItem = await $(`//a[@href="#/generic/mc-overview"]`)
+
+    await menuItem.waitForDisplayed({ timeout: 10000 })
+    await expect(menuItem).toBeDisplayed()
+  })
+
+  it("Verify Device type - GLOBAL", async () => {
+    const kompaktDeviceTypeLabel =
+      await OverviewKompaktPage.kompaktDeviceTypeLabel
+    await expect(kompaktDeviceTypeLabel).toBeDisplayed()
+    await expect(kompaktDeviceTypeLabel).toHaveText("Device type:")
+
+    const kompaktDeviceTypeLabelValue1st =
+      await OverviewKompaktPage.kompaktDeviceTypeLabelValue1st
+    await expect(kompaktDeviceTypeLabelValue1st).toBeDisplayed()
+    await expect(kompaktDeviceTypeLabelValue1st).toHaveText("GLOBAL")
+  })
+
+  it("Connect device 2nd - US", async () => {
+    E2EMockClient.mockResponses([
+      {
+        path: "path-2",
+        body: overviewDataWithOneSimCard2nd,
+        endpoint: "FEATURE_DATA",
+        method: "GET",
+        status: 200,
+      },
+    ])
+    E2EMockClient.addDevice({
+      path: "path-2",
+      serialNumber: secondSerialNumber,
+    })
+
+    await browser.pause(6000)
+    const menuItem = await $(`//a[@href="#/generic/mc-overview"]`)
+
+    await menuItem.waitForDisplayed({ timeout: 10000 })
+    await expect(menuItem).toBeDisplayed()
+  })
+
+  it("Switch to 2nd device and Verify Device type - US", async () => {
+    const secondDeviceOnDrawer = await drawerPage.getDeviceOnDrawer(
+      secondSerialNumber
+    )
+    await expect(secondDeviceOnDrawer).toBeDisplayed()
+    await secondDeviceOnDrawer.waitForClickable()
+    await secondDeviceOnDrawer.click()
+    const kompaktDeviceTypeLabel =
+      await OverviewKompaktPage.kompaktDeviceTypeLabel
+    await expect(kompaktDeviceTypeLabel).toBeDisplayed()
+    await expect(kompaktDeviceTypeLabel).toHaveText("Device type:")
+
+    const kompaktDeviceTypeLabelValue2nd =
+      await OverviewKompaktPage.kompaktDeviceTypeLabelValue2nd
+    await expect(kompaktDeviceTypeLabelValue2nd).toBeDisplayed()
+    await expect(kompaktDeviceTypeLabelValue2nd).toHaveText("US")
+  })
+})


### PR DESCRIPTION
… or different

JIRA Reference: [CP-3805]

### :memo: Description ️

- check device type label for both options

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated
