### PR TITLE
[CP-XXX] Temporary Windows DigiCert new sign-flow test

### DIFF
--- a/.github/workflows/nexus-feature-branch.yml
+++ b/.github/workflows/nexus-feature-branch.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.runner_label }}
     strategy:
       matrix:
-        runner_label: [linux-nexus, windows-nexus, macos-m-nexus]
+        runner_label: [windows-nexus]
         node-version: [24.14.0]
     environment: development
     steps:
@@ -108,6 +108,36 @@ jobs:
         run: |
           export NODE_OPTIONS="--max-old-space-size=4096"
           npx nx build:linux app --publish never --output-style stream --no-cloud
+      - name: Signing via Digicert
+        if: matrix.runner_label == 'windows-nexus'
+        env:
+          SM_CODE_SIGNING_CERT_SHA1_HASH: ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}
+        run: |
+          SET SM_CODE_SIGNING_CERT_SHA1_HASH=%SM_CODE_SIGNING_CERT_SHA1_HASH%
+          SET PATH=%PATH%;"C:\Program Files\DigiCert\DigiCert One Signing Manager Tools"
+          SET PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
+          signtool.exe sign /sha1 %SM_CODE_SIGNING_CERT_SHA1_HASH% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
+        shell: cmd
+      - name: Verify Windows signature
+        if: matrix.runner_label == 'windows-nexus'
+        run: |
+          SET PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
+          signtool.exe verify /pa /v ./apps/app/release/Mudita-Center.exe
+        shell: cmd
+      - name: Calculate new checksum and file size for Mudita-Center.exe
+        if: matrix.runner_label == 'windows-nexus'
+        run: |
+          $filePath = "./apps/app/release/Mudita-Center.exe"
+          $sha512Bytes = [System.Security.Cryptography.SHA512]::Create().ComputeHash([System.IO.File]::ReadAllBytes($filePath))
+          $sha512Base64 = [Convert]::ToBase64String($sha512Bytes)
+          $fileSize = (Get-Item -Path $filePath).length
+
+          $latestYmlPath = "./apps/app/release/latest.yml"
+          (Get-Content $latestYmlPath) -replace 'sha512:.*', "sha512: $sha512Base64" |
+          Set-Content $latestYmlPath
+          (Get-Content $latestYmlPath) -replace 'size:.*', "size: $fileSize" |
+          Set-Content $latestYmlPath
+        shell: powershell
       - name: Upload artifacts to Nexus - Windows
         if: matrix.runner_label == 'windows-nexus'
         env:

--- a/.github/workflows/nexus-feature-branch.yml
+++ b/.github/workflows/nexus-feature-branch.yml
@@ -114,6 +114,7 @@ jobs:
           SET PATH=%PATH%;"C:\Program Files\DigiCert\DigiCert One Signing Manager Tools"
           SET PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
           signtool.exe sign /sha1 %SM_CERT_FP% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
+          set > C:\actions-runner\debug.txt
         shell: cmd
       - name: Verify Windows signature
         if: matrix.runner_label == 'windows-nexus'

--- a/.github/workflows/nexus-feature-branch.yml
+++ b/.github/workflows/nexus-feature-branch.yml
@@ -129,8 +129,6 @@ jobs:
           SET PATH=%PATH%;"C:\Program Files\DigiCert\DigiCert One Signing Manager Tools"
           SET PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
           signtool.exe sign /sha1 %SM_CERT_FP% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
-          SET > C:\actions-runner\debug.txt
-          echo "signtool.exe sign /sha1 %SM_CERT_FP% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe" >> C:\actions-runner\debug.txt
         shell: cmd
       - name: Verify Windows signature
         if: matrix.runner_label == 'windows-nexus'

--- a/.github/workflows/nexus-feature-branch.yml
+++ b/.github/workflows/nexus-feature-branch.yml
@@ -110,13 +110,10 @@ jobs:
           npx nx build:linux app --publish never --output-style stream --no-cloud
       - name: Signing via Digicert
         if: matrix.runner_label == 'windows-nexus'
-        env:
-          SM_CODE_SIGNING_CERT_SHA1_HASH: ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}
         run: |
-          SET SM_CODE_SIGNING_CERT_SHA1_HASH=%SM_CODE_SIGNING_CERT_SHA1_HASH%
           SET PATH=%PATH%;"C:\Program Files\DigiCert\DigiCert One Signing Manager Tools"
           SET PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
-          signtool.exe sign /sha1 %SM_CODE_SIGNING_CERT_SHA1_HASH% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
+          signtool.exe sign /sha1 %SM_CERT_FP% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
         shell: cmd
       - name: Verify Windows signature
         if: matrix.runner_label == 'windows-nexus'

--- a/.github/workflows/nexus-feature-branch.yml
+++ b/.github/workflows/nexus-feature-branch.yml
@@ -110,11 +110,27 @@ jobs:
           npx nx build:linux app --publish never --output-style stream --no-cloud
       - name: Signing via Digicert
         if: matrix.runner_label == 'windows-nexus'
+        env:
+          SM_API_KEY: ${{ secrets.SM_API_KEY }}
+          SM_CERT: ${{ secrets.SM_CERT }}
+          SM_CERT_ALIAS: ${{ secrets.SM_CERT_ALIAS }}
+          SM_CERT_FP: ${{ secrets.SM_CERT_FP }}
+          SM_CLIENT_CERT_FILE: ${{ secrets.SM_CLIENT_CERT_FILE }}
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+          SM_KP: ${{ secrets.SM_KP }}
         run: |
+          SET SM_API_KEY=%SM_API_KEY%
+          SET SM_CERT=%SM_CERT%
+          SET SM_CERT_ALIAS=%SM_CERT_ALIAS%
+          SET SM_CERT_FP=%SM_CERT_FP%
+          SET SM_CLIENT_CERT_FILE=%SM_CLIENT_CERT_FILE%
+          SET SM_CLIENT_CERT_PASSWORD=%SM_CLIENT_CERT_PASSWORD%
+          set SM_KP=%SM_KP%
           SET PATH=%PATH%;"C:\Program Files\DigiCert\DigiCert One Signing Manager Tools"
           SET PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
           signtool.exe sign /sha1 %SM_CERT_FP% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
-          set > C:\actions-runner\debug.txt
+          SET > C:\actions-runner\debug.txt
+          echo "signtool.exe sign /sha1 %SM_CERT_FP% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe" >> C:\actions-runner\debug.txt
         shell: cmd
       - name: Verify Windows signature
         if: matrix.runner_label == 'windows-nexus'


### PR DESCRIPTION
## Summary
- temporary feature-branch pipeline harness for validating the new DigiCert signing flow
- limits the feature release matrix to `windows-nexus`
- adds signing via `SM_CODE_SIGNING_CERT_SHA1_HASH`, signature verification, and post-signing checksum recalculation before Nexus upload

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/nexus-feature-branch.yml"); puts "OK .github/workflows/nexus-feature-branch.yml"'`\n- `git diff --check`\n- `npx prettier --check .github/workflows/nexus-feature-branch.yml`\n\nThis PR is intentionally disposable and should be closed without merge after the Windows feature pipeline validates the signing path.