### PR TITLE
[CP-XXX] Propagate DigiCert new sign flow

### DIFF
--- a/.github/workflows/nexus-mass-update.yml
+++ b/.github/workflows/nexus-mass-update.yml
@@ -97,20 +97,12 @@ jobs:
       - name: Signing via Digicert
         if: matrix.runner_label == 'windows-nexus'
         env:
-          SM_HOST: ${{ secrets.SM_HOST }}
-          SM_API_KEY: ${{ secrets.SM_API_KEY }}
-          SM_CLIENT_CERT_FILE: "C:\\actions-runner\\certs\\Certificate_pkcs12.p12"
-          SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
           SM_CODE_SIGNING_CERT_SHA1_HASH: ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}
         run: |
-          SET SM_HOST=%SM_HOST%
-          SET SM_API_KEY=%SM_API_KEY%
-          SET SM_CLIENT_CERT_FILE=%SM_CLIENT_CERT_FILE%
-          SET SM_CLIENT_CERT_PASSWORD=%SM_CLIENT_CERT_PASSWORD%
           SET SM_CODE_SIGNING_CERT_SHA1_HASH=%SM_CODE_SIGNING_CERT_SHA1_HASH%
           SET PATH=%PATH%;"C:\Program Files\DigiCert\DigiCert One Signing Manager Tools"
           SET PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
-          signtool.exe sign /n "MUDITA SP. Z O.O." /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
+          signtool.exe sign /sha1 %SM_CODE_SIGNING_CERT_SHA1_HASH% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
         shell: cmd
       - name: Calculate new checksum and file size for Mudita-Center.exe
         if: matrix.runner_label == 'windows-nexus'

--- a/.github/workflows/nexus-pre-production-latest.yml
+++ b/.github/workflows/nexus-pre-production-latest.yml
@@ -152,20 +152,12 @@ jobs:
       - name: Signing via Digicert
         if: matrix.runner_label == 'windows-nexus'
         env:
-          SM_HOST: ${{ secrets.SM_HOST }}
-          SM_API_KEY: ${{ secrets.SM_API_KEY }}
-          SM_CLIENT_CERT_FILE: "C:\\actions-runner\\certs\\Certificate_pkcs12.p12"
-          SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
           SM_CODE_SIGNING_CERT_SHA1_HASH: ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}
         run: |
-          SET SM_HOST=%SM_HOST%
-          SET SM_API_KEY=%SM_API_KEY%
-          SET SM_CLIENT_CERT_FILE=%SM_CLIENT_CERT_FILE%
-          SET SM_CLIENT_CERT_PASSWORD=%SM_CLIENT_CERT_PASSWORD%
           SET SM_CODE_SIGNING_CERT_SHA1_HASH=%SM_CODE_SIGNING_CERT_SHA1_HASH%
           SET PATH=%PATH%;"C:\Program Files\DigiCert\DigiCert One Signing Manager Tools"
           SET PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
-          signtool.exe sign /n "MUDITA SP. Z O.O." /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
+          signtool.exe sign /sha1 %SM_CODE_SIGNING_CERT_SHA1_HASH% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
         shell: cmd
       - name: Calculate new checksum and file size for Mudita-Center.exe
         if: matrix.runner_label == 'windows-nexus'

--- a/.github/workflows/nexus-pre-production.yml
+++ b/.github/workflows/nexus-pre-production.yml
@@ -103,20 +103,12 @@ jobs:
       - name: Signing via Digicert
         if: matrix.runner_label == 'windows-nexus'
         env:
-          SM_HOST: ${{ secrets.SM_HOST }}
-          SM_API_KEY: ${{ secrets.SM_API_KEY }}
-          SM_CLIENT_CERT_FILE: "C:\\actions-runner\\certs\\Certificate_pkcs12.p12"
-          SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
           SM_CODE_SIGNING_CERT_SHA1_HASH: ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}
         run: |
-          SET SM_HOST=%SM_HOST%
-          SET SM_API_KEY=%SM_API_KEY%
-          SET SM_CLIENT_CERT_FILE=%SM_CLIENT_CERT_FILE%
-          SET SM_CLIENT_CERT_PASSWORD=%SM_CLIENT_CERT_PASSWORD%
           SET SM_CODE_SIGNING_CERT_SHA1_HASH=%SM_CODE_SIGNING_CERT_SHA1_HASH%
           SET PATH=%PATH%;"C:\Program Files\DigiCert\DigiCert One Signing Manager Tools"
           SET PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
-          signtool.exe sign /n "MUDITA SP. Z O.O." /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
+          signtool.exe sign /sha1 %SM_CODE_SIGNING_CERT_SHA1_HASH% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
         shell: cmd
       - name: Calculate new checksum and file size for Mudita-Center.exe
         if: matrix.runner_label == 'windows-nexus'

--- a/.github/workflows/nexus-production-with-os-rc.yml
+++ b/.github/workflows/nexus-production-with-os-rc.yml
@@ -97,20 +97,12 @@ jobs:
       - name: Signing via Digicert
         if: matrix.runner_label == 'windows-nexus'
         env:
-          SM_HOST: ${{ secrets.SM_HOST }}
-          SM_API_KEY: ${{ secrets.SM_API_KEY }}
-          SM_CLIENT_CERT_FILE: "C:\\actions-runner\\certs\\Certificate_pkcs12.p12"
-          SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
           SM_CODE_SIGNING_CERT_SHA1_HASH: ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}
         run: |
-          SET SM_HOST=%SM_HOST%
-          SET SM_API_KEY=%SM_API_KEY%
-          SET SM_CLIENT_CERT_FILE=%SM_CLIENT_CERT_FILE%
-          SET SM_CLIENT_CERT_PASSWORD=%SM_CLIENT_CERT_PASSWORD%
           SET SM_CODE_SIGNING_CERT_SHA1_HASH=%SM_CODE_SIGNING_CERT_SHA1_HASH%
           SET PATH=%PATH%;"C:\Program Files\DigiCert\DigiCert One Signing Manager Tools"
           SET PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
-          signtool.exe sign /n "MUDITA SP. Z O.O." /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
+          signtool.exe sign /sha1 %SM_CODE_SIGNING_CERT_SHA1_HASH% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
         shell: cmd
       - name: Calculate new checksum and file size for Mudita-Center.exe
         if: matrix.runner_label == 'windows-nexus'


### PR DESCRIPTION
## Summary
- propagates the production DigiCert new sign flow to the remaining release workflows that already sign Windows installers
- keeps only `SM_CODE_SIGNING_CERT_SHA1_HASH` in the signing step
- switches the remaining signing commands back to `signtool.exe sign /sha1 %SM_CODE_SIGNING_CERT_SHA1_HASH%`

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' .github/workflows/nexus-mass-update.yml .github/workflows/nexus-pre-production-latest.yml .github/workflows/nexus-pre-production.yml .github/workflows/nexus-production-with-os-rc.yml .github/workflows/nexus-production.yml`\n- `git diff --check`\n- compared `Signing via Digicert` blocks across production, pre-production, pre-production-latest, production-with-os-rc, and mass-update\n\nNote: `npx prettier --check` still reports pre-existing spacing style in `.github/workflows/nexus-pre-production-latest.yml`; this PR intentionally avoids unrelated formatting churn.