### PR TITLE
[CP-3842] Fix Linux executableName whitespace causing invalid icon cache

### DIFF
--- a/apps/mudita-center/package.json
+++ b/apps/mudita-center/package.json
@@ -74,7 +74,7 @@
     "linux": {
       "target": "AppImage",
       "category": "Utility",
-      "executableName": "Mudita Center",
+      "executableName": "mudita-center",
       "artifactName": "Mudita-Center.${ext}"
     },
     "appImage": {


### PR DESCRIPTION
JIRA Reference: [CP-3842]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated
