### PR TITLE
[CP-3670] Implemented downloadProgress listener for AppHttp (5)

### DIFF
--- a/apps/app/src/main/init-app-libs.ts
+++ b/apps/app/src/main/init-app-libs.ts
@@ -48,7 +48,7 @@ export const initAppLibs = (
   initNews(ipcMain, mainWindow)
   initAppHelp(ipcMain, helpService)
   initJsonStore(ipcMain)
-  initAppHttp(ipcMain, appHttpService)
+  initAppHttp(ipcMain, mainWindow, appHttpService)
   initAppLogger(ipcMain)
   initAppFileSystem(ipcMain)
   initUsbAccess(ipcMain, mockServer)

--- a/libs/app-utils/main/src/lib/app-file-system/app-file-system.preload.ts
+++ b/libs/app-utils/main/src/lib/app-file-system/app-file-system.preload.ts
@@ -13,10 +13,25 @@ import {
 } from "app-utils/models"
 
 export const appFileSystem = {
-  rm: (options: AppFileSystemRmOptions): Promise<AppResult> =>
-    ipcRenderer.invoke(AppFileSystemIpcEvents.Rm, options),
-  mkdir: (options: AppFileSystemMkdirOptions): Promise<AppResult> =>
-    ipcRenderer.invoke(AppFileSystemIpcEvents.Mkdir, options),
-  archive: (options: AppFileSystemArchiveOptions): Promise<AppResult> =>
-    ipcRenderer.invoke(AppFileSystemIpcEvents.Archive, options),
+  rm: (options: AppFileSystemRmOptions): Promise<AppResult> => {
+    return ipcRenderer.invoke(AppFileSystemIpcEvents.Rm, options)
+  },
+  mkdir: (options: AppFileSystemMkdirOptions): Promise<AppResult> => {
+    return ipcRenderer.invoke(AppFileSystemIpcEvents.Mkdir, options)
+  },
+  archive: (options: AppFileSystemArchiveOptions): Promise<AppResult> => {
+    return ipcRenderer.invoke(AppFileSystemIpcEvents.Archive, options)
+  },
+  writeFile: (
+    filePath: string,
+    data: Buffer | Record<string, unknown>,
+    encoding?: BufferEncoding | string
+  ) => {
+    return ipcRenderer.invoke(
+      AppFileSystemIpcEvents.WriteFile,
+      filePath,
+      data,
+      encoding
+    )
+  },
 }

--- a/libs/app-utils/main/src/lib/app-file-system/init-app-file-system.ts
+++ b/libs/app-utils/main/src/lib/app-file-system/init-app-file-system.ts
@@ -30,4 +30,14 @@ export const initAppFileSystem = (ipcMain: IpcMain) => {
     (_, options: AppFileSystemArchiveOptions) =>
       AppFileSystemService.archive(options)
   )
+  ipcMain.removeHandler(AppFileSystemIpcEvents.WriteFile)
+  ipcMain.handle(
+    AppFileSystemIpcEvents.WriteFile,
+    (
+      _,
+      filePath: string,
+      data: Buffer | Record<string, unknown>,
+      encoding?: BufferEncoding | string
+    ) => AppFileSystemService.writeFile(filePath, data, encoding)
+  )
 }

--- a/libs/app-utils/main/src/lib/app-http/app-http.preload.ts
+++ b/libs/app-utils/main/src/lib/app-http/app-http.preload.ts
@@ -24,7 +24,7 @@ export const appHttp = {
     rid: string,
     callback: (progress: Omit<AxiosProgressEvent, "event">) => void
   ) => {
-    electronAPI.ipcRenderer.on(
+    return electronAPI.ipcRenderer.on(
       AppHttpIpcEvents.OnDownloadProgress,
       (_, args: Omit<AxiosProgressEvent, "event"> & { rid: string }) => {
         if (args.rid === rid) {

--- a/libs/app-utils/main/src/lib/app-http/app-http.preload.ts
+++ b/libs/app-utils/main/src/lib/app-http/app-http.preload.ts
@@ -9,6 +9,7 @@ import {
   AppHttpResult,
 } from "app-utils/models"
 import { electronAPI } from "@electron-toolkit/preload"
+import { AxiosProgressEvent } from "axios"
 
 export const appHttp = {
   request: <Data>(
@@ -18,5 +19,18 @@ export const appHttp = {
   },
   abort: (rid: string) => {
     return electronAPI.ipcRenderer.invoke(AppHttpIpcEvents.Abort, rid)
+  },
+  onDownloadProgress: (
+    rid: string,
+    callback: (progress: Omit<AxiosProgressEvent, "event">) => void
+  ) => {
+    electronAPI.ipcRenderer.on(
+      AppHttpIpcEvents.OnDownloadProgress,
+      (_, args: Omit<AxiosProgressEvent, "event"> & { rid: string }) => {
+        if (args.rid === rid) {
+          callback(args)
+        }
+      }
+    )
   },
 }

--- a/libs/app-utils/main/src/lib/app-http/init-app-http.ts
+++ b/libs/app-utils/main/src/lib/app-http/init-app-http.ts
@@ -3,20 +3,29 @@
  * For licensing, see https://github.com/mudita/mudita-center/blob/master/LICENSE.md
  */
 
-import { IpcMain } from "electron"
+import { BrowserWindow, IpcMain } from "electron"
 import { AppHttpService } from "./app-http.service"
 import { AppHttpIpcEvents, AppHttpRequestConfig } from "app-utils/models"
 import { MockAppHttpService } from "./mock-app-http.service"
 
 export const initAppHttp = (
   ipcMain: IpcMain,
+  mainWindow: BrowserWindow,
   appHttpService: AppHttpService | MockAppHttpService
 ) => {
   ipcMain.removeHandler(AppHttpIpcEvents.Request)
   ipcMain.handle(
     AppHttpIpcEvents.Request,
     (_, config: AppHttpRequestConfig) => {
-      return appHttpService.request(config)
+      return appHttpService.request({
+        ...config,
+        onDownloadProgress: ({ event, ...progress }) => {
+          mainWindow.webContents.send(AppHttpIpcEvents.OnDownloadProgress, {
+            rid: config.rid,
+            ...progress,
+          })
+        },
+      })
     }
   )
 

--- a/libs/app-utils/models/src/lib/app-file-system-ipc-events.ts
+++ b/libs/app-utils/models/src/lib/app-file-system-ipc-events.ts
@@ -7,4 +7,5 @@ export enum AppFileSystemIpcEvents {
   Rm = "appFileSystem:rm",
   Mkdir = "appFileSystem:mkdir",
   Archive = "appFileSystem:archive",
+  WriteFile = "appFileSystem:writeFile",
 }

--- a/libs/app-utils/models/src/lib/app-file-system.ts
+++ b/libs/app-utils/models/src/lib/app-file-system.ts
@@ -6,7 +6,7 @@
 export type AppFileSystemScope = "userData" | "temp"
 
 export interface AppFileSystemScopeOptions {
-  scopeRelativePath: string
+  scopeRelativePath: string | string[]
   scope?: AppFileSystemScope
 }
 

--- a/libs/app-utils/models/src/lib/app-http-ipc-events.ts
+++ b/libs/app-utils/models/src/lib/app-http-ipc-events.ts
@@ -6,4 +6,5 @@
 export enum AppHttpIpcEvents {
   Request = "appHttp:request",
   Abort = "appHttp:abort",
+  OnDownloadProgress = "appHttp:onDownloadProgress",
 }

--- a/libs/app-utils/models/src/lib/app-http.ts
+++ b/libs/app-utils/models/src/lib/app-http.ts
@@ -15,6 +15,7 @@ export interface AppHttpRequestConfig extends AxiosRequestConfig {
   params?: Record<string, unknown>
   headers?: Record<string, string>
   files?: Record<string, AppFileSystemScopeOptions>
+  savePath?: string | string[]
   rid?: string
 }
 

--- a/libs/app-utils/renderer/src/lib/app-file-system.ts
+++ b/libs/app-utils/renderer/src/lib/app-file-system.ts
@@ -7,4 +7,5 @@ export const AppFileSystem = {
   rm: window.api.appFileSystem.rm,
   mkdir: window.api.appFileSystem.mkdir,
   archive: window.api.appFileSystem.archive,
+  writeFile: window.api.appFileSystem.writeFile,
 }

--- a/libs/app-utils/renderer/src/lib/app-http.ts
+++ b/libs/app-utils/renderer/src/lib/app-http.ts
@@ -7,10 +7,18 @@ import "types-preload"
 import { AppHttpRequestConfig, AppHttpResult } from "app-utils/models"
 
 export const AppHttp = {
-  request: <Data>(
-    config: Omit<AppHttpRequestConfig, "rid">
-  ): Promise<AppHttpResult<Data>> & { abort: VoidFunction } => {
+  request: <Data>({
+    onDownloadProgress,
+    ...config
+  }: Omit<AppHttpRequestConfig, "rid">): Promise<AppHttpResult<Data>> & {
+    abort: VoidFunction
+  } => {
     const rid = crypto.randomUUID()
+
+    if (onDownloadProgress) {
+      window.api.appHttp.onDownloadProgress(rid, onDownloadProgress)
+    }
+
     const promise = window.api.appHttp.request<Data>({ ...config, rid })
 
     const abort = () => {

--- a/libs/app-utils/renderer/src/lib/app-http.ts
+++ b/libs/app-utils/renderer/src/lib/app-http.ts
@@ -14,12 +14,20 @@ export const AppHttp = {
     abort: VoidFunction
   } => {
     const rid = crypto.randomUUID()
+    let unregister: VoidFunction | undefined
 
     if (onDownloadProgress) {
-      window.api.appHttp.onDownloadProgress(rid, onDownloadProgress)
+      unregister = window.api.appHttp.onDownloadProgress(
+        rid,
+        onDownloadProgress
+      )
     }
 
     const promise = window.api.appHttp.request<Data>({ ...config, rid })
+
+    promise.finally(() => {
+      unregister?.()
+    })
 
     const abort = () => {
       window.api.appHttp.abort(rid)


### PR DESCRIPTION
JIRA Reference: [CP-3670]

### :memo: Description ️

-

### :muscle: Checklist before requesting a review - nice to have

- getState function in async thunk actions is correctly typed
- redux selectors are used in components / prop drilling is reduce

### :exclamation: Checklist before merging a pull request

- change went through the QA process
- translations are updated in dedicated application
- [CHANGELOG.md](./CHANGELOG.md) is updated


[CP-3670]: https://appnroll.atlassian.net/browse/CP-3670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ