### PR TITLE
[CP-XXX] Temporary Windows DigiCert SM_CERT_FP signing test

### DIFF
--- a/.github/workflows/nexus-feature-branch.yml
+++ b/.github/workflows/nexus-feature-branch.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.runner_label }}
     strategy:
       matrix:
-        runner_label: [linux-nexus, windows-nexus, macos-m-nexus]
+        runner_label: [windows-nexus]
         node-version: [24.14.0]
     environment: development
     steps:
@@ -108,6 +108,48 @@ jobs:
         run: |
           export NODE_OPTIONS="--max-old-space-size=4096"
           npx nx build:linux app --publish never --output-style stream --no-cloud
+      - name: Signing via Digicert
+        if: matrix.runner_label == 'windows-nexus'
+        env:
+          SM_API_KEY: ${{ secrets.SM_API_KEY }}
+          SM_CERT: ${{ secrets.SM_CERT }}
+          SM_CERT_ALIAS: ${{ secrets.SM_CERT_ALIAS }}
+          SM_CERT_FP: ${{ secrets.SM_CERT_FP }}
+          SM_CLIENT_CERT_FILE: ${{ secrets.SM_CLIENT_CERT_FILE }}
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+          SM_KP: ${{ secrets.SM_KP }}
+        run: |
+          SET SM_API_KEY=%SM_API_KEY%
+          SET SM_CERT=%SM_CERT%
+          SET SM_CERT_ALIAS=%SM_CERT_ALIAS%
+          SET SM_CERT_FP=%SM_CERT_FP%
+          SET SM_CLIENT_CERT_FILE=%SM_CLIENT_CERT_FILE%
+          SET SM_CLIENT_CERT_PASSWORD=%SM_CLIENT_CERT_PASSWORD%
+          set SM_KP=%SM_KP%
+          SET PATH=%PATH%;"C:\Program Files\DigiCert\DigiCert One Signing Manager Tools"
+          SET PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
+          signtool.exe sign /sha1 %SM_CERT_FP% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
+        shell: cmd
+      - name: Verify Windows signature
+        if: matrix.runner_label == 'windows-nexus'
+        run: |
+          SET PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
+          signtool.exe verify /pa /v ./apps/app/release/Mudita-Center.exe
+        shell: cmd
+      - name: Calculate new checksum and file size for Mudita-Center.exe
+        if: matrix.runner_label == 'windows-nexus'
+        run: |
+          $filePath = "./apps/app/release/Mudita-Center.exe"
+          $sha512Bytes = [System.Security.Cryptography.SHA512]::Create().ComputeHash([System.IO.File]::ReadAllBytes($filePath))
+          $sha512Base64 = [Convert]::ToBase64String($sha512Bytes)
+          $fileSize = (Get-Item -Path $filePath).length
+
+          $latestYmlPath = "./apps/app/release/latest.yml"
+          (Get-Content $latestYmlPath) -replace 'sha512:.*', "sha512: $sha512Base64" |
+          Set-Content $latestYmlPath
+          (Get-Content $latestYmlPath) -replace 'size:.*', "size: $fileSize" |
+          Set-Content $latestYmlPath
+        shell: powershell
       - name: Upload artifacts to Nexus - Windows
         if: matrix.runner_label == 'windows-nexus'
         env:


### PR DESCRIPTION
## Summary
Temporary validation branch for the DigiCert `SM_CERT_FP` signing flow introduced in #2856.

## What this changes
- Limits the feature release matrix to `windows-nexus`.
- Adds the same DigiCert signing block as the permanent workflows.
- Verifies the Windows signature after signing.
- Recalculates checksum and size before uploading Windows artifacts to Nexus.

## Expected result
The feature release pipeline should pass `Signing via Digicert`, `Verify Windows signature`, checksum recalculation, and `Upload artifacts to Nexus - Windows`.

This PR is temporary and should be closed without merge after validation.
