### PR TITLE
[CP-XXX] Propagate DigiCert subject-name signing

### DIFF
--- a/.github/workflows/nexus-mass-update.yml
+++ b/.github/workflows/nexus-mass-update.yml
@@ -110,7 +110,7 @@ jobs:
           SET SM_CODE_SIGNING_CERT_SHA1_HASH=%SM_CODE_SIGNING_CERT_SHA1_HASH%
           SET PATH=%PATH%;"C:\Program Files\DigiCert\DigiCert One Signing Manager Tools"
           SET PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
-          signtool.exe sign /sha1 %SM_CODE_SIGNING_CERT_SHA1_HASH% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
+          signtool.exe sign /n "MUDITA SP. Z O.O." /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
         shell: cmd
       - name: Calculate new checksum and file size for Mudita-Center.exe
         if: matrix.runner_label == 'windows-nexus'

--- a/.github/workflows/nexus-pre-production-latest.yml
+++ b/.github/workflows/nexus-pre-production-latest.yml
@@ -165,7 +165,7 @@ jobs:
           SET SM_CODE_SIGNING_CERT_SHA1_HASH=%SM_CODE_SIGNING_CERT_SHA1_HASH%
           SET PATH=%PATH%;"C:\Program Files\DigiCert\DigiCert One Signing Manager Tools"
           SET PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
-          signtool.exe sign /sha1 %SM_CODE_SIGNING_CERT_SHA1_HASH% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
+          signtool.exe sign /n "MUDITA SP. Z O.O." /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
         shell: cmd
       - name: Calculate new checksum and file size for Mudita-Center.exe
         if: matrix.runner_label == 'windows-nexus'

--- a/.github/workflows/nexus-pre-production.yml
+++ b/.github/workflows/nexus-pre-production.yml
@@ -116,7 +116,7 @@ jobs:
           SET SM_CODE_SIGNING_CERT_SHA1_HASH=%SM_CODE_SIGNING_CERT_SHA1_HASH%
           SET PATH=%PATH%;"C:\Program Files\DigiCert\DigiCert One Signing Manager Tools"
           SET PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
-          signtool.exe sign /sha1 %SM_CODE_SIGNING_CERT_SHA1_HASH% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
+          signtool.exe sign /n "MUDITA SP. Z O.O." /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
         shell: cmd
       - name: Calculate new checksum and file size for Mudita-Center.exe
         if: matrix.runner_label == 'windows-nexus'

--- a/.github/workflows/nexus-production-with-os-rc.yml
+++ b/.github/workflows/nexus-production-with-os-rc.yml
@@ -110,7 +110,7 @@ jobs:
           SET SM_CODE_SIGNING_CERT_SHA1_HASH=%SM_CODE_SIGNING_CERT_SHA1_HASH%
           SET PATH=%PATH%;"C:\Program Files\DigiCert\DigiCert One Signing Manager Tools"
           SET PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
-          signtool.exe sign /sha1 %SM_CODE_SIGNING_CERT_SHA1_HASH% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
+          signtool.exe sign /n "MUDITA SP. Z O.O." /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
         shell: cmd
       - name: Calculate new checksum and file size for Mudita-Center.exe
         if: matrix.runner_label == 'windows-nexus'


### PR DESCRIPTION
## Summary
- propagates the production DigiCert signing change to the remaining release workflows that already sign Windows installers
- switches `signtool` certificate selection from `/sha1 %SM_CODE_SIGNING_CERT_SHA1_HASH%` to `/n "MUDITA SP. Z O.O."`
- leaves development and feature-branch workflows unchanged

## Validation
- `rg --hidden -n "signtool\.exe sign|/sha1|/n \"MUDITA SP\. Z O\.O\.\"" .github/workflows/nexus-*.yml`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' .github/workflows/nexus-mass-update.yml .github/workflows/nexus-pre-production-latest.yml .github/workflows/nexus-pre-production.yml .github/workflows/nexus-production-with-os-rc.yml .github/workflows/nexus-production.yml`\n- `git diff --check`\n\nNote: `npx prettier --check` still reports pre-existing spacing style in `.github/workflows/nexus-pre-production-latest.yml`; this PR intentionally avoids unrelated formatting churn.