### PR TITLE
[CP-XXX] Temporary DigiCert publisherName signing test

### DIFF
--- a/.github/workflows/nexus-feature-branch.yml
+++ b/.github/workflows/nexus-feature-branch.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.runner_label }}
     strategy:
       matrix:
-        runner_label: [linux-nexus, windows-nexus, macos-m-nexus]
+        runner_label: [windows-nexus]
         node-version: [24.14.0]
     environment: development
     steps:
@@ -108,6 +108,48 @@ jobs:
         run: |
           export NODE_OPTIONS="--max-old-space-size=4096"
           npx nx build:linux app --publish never --output-style stream --no-cloud
+      - name: Signing via Digicert
+        if: matrix.runner_label == 'windows-nexus'
+        env:
+          SM_API_KEY: ${{ secrets.SM_API_KEY }}
+          SM_CERT: ${{ secrets.SM_CERT }}
+          SM_CERT_ALIAS: ${{ secrets.SM_CERT_ALIAS }}
+          SM_CERT_FP: ${{ secrets.SM_CERT_FP }}
+          SM_CLIENT_CERT_FILE: ${{ secrets.SM_CLIENT_CERT_FILE }}
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+          SM_KP: ${{ secrets.SM_KP }}
+        run: |
+          SET SM_API_KEY=%SM_API_KEY%
+          SET SM_CERT=%SM_CERT%
+          SET SM_CERT_ALIAS=%SM_CERT_ALIAS%
+          SET SM_CERT_FP=%SM_CERT_FP%
+          SET SM_CLIENT_CERT_FILE=%SM_CLIENT_CERT_FILE%
+          SET SM_CLIENT_CERT_PASSWORD=%SM_CLIENT_CERT_PASSWORD%
+          set SM_KP=%SM_KP%
+          SET PATH=%PATH%;"C:\Program Files\DigiCert\DigiCert One Signing Manager Tools"
+          SET PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
+          signtool.exe sign /sha1 %SM_CERT_FP% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
+        shell: cmd
+      - name: Verify Windows signature
+        if: matrix.runner_label == 'windows-nexus'
+        run: |
+          SET PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
+          signtool.exe verify /pa /v ./apps/app/release/Mudita-Center.exe
+        shell: cmd
+      - name: Calculate new checksum and file size for Mudita-Center.exe
+        if: matrix.runner_label == 'windows-nexus'
+        run: |
+          $filePath = "./apps/app/release/Mudita-Center.exe"
+          $sha512Bytes = [System.Security.Cryptography.SHA512]::Create().ComputeHash([System.IO.File]::ReadAllBytes($filePath))
+          $sha512Base64 = [Convert]::ToBase64String($sha512Bytes)
+          $fileSize = (Get-Item -Path $filePath).length
+
+          $latestYmlPath = "./apps/app/release/latest.yml"
+          (Get-Content $latestYmlPath) -replace 'sha512:.*', "sha512: $sha512Base64" |
+          Set-Content $latestYmlPath
+          (Get-Content $latestYmlPath) -replace 'size:.*', "size: $fileSize" |
+          Set-Content $latestYmlPath
+        shell: powershell
       - name: Upload artifacts to Nexus - Windows
         if: matrix.runner_label == 'windows-nexus'
         env:

--- a/.github/workflows/nexus-mass-update.yml
+++ b/.github/workflows/nexus-mass-update.yml
@@ -97,20 +97,24 @@ jobs:
       - name: Signing via Digicert
         if: matrix.runner_label == 'windows-nexus'
         env:
-          SM_HOST: ${{ secrets.SM_HOST }}
           SM_API_KEY: ${{ secrets.SM_API_KEY }}
-          SM_CLIENT_CERT_FILE: "C:\\actions-runner\\certs\\Certificate_pkcs12.p12"
+          SM_CERT: ${{ secrets.SM_CERT }}
+          SM_CERT_ALIAS: ${{ secrets.SM_CERT_ALIAS }}
+          SM_CERT_FP: ${{ secrets.SM_CERT_FP }}
+          SM_CLIENT_CERT_FILE: ${{ secrets.SM_CLIENT_CERT_FILE }}
           SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
-          SM_CODE_SIGNING_CERT_SHA1_HASH: ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}
+          SM_KP: ${{ secrets.SM_KP }}
         run: |
-          SET SM_HOST=%SM_HOST%
           SET SM_API_KEY=%SM_API_KEY%
+          SET SM_CERT=%SM_CERT%
+          SET SM_CERT_ALIAS=%SM_CERT_ALIAS%
+          SET SM_CERT_FP=%SM_CERT_FP%
           SET SM_CLIENT_CERT_FILE=%SM_CLIENT_CERT_FILE%
           SET SM_CLIENT_CERT_PASSWORD=%SM_CLIENT_CERT_PASSWORD%
-          SET SM_CODE_SIGNING_CERT_SHA1_HASH=%SM_CODE_SIGNING_CERT_SHA1_HASH%
+          set SM_KP=%SM_KP%
           SET PATH=%PATH%;"C:\Program Files\DigiCert\DigiCert One Signing Manager Tools"
           SET PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
-          signtool.exe sign /n "MUDITA SP. Z O.O." /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
+          signtool.exe sign /sha1 %SM_CERT_FP% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
         shell: cmd
       - name: Calculate new checksum and file size for Mudita-Center.exe
         if: matrix.runner_label == 'windows-nexus'

--- a/.github/workflows/nexus-pre-production-latest.yml
+++ b/.github/workflows/nexus-pre-production-latest.yml
@@ -152,20 +152,24 @@ jobs:
       - name: Signing via Digicert
         if: matrix.runner_label == 'windows-nexus'
         env:
-          SM_HOST: ${{ secrets.SM_HOST }}
           SM_API_KEY: ${{ secrets.SM_API_KEY }}
-          SM_CLIENT_CERT_FILE: "C:\\actions-runner\\certs\\Certificate_pkcs12.p12"
+          SM_CERT: ${{ secrets.SM_CERT }}
+          SM_CERT_ALIAS: ${{ secrets.SM_CERT_ALIAS }}
+          SM_CERT_FP: ${{ secrets.SM_CERT_FP }}
+          SM_CLIENT_CERT_FILE: ${{ secrets.SM_CLIENT_CERT_FILE }}
           SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
-          SM_CODE_SIGNING_CERT_SHA1_HASH: ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}
+          SM_KP: ${{ secrets.SM_KP }}
         run: |
-          SET SM_HOST=%SM_HOST%
           SET SM_API_KEY=%SM_API_KEY%
+          SET SM_CERT=%SM_CERT%
+          SET SM_CERT_ALIAS=%SM_CERT_ALIAS%
+          SET SM_CERT_FP=%SM_CERT_FP%
           SET SM_CLIENT_CERT_FILE=%SM_CLIENT_CERT_FILE%
           SET SM_CLIENT_CERT_PASSWORD=%SM_CLIENT_CERT_PASSWORD%
-          SET SM_CODE_SIGNING_CERT_SHA1_HASH=%SM_CODE_SIGNING_CERT_SHA1_HASH%
+          set SM_KP=%SM_KP%
           SET PATH=%PATH%;"C:\Program Files\DigiCert\DigiCert One Signing Manager Tools"
           SET PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
-          signtool.exe sign /n "MUDITA SP. Z O.O." /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
+          signtool.exe sign /sha1 %SM_CERT_FP% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
         shell: cmd
       - name: Calculate new checksum and file size for Mudita-Center.exe
         if: matrix.runner_label == 'windows-nexus'

--- a/.github/workflows/nexus-pre-production.yml
+++ b/.github/workflows/nexus-pre-production.yml
@@ -103,20 +103,24 @@ jobs:
       - name: Signing via Digicert
         if: matrix.runner_label == 'windows-nexus'
         env:
-          SM_HOST: ${{ secrets.SM_HOST }}
           SM_API_KEY: ${{ secrets.SM_API_KEY }}
-          SM_CLIENT_CERT_FILE: "C:\\actions-runner\\certs\\Certificate_pkcs12.p12"
+          SM_CERT: ${{ secrets.SM_CERT }}
+          SM_CERT_ALIAS: ${{ secrets.SM_CERT_ALIAS }}
+          SM_CERT_FP: ${{ secrets.SM_CERT_FP }}
+          SM_CLIENT_CERT_FILE: ${{ secrets.SM_CLIENT_CERT_FILE }}
           SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
-          SM_CODE_SIGNING_CERT_SHA1_HASH: ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}
+          SM_KP: ${{ secrets.SM_KP }}
         run: |
-          SET SM_HOST=%SM_HOST%
           SET SM_API_KEY=%SM_API_KEY%
+          SET SM_CERT=%SM_CERT%
+          SET SM_CERT_ALIAS=%SM_CERT_ALIAS%
+          SET SM_CERT_FP=%SM_CERT_FP%
           SET SM_CLIENT_CERT_FILE=%SM_CLIENT_CERT_FILE%
           SET SM_CLIENT_CERT_PASSWORD=%SM_CLIENT_CERT_PASSWORD%
-          SET SM_CODE_SIGNING_CERT_SHA1_HASH=%SM_CODE_SIGNING_CERT_SHA1_HASH%
+          set SM_KP=%SM_KP%
           SET PATH=%PATH%;"C:\Program Files\DigiCert\DigiCert One Signing Manager Tools"
           SET PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
-          signtool.exe sign /n "MUDITA SP. Z O.O." /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
+          signtool.exe sign /sha1 %SM_CERT_FP% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
         shell: cmd
       - name: Calculate new checksum and file size for Mudita-Center.exe
         if: matrix.runner_label == 'windows-nexus'

--- a/.github/workflows/nexus-production-with-os-rc.yml
+++ b/.github/workflows/nexus-production-with-os-rc.yml
@@ -97,20 +97,24 @@ jobs:
       - name: Signing via Digicert
         if: matrix.runner_label == 'windows-nexus'
         env:
-          SM_HOST: ${{ secrets.SM_HOST }}
           SM_API_KEY: ${{ secrets.SM_API_KEY }}
-          SM_CLIENT_CERT_FILE: "C:\\actions-runner\\certs\\Certificate_pkcs12.p12"
+          SM_CERT: ${{ secrets.SM_CERT }}
+          SM_CERT_ALIAS: ${{ secrets.SM_CERT_ALIAS }}
+          SM_CERT_FP: ${{ secrets.SM_CERT_FP }}
+          SM_CLIENT_CERT_FILE: ${{ secrets.SM_CLIENT_CERT_FILE }}
           SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
-          SM_CODE_SIGNING_CERT_SHA1_HASH: ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}
+          SM_KP: ${{ secrets.SM_KP }}
         run: |
-          SET SM_HOST=%SM_HOST%
           SET SM_API_KEY=%SM_API_KEY%
+          SET SM_CERT=%SM_CERT%
+          SET SM_CERT_ALIAS=%SM_CERT_ALIAS%
+          SET SM_CERT_FP=%SM_CERT_FP%
           SET SM_CLIENT_CERT_FILE=%SM_CLIENT_CERT_FILE%
           SET SM_CLIENT_CERT_PASSWORD=%SM_CLIENT_CERT_PASSWORD%
-          SET SM_CODE_SIGNING_CERT_SHA1_HASH=%SM_CODE_SIGNING_CERT_SHA1_HASH%
+          set SM_KP=%SM_KP%
           SET PATH=%PATH%;"C:\Program Files\DigiCert\DigiCert One Signing Manager Tools"
           SET PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
-          signtool.exe sign /n "MUDITA SP. Z O.O." /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
+          signtool.exe sign /sha1 %SM_CERT_FP% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
         shell: cmd
       - name: Calculate new checksum and file size for Mudita-Center.exe
         if: matrix.runner_label == 'windows-nexus'

--- a/.github/workflows/nexus-production.yml
+++ b/.github/workflows/nexus-production.yml
@@ -100,12 +100,24 @@ jobs:
       - name: Signing via Digicert
         if: matrix.runner_label == 'windows-nexus'
         env:
-          SM_CODE_SIGNING_CERT_SHA1_HASH: ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}
+          SM_API_KEY: ${{ secrets.SM_API_KEY }}
+          SM_CERT: ${{ secrets.SM_CERT }}
+          SM_CERT_ALIAS: ${{ secrets.SM_CERT_ALIAS }}
+          SM_CERT_FP: ${{ secrets.SM_CERT_FP }}
+          SM_CLIENT_CERT_FILE: ${{ secrets.SM_CLIENT_CERT_FILE }}
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+          SM_KP: ${{ secrets.SM_KP }}
         run: |
-          SET SM_CODE_SIGNING_CERT_SHA1_HASH=%SM_CODE_SIGNING_CERT_SHA1_HASH%
+          SET SM_API_KEY=%SM_API_KEY%
+          SET SM_CERT=%SM_CERT%
+          SET SM_CERT_ALIAS=%SM_CERT_ALIAS%
+          SET SM_CERT_FP=%SM_CERT_FP%
+          SET SM_CLIENT_CERT_FILE=%SM_CLIENT_CERT_FILE%
+          SET SM_CLIENT_CERT_PASSWORD=%SM_CLIENT_CERT_PASSWORD%
+          set SM_KP=%SM_KP%
           SET PATH=%PATH%;"C:\Program Files\DigiCert\DigiCert One Signing Manager Tools"
           SET PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64"
-          signtool.exe sign /sha1 %SM_CODE_SIGNING_CERT_SHA1_HASH% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
+          signtool.exe sign /sha1 %SM_CERT_FP% /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 ./apps/app/release/Mudita-Center.exe
         shell: cmd
       - name: Calculate new checksum and file size for Mudita-Center.exe
         if: matrix.runner_label == 'windows-nexus'

--- a/apps/app/electron-builder.yml
+++ b/apps/app/electron-builder.yml
@@ -17,6 +17,9 @@ files:
   - "!{tsconfig.json,tsconfig.node.json,tsconfig.web.json}"
 win:
   icon: ./resources/icons/icon.ico
+  signtoolOptions:
+    publisherName:
+      - "CN=MUDITA SP. Z O.O.,O=MUDITA SP. Z O.O.,L=WARSZAWA,C=PL"
   target:
     - nsis
   extraFiles:


### PR DESCRIPTION
## Summary

Temporary branch for validating Windows signing/update metadata with publisherName copied from the signed Authenticode certificate subject.

## Changes

- adds win.signtoolOptions.publisherName in apps/app/electron-builder.yml
- temporarily narrows feature release pipeline to windows-nexus
- temporarily adds DigiCert SM_CERT_FP signing, signtool verify, checksum recalculation, and Windows Nexus upload validation
- keeps the permanent DigiCert SM_CERT_FP workflow changes from #2856 unchanged

## Test Plan

- feature branch pipeline should run for CP-XXX-digicert-publisher-name-test
- Windows build/sign/verify/checksum/upload should pass
- verify generated update metadata and Windows manual SmartScreen/user-facing behavior before copying only the publisherName config change to #2856

This PR is temporary and should be closed without merge after validation.