### PR TITLE
[CP-3670] Implemented file saving option for AppHttp service (3)

### DIFF
--- a/libs/app-utils/main/src/lib/app-file-system/app-file-system.preload.ts
+++ b/libs/app-utils/main/src/lib/app-file-system/app-file-system.preload.ts
@@ -13,10 +13,25 @@ import {
 } from "app-utils/models"
 
 export const appFileSystem = {
-  rm: (options: AppFileSystemRmOptions): Promise<AppResult> =>
-    ipcRenderer.invoke(AppFileSystemIpcEvents.Rm, options),
-  mkdir: (options: AppFileSystemMkdirOptions): Promise<AppResult> =>
-    ipcRenderer.invoke(AppFileSystemIpcEvents.Mkdir, options),
-  archive: (options: AppFileSystemArchiveOptions): Promise<AppResult> =>
-    ipcRenderer.invoke(AppFileSystemIpcEvents.Archive, options),
+  rm: (options: AppFileSystemRmOptions): Promise<AppResult> => {
+    return ipcRenderer.invoke(AppFileSystemIpcEvents.Rm, options)
+  },
+  mkdir: (options: AppFileSystemMkdirOptions): Promise<AppResult> => {
+    return ipcRenderer.invoke(AppFileSystemIpcEvents.Mkdir, options)
+  },
+  archive: (options: AppFileSystemArchiveOptions): Promise<AppResult> => {
+    return ipcRenderer.invoke(AppFileSystemIpcEvents.Archive, options)
+  },
+  writeFile: (
+    filePath: string,
+    data: Buffer | Record<string, unknown>,
+    encoding?: BufferEncoding | string
+  ) => {
+    return ipcRenderer.invoke(
+      AppFileSystemIpcEvents.WriteFile,
+      filePath,
+      data,
+      encoding
+    )
+  },
 }

--- a/libs/app-utils/main/src/lib/app-file-system/init-app-file-system.ts
+++ b/libs/app-utils/main/src/lib/app-file-system/init-app-file-system.ts
@@ -30,4 +30,14 @@ export const initAppFileSystem = (ipcMain: IpcMain) => {
     (_, options: AppFileSystemArchiveOptions) =>
       AppFileSystemService.archive(options)
   )
+  ipcMain.removeHandler(AppFileSystemIpcEvents.WriteFile)
+  ipcMain.handle(
+    AppFileSystemIpcEvents.WriteFile,
+    (
+      _,
+      filePath: string,
+      data: Buffer | Record<string, unknown>,
+      encoding?: BufferEncoding | string
+    ) => AppFileSystemService.writeFile(filePath, data, encoding)
+  )
 }

--- a/libs/app-utils/models/src/lib/app-file-system-ipc-events.ts
+++ b/libs/app-utils/models/src/lib/app-file-system-ipc-events.ts
@@ -7,4 +7,5 @@ export enum AppFileSystemIpcEvents {
   Rm = "appFileSystem:rm",
   Mkdir = "appFileSystem:mkdir",
   Archive = "appFileSystem:archive",
+  WriteFile = "appFileSystem:writeFile",
 }

--- a/libs/app-utils/models/src/lib/app-file-system.ts
+++ b/libs/app-utils/models/src/lib/app-file-system.ts
@@ -6,7 +6,7 @@
 export type AppFileSystemScope = "userData" | "temp"
 
 export interface AppFileSystemScopeOptions {
-  scopeRelativePath: string
+  scopeRelativePath: string | string[]
   scope?: AppFileSystemScope
 }
 

--- a/libs/app-utils/models/src/lib/app-http.ts
+++ b/libs/app-utils/models/src/lib/app-http.ts
@@ -15,6 +15,7 @@ export interface AppHttpRequestConfig extends AxiosRequestConfig {
   params?: Record<string, unknown>
   headers?: Record<string, string>
   files?: Record<string, AppFileSystemScopeOptions>
+  savePath?: string | string[]
   rid?: string
 }
 

--- a/libs/app-utils/renderer/src/lib/app-file-system.ts
+++ b/libs/app-utils/renderer/src/lib/app-file-system.ts
@@ -7,4 +7,5 @@ export const AppFileSystem = {
   rm: window.api.appFileSystem.rm,
   mkdir: window.api.appFileSystem.mkdir,
   archive: window.api.appFileSystem.archive,
+  writeFile: window.api.appFileSystem.writeFile,
 }


### PR DESCRIPTION
JIRA Reference: [CP-3670]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-3670]: https://appnroll.atlassian.net/browse/CP-3670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ