### PR TITLE
[CP-XXX] Temporary Windows DigiCert feature-branch test

### DIFF
--- a/.github/workflows/nexus-feature-branch.yml
+++ b/.github/workflows/nexus-feature-branch.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.runner_label }}
     strategy:
       matrix:
-        runner_label: [linux-nexus, windows-nexus, macos-m-nexus]
+        runner_label: [windows-nexus]
         node-version: [24.14.0]
     environment: development
     steps:
@@ -108,6 +108,44 @@ jobs:
         run: |
           export NODE_OPTIONS="--max-old-space-size=4096"
           npx nx build:linux app --publish never --output-style stream --no-cloud
+      - name: Signing via Digicert
+        if: matrix.runner_label == 'windows-nexus'
+        env:
+          SM_HOST: ${{ secrets.SM_HOST }}
+          SM_API_KEY: ${{ secrets.SM_API_KEY }}
+          SM_CLIENT_CERT_FILE: "C:\\actions-runner\\certs\\Certificate_pkcs12.p12"
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+          SM_CODE_SIGNING_CERT_SHA1_HASH: ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}
+        run: |
+          SET SM_HOST=%SM_HOST%
+          SET SM_API_KEY=%SM_API_KEY%
+          SET SM_CLIENT_CERT_FILE=%SM_CLIENT_CERT_FILE%
+          SET SM_CLIENT_CERT_PASSWORD=%SM_CLIENT_CERT_PASSWORD%
+          SET SM_CODE_SIGNING_CERT_SHA1_HASH=%SM_CODE_SIGNING_CERT_SHA1_HASH%
+          SET PATH=%PATH%;"C:\Program Files\DigiCert\DigiCert One Signing Manager Tools"
+          SET PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
+          signtool.exe sign /n "MUDITA SP. Z O.O." /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
+        shell: cmd
+      - name: Verify Windows signature
+        if: matrix.runner_label == 'windows-nexus'
+        run: |
+          SET PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
+          signtool.exe verify /pa /v ./apps/app/release/Mudita-Center.exe
+        shell: cmd
+      - name: Calculate new checksum and file size for Mudita-Center.exe
+        if: matrix.runner_label == 'windows-nexus'
+        run: |
+          $filePath = "./apps/app/release/Mudita-Center.exe"
+          $sha512Bytes = [System.Security.Cryptography.SHA512]::Create().ComputeHash([System.IO.File]::ReadAllBytes($filePath))
+          $sha512Base64 = [Convert]::ToBase64String($sha512Bytes)
+          $fileSize = (Get-Item -Path $filePath).length
+
+          $latestYmlPath = "./apps/app/release/latest.yml"
+          (Get-Content $latestYmlPath) -replace 'sha512:.*', "sha512: $sha512Base64" |
+          Set-Content $latestYmlPath
+          (Get-Content $latestYmlPath) -replace 'size:.*', "size: $fileSize" |
+          Set-Content $latestYmlPath
+        shell: powershell
       - name: Upload artifacts to Nexus - Windows
         if: matrix.runner_label == 'windows-nexus'
         env:


### PR DESCRIPTION
## Summary
- temporary test branch for validating Windows DigiCert signing in the feature-branch pipeline
- limits the feature-branch release matrix to `windows-nexus`
- adds DigiCert signing, signature verification, and post-signing `latest.yml` checksum recalculation before Nexus upload

## Validation
- `npx prettier --check .github/workflows/nexus-feature-branch.yml`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' .github/workflows/nexus-feature-branch.yml`\n- `git diff --check`\n\nThis PR is intentionally disposable and should be closed without merging after the Windows feature pipeline proves the signing path.